### PR TITLE
First pass at a ICCTransform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,20 @@ set(YAML_CPP_LIBRARY_DIRS ${PROJECT_BINARY_DIR}/ext/dist/lib)
 set(YAML_CPP_STATIC_LIBRARIES ${PROJECT_BINARY_DIR}/ext/dist/lib/libyaml-cpp.a)
 
 ###############################################################################
+### LCMS ###
+
+set(LCMS_VERSION 2.1)
+ExternalProject_Add(LCMS
+    URL ${CMAKE_SOURCE_DIR}/ext/lcms2-${LCMS_VERSION}.tar.gz
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND ./configure --prefix=${PROJECT_BINARY_DIR}/ext/dist --without-jpeg --without-tiff --without-zlib
+    BUILD_COMMAND make
+    INSTALL_COMMAND make install
+)
+set(LCMS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ext/dist/include)
+set(LCMS_STATIC_LIBRARIES ${PROJECT_BINARY_DIR}/ext/dist/lib/liblcms2.a)
+
+###############################################################################
 ### Externals ###
 
 set(EXTERNAL_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ext/dist/include)
@@ -119,7 +133,8 @@ set(EXTERNAL_LINK_FLAGS "")
 set(EXTERNAL_LIBRARY_DIRS ${PROJECT_BINARY_DIR}/ext/dist/lib)
 set(EXTERNAL_LIBRARIES
     ${TINYXML_STATIC_LIBRARIES}
-    ${YAML_CPP_STATIC_LIBRARIES})
+    ${YAML_CPP_STATIC_LIBRARIES}
+    ${LCMS_STATIC_LIBRARIES})
 
 ###############################################################################
 ### Documentation ###

--- a/export/OpenColorIO/OpenColorTransforms.h
+++ b/export/OpenColorIO/OpenColorTransforms.h
@@ -692,6 +692,83 @@ OCIO_NAMESPACE_ENTER
     //!cpp:function::
     extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const TruelightTransform &);
     
+    //!rst:: //////////////////////////////////////////////////////////////////
+    
+    //!cpp:class:: ICC transform using the littlecms2 api
+    class OCIOEXPORT ICCTransform : public Transform
+    {
+    public:
+        //!cpp:function::
+        static ICCTransformRcPtr Create();
+        
+        //!cpp:function::
+        virtual TransformRcPtr createEditableCopy() const;
+        
+        //!cpp:function::
+        virtual TransformDirection getDirection() const;
+        //!cpp:function::
+        virtual void setDirection(TransformDirection dir);
+        
+        //!cpp:function::
+        void setInput(const char * input);
+        //!cpp:function::
+        void setInputMem(const void * inputPtr, int size);
+        //!cpp:function::
+        const char * getIntput() const;
+        
+        //!cpp:function::
+        void setOutput(const char * output);
+        //!cpp:function::
+        void setOutputMem(const void * outputPtr, int size);
+        //!cpp:function::
+        const char * getOutput() const;
+        
+        //!cpp:function::
+        void setProof(const char * proof);
+        //!cpp:function::
+        void setProofMem(const void * proofPtr, int size);
+        //!cpp:function::
+        const char * getProof() const;
+        
+        //!cpp:function::
+        void setIntent(IccIntent intent);
+        //!cpp:function::
+        IccIntent getIntent() const;
+        
+        //!cpp:function::
+        void setBlackpointCompensation(bool blackpointCompensation);
+        //!cpp:function::
+        bool getBlackpointCompensation() const;
+        
+        //!cpp:function::
+        void setSoftProofing(bool softProofing);
+        //!cpp:function::
+        bool getSoftProofing() const;
+        
+        //!cpp:function::
+        void setGamutCheck(bool gamutCheck);
+        //!cpp:function::
+        bool getGamutCheck() const;
+        
+    private:
+        ICCTransform();
+        ICCTransform(const ICCTransform &);
+        virtual ~ICCTransform();
+        
+        ICCTransform& operator= (const ICCTransform &);
+        
+        static void deleter(ICCTransform* t);
+        
+        class Impl;
+        friend class Impl;
+        Impl * m_impl;
+        Impl * getImpl() { return m_impl; }
+        const Impl * getImpl() const { return m_impl; }
+    };
+    
+    //!cpp:function::
+    extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const ICCTransform &);
+    
 }
 OCIO_NAMESPACE_EXIT
 

--- a/export/OpenColorIO/OpenColorTypes.h
+++ b/export/OpenColorIO/OpenColorTypes.h
@@ -163,6 +163,12 @@ OCIO_NAMESPACE_ENTER
     //!cpp:type::
     typedef OCIO_SHARED_PTR<TruelightTransform> TruelightTransformRcPtr;
     
+    class OCIOEXPORT ICCTransform;
+    //!cpp:type::
+    typedef OCIO_SHARED_PTR<const ICCTransform> ConstICCTransformRcPtr;
+    //!cpp:type::
+    typedef OCIO_SHARED_PTR<ICCTransform> ICCTransformRcPtr;
+    
     template <class T, class U>
     inline OCIO_SHARED_PTR<T> DynamicPtrCast(OCIO_SHARED_PTR<U> const & ptr)
     {
@@ -227,6 +233,14 @@ OCIO_NAMESPACE_ENTER
         GPU_LANGUAGE_GLSL_1_3,     ///< OpenGL Shading Language
     };
     
+    //!cpp:type::
+    enum IccIntent {
+        ICC_INTENT_UNKNOWN = 0,
+        ICC_INTENT_PERCEPTUAL,
+        ICC_INTENT_RELATIVE_COLORIMETRIC,
+        ICC_INTENT_SATURATION,
+        ICC_INTENT_ABSOLUTE_COLORIMETRIC
+    };
     
     //!rst::
     // Conversion
@@ -276,6 +290,11 @@ OCIO_NAMESPACE_ENTER
     extern OCIOEXPORT const char * GpuLanguageToString(GpuLanguage language);
     //!cpp:function::
     extern OCIOEXPORT GpuLanguage GpuLanguageFromString(const char * s);
+    
+    //!cpp:function::
+    extern OCIOEXPORT const char * IccIntentToString(IccIntent intent);
+    //!cpp:function::
+    extern OCIOEXPORT IccIntent IccIntentFromString(const char * s);
     
     
     /*!rst::

--- a/src/apps/ocio2icc/CMakeLists.txt
+++ b/src/apps/ocio2icc/CMakeLists.txt
@@ -1,16 +1,16 @@
 
 # LCMS
-set(LCMS_VERSION 2.1)
-ExternalProject_Add(LCMS
-    URL ${CMAKE_SOURCE_DIR}/ext/lcms2-${LCMS_VERSION}.tar.gz
-    BUILD_IN_SOURCE 1
-    CONFIGURE_COMMAND ./configure --prefix=${PROJECT_BINARY_DIR}/ext/dist --without-jpeg --without-tiff --without-zlib
-    BUILD_COMMAND make
-    INSTALL_COMMAND make install
-)
-set(LCMS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ext/dist/include)
-set(LCMS_LIBRARY_DIRS ${PROJECT_BINARY_DIR}/ext/dist/lib)
-set(LCMS_STATIC_LIBRARIES ${PROJECT_BINARY_DIR}/ext/dist/lib/liblcms2.a)
+#set(LCMS_VERSION 2.1)
+#ExternalProject_Add(LCMS
+#    URL ${CMAKE_SOURCE_DIR}/ext/lcms2-${LCMS_VERSION}.tar.gz
+#    BUILD_IN_SOURCE 1
+#    CONFIGURE_COMMAND ./configure --prefix=${PROJECT_BINARY_DIR}/ext/dist --without-jpeg --without-tiff --without-zlib
+#    BUILD_COMMAND make
+#    INSTALL_COMMAND make install
+#)
+#set(LCMS_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ext/dist/include)
+#set(LCMS_LIBRARY_DIRS ${PROJECT_BINARY_DIR}/ext/dist/lib)
+#set(LCMS_STATIC_LIBRARIES ${PROJECT_BINARY_DIR}/ext/dist/lib/liblcms2.a)
 
 file(GLOB_RECURSE share_src_files "${CMAKE_SOURCE_DIR}/src/apps/share/*.cpp")
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -20,7 +20,7 @@ list(APPEND core_export_headers ${CMAKE_BINARY_DIR}/export/OpenColorVersion.h)
 # SHARED
 
 add_library(OpenColorIO SHARED ${core_src_files})
-add_dependencies(OpenColorIO tinyxml YAML_CPP_LOCAL)
+add_dependencies(OpenColorIO tinyxml YAML_CPP_LOCAL LCMS)
 target_link_libraries(OpenColorIO ${EXTERNAL_LIBRARIES})
 set_target_properties(OpenColorIO PROPERTIES
     OUTPUT_NAME OpenColorIO
@@ -32,7 +32,7 @@ install(TARGETS OpenColorIO DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 
 list(REMOVE_ITEM core_src_files ${CMAKE_SOURCE_DIR}/src/core/UnitTest.cpp)
 add_library(OpenColorIO_STATIC STATIC ${core_src_files})
-add_dependencies(OpenColorIO_STATIC tinyxml YAML_CPP_LOCAL)
+add_dependencies(OpenColorIO_STATIC tinyxml YAML_CPP_LOCAL LCMS)
 target_link_libraries(OpenColorIO_STATIC ${EXTERNAL_LIBRARIES})
 set_target_properties(OpenColorIO_STATIC PROPERTIES
     OUTPUT_NAME OpenColorIO

--- a/src/core/ICCOp.cpp
+++ b/src/core/ICCOp.cpp
@@ -1,0 +1,236 @@
+/*
+Copyright (c) 2003-2010 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <iostream>
+
+#include <lcms2.h>
+#include <lcms2_plugin.h>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "ICCOp.h"
+
+OCIO_NAMESPACE_ENTER
+{
+    namespace
+    {
+        
+        void ErrorHandler(cmsContext /*ContextID*/, cmsUInt32Number ErrorCode, const char *Text)
+        {
+            std::ostringstream err;
+            err << "Error: (" << ErrorCode << ") '" << Text << "'";
+            throw Exception(err.str().c_str());
+        }
+        
+        class ICCOp : public Op
+        {
+        public:
+            ICCOp(const char * input,
+                  const char * output,
+                  const char * proof,
+                  IccIntent intent,
+                  bool blackpointCompensation,
+                  bool softProofing,
+                  bool gamutCheck,
+                  TransformDirection direction);
+            virtual ~ICCOp();
+            
+            virtual OpRcPtr clone() const;
+            
+            virtual std::string getInfo() const;
+            virtual std::string getCacheID() const;
+            
+            virtual bool isNoOp() const;
+            virtual void finalize();
+            virtual void apply(float* rgbaBuffer, long numPixels) const;
+            
+            virtual bool supportsGpuShader() const;
+            virtual void writeGpuShader(std::ostream & shader,
+                                        const std::string & pixelName,
+                                        const GpuShaderDesc & shaderDesc) const;
+            
+            virtual bool definesAllocation() const;
+            virtual AllocationData getAllocation() const;
+        
+        private:
+            TransformDirection m_direction;
+            std::string m_input;
+            std::string m_output;
+            std::string m_proof;
+            IccIntent m_intent;
+            bool m_blackpointCompensation;
+            bool m_softProofing;
+            bool m_gamutCheck;
+            cmsHTRANSFORM m_transform;
+            std::string m_cacheID;
+        };
+        
+        ICCOp::ICCOp(const char * input,
+                     const char * output,
+                     const char * proof,
+                     IccIntent intent,
+                     bool blackpointCompensation,
+                     bool softProofing,
+                     bool gamutCheck,
+                     TransformDirection direction):
+                     Op(),
+                     m_direction(direction),
+                     m_input(input),
+                     m_output(output),
+                     m_proof(proof),
+                     m_intent(intent),
+                     m_blackpointCompensation(blackpointCompensation),
+                     m_softProofing(softProofing),
+                     m_gamutCheck(gamutCheck),
+                     m_transform(NULL)
+        {
+            // Setup the Error Handler
+            cmsSetLogErrorHandler(ErrorHandler);
+        }
+        
+        OpRcPtr ICCOp::clone() const
+        {
+            OpRcPtr op = OpRcPtr(new ICCOp(m_input.c_str(),
+                                           m_output.c_str(),
+                                           m_proof.c_str(),
+                                           m_intent,
+                                           m_blackpointCompensation,
+                                           m_softProofing,
+                                           m_gamutCheck,
+                                           m_direction));
+            return op;
+        }
+        
+        ICCOp::~ICCOp()
+        {
+            if(m_transform) cmsDeleteTransform(m_transform);
+        }
+        
+        std::string ICCOp::getInfo() const
+        {
+            return "<ICCOp>";
+        }
+        
+        std::string ICCOp::getCacheID() const
+        {
+            return m_cacheID;
+        }
+        
+        bool ICCOp::isNoOp() const
+        {
+            return false;
+        }
+        
+        void ICCOp::finalize()
+        {
+            
+            // TODO: should this be in the ICCTransform rather than here?
+            //std::string inputpath = context->resolveFileLocation(m_input.c_str());
+            //std::string outputpath = context->resolveFileLocation(m_output.c_str());
+            
+            cmsHPROFILE inputIcc = cmsOpenProfileFromFile(m_input.c_str(), "r");
+            cmsHPROFILE outputIcc = cmsOpenProfileFromFile(m_output.c_str(), "r");
+            
+            // invert the transform depending on direction
+            if(m_direction == TRANSFORM_DIR_FORWARD)
+            {
+                m_transform = cmsCreateTransform(inputIcc,  TYPE_RGBA_FLT,
+                                                 outputIcc, TYPE_RGBA_FLT,
+                                                 INTENT_PERCEPTUAL,
+                                                 0);
+            }
+            else if(m_direction == TRANSFORM_DIR_INVERSE)
+            {
+                m_transform = cmsCreateTransform(outputIcc, TYPE_RGBA_FLT,
+                                                 inputIcc,  TYPE_RGBA_FLT,
+                                                 INTENT_PERCEPTUAL,
+                                                 0);
+            }
+            
+            cmsCloseProfile(inputIcc);
+            cmsCloseProfile(outputIcc);
+            
+            // build cache id
+            std::ostringstream cacheIDStream;
+            cacheIDStream << "<ICCOp ";
+            cacheIDStream << m_input << " ";
+            cacheIDStream << m_output << " ";
+            cacheIDStream << m_proof << " ";
+            cacheIDStream << m_intent << " ";
+            cacheIDStream << m_blackpointCompensation << " ";
+            cacheIDStream << m_softProofing << " ";
+            cacheIDStream << m_gamutCheck << " ";
+            cacheIDStream << TransformDirectionToString(m_direction) << " ";
+            cacheIDStream << ">";
+            m_cacheID = cacheIDStream.str();
+        }
+        
+        void ICCOp::apply(float* rgbaBuffer, long numPixels) const
+        {
+            if(m_transform != NULL) cmsDoTransform(m_transform, rgbaBuffer, rgbaBuffer, numPixels);
+        }
+        
+        bool ICCOp::supportsGpuShader() const
+        {
+            return false;
+        }
+        
+        void ICCOp::writeGpuShader(std::ostream & /*shader*/,
+                                   const std::string & /*pixelName*/,
+                                   const GpuShaderDesc & /*shaderDesc*/) const
+        {
+            throw Exception("ICCOp does not define an gpu shader.");
+        }
+        
+        bool ICCOp::definesAllocation() const
+        {
+            return false;
+        }
+        
+        AllocationData ICCOp::getAllocation() const
+        {
+            throw Exception("ICCOp does not define an allocation.");
+        }
+        
+    }  // anonymous namespace
+    
+    void CreateICCOps(OpRcPtrVec & ops,
+                      const ICCTransform & data,
+                      TransformDirection direction)
+    {
+        ops.push_back(OpRcPtr(new ICCOp(data.getIntput(),
+                                        data.getOutput(),
+                                        data.getProof(),
+                                        data.getIntent(),
+                                        data.getBlackpointCompensation(),
+                                        data.getSoftProofing(),
+                                        data.getGamutCheck(),
+                                        direction)));
+    }
+}
+OCIO_NAMESPACE_EXIT

--- a/src/core/ICCOp.h
+++ b/src/core/ICCOp.h
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2003-2010 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef INCLUDED_OCIO_ICCOP_H
+#define INCLUDED_OCIO_ICCOP_H
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "Op.h"
+
+OCIO_NAMESPACE_ENTER
+{
+    void CreateICCOps(OpRcPtrVec & ops,
+                      const ICCTransform & data,
+                      TransformDirection dir);
+}
+OCIO_NAMESPACE_EXIT
+
+#endif // INCLUDED_OCIO_ICCOP_H

--- a/src/core/ICCTransform.cpp
+++ b/src/core/ICCTransform.cpp
@@ -1,0 +1,332 @@
+/*
+Copyright (c) 2003-2010 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+//#include <iostream>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "OpBuilders.h"
+#include "ICCOp.h"
+
+OCIO_NAMESPACE_ENTER
+{
+    
+    ICCTransformRcPtr ICCTransform::Create()
+    {
+        return ICCTransformRcPtr(new ICCTransform(), &deleter);
+    }
+    
+    void ICCTransform::deleter(ICCTransform* t)
+    {
+        delete t;
+    }
+    
+    class ICCTransform::Impl
+    {
+    public:
+        TransformDirection dir_;
+        std::string input_;
+        std::string output_;
+        std::string proof_;
+        IccIntent intent_;
+        bool blackpointCompensation_;
+        bool softProofing_;
+        bool gamutCheck_;
+        
+        Impl() : dir_(TRANSFORM_DIR_FORWARD)
+        { }
+        
+        ~Impl()
+        { }
+        
+        Impl& operator= (const Impl & rhs)
+        {
+            dir_ = rhs.dir_;
+            input_ = rhs.input_;
+            output_ = rhs.output_;
+            proof_ = rhs.proof_;
+            intent_ = rhs.intent_;
+            blackpointCompensation_ = rhs.blackpointCompensation_;
+            softProofing_ = rhs.softProofing_;
+            gamutCheck_ = rhs.gamutCheck_;
+            return *this;
+        }
+    };
+    
+    ///////////////////////////////////////////////////////////////////////////
+    
+    ICCTransform::ICCTransform()
+        : m_impl(new ICCTransform::Impl)
+    {
+        getImpl()->input_ = "";
+        getImpl()->output_ = "";
+        getImpl()->proof_ = "";
+        getImpl()->intent_ = ICC_INTENT_UNKNOWN;
+        getImpl()->blackpointCompensation_ = false;
+        getImpl()->softProofing_ = false;
+        getImpl()->gamutCheck_ = false;
+    }
+    
+    TransformRcPtr ICCTransform::createEditableCopy() const
+    {
+        ICCTransformRcPtr transform = ICCTransform::Create();
+        *(transform->m_impl) = *m_impl;
+        return transform;
+    }
+    
+    ICCTransform::~ICCTransform()
+    {
+        delete m_impl;
+        m_impl = NULL;
+    }
+    
+    ICCTransform& ICCTransform::operator= (const ICCTransform & rhs)
+    {
+        *m_impl = *rhs.m_impl;
+        return *this;
+    }
+    
+    TransformDirection ICCTransform::getDirection() const
+    {
+        return getImpl()->dir_;
+    }
+    
+    void ICCTransform::setDirection(TransformDirection dir)
+    {
+        getImpl()->dir_ = dir;
+    }
+    
+    void ICCTransform::setInput(const char * input)
+    {
+        getImpl()->input_ = input;
+    }
+    
+    void ICCTransform::setInputMem(const void * /*inputPtr*/, int /*size*/)
+    {
+        // not yet impl
+    }
+    
+    const char * ICCTransform::getIntput() const
+    {
+        return getImpl()->input_.c_str();
+    }
+    
+    void ICCTransform::setOutput(const char * output)
+    {
+        getImpl()->output_ = output;
+    }
+    
+    void ICCTransform::setOutputMem(const void * /*outputPtr*/, int /*size*/)
+    {
+        // not yet impl
+    }
+    
+    const char * ICCTransform::getOutput() const
+    {
+        return getImpl()->output_.c_str();
+    }
+    
+    void ICCTransform::setProof(const char * proof)
+    {
+        getImpl()->proof_ = proof;
+    }
+    
+    void ICCTransform::setProofMem(const void * /*proofPtr*/, int /*size*/)
+    {
+        // not yet impl
+    }
+    
+    const char * ICCTransform::getProof() const
+    {
+        return getImpl()->proof_.c_str();
+    }
+    
+    void ICCTransform::setIntent(IccIntent intent)
+    {
+        getImpl()->intent_ = intent;
+    }
+    
+    IccIntent ICCTransform::getIntent() const
+    {
+        return getImpl()->intent_;
+    }
+    
+    void ICCTransform::setBlackpointCompensation(bool blackpointCompensation)
+    {
+        getImpl()->blackpointCompensation_ = blackpointCompensation;
+    }
+    
+    bool ICCTransform::getBlackpointCompensation() const
+    {
+        return getImpl()->blackpointCompensation_;
+    }
+    
+    void ICCTransform::setSoftProofing(bool softProofing)
+    {
+        getImpl()->softProofing_ = softProofing;
+    }
+    
+    bool ICCTransform::getSoftProofing() const
+    {
+        return getImpl()->softProofing_;
+    }
+    
+    void ICCTransform::setGamutCheck(bool gamutCheck)
+    {
+        getImpl()->gamutCheck_ = gamutCheck;
+    }
+    
+    bool ICCTransform::getGamutCheck() const
+    {
+        return getImpl()->gamutCheck_;
+    }
+    
+    std::ostream& operator<< (std::ostream& os, const ICCTransform& t)
+    {
+        os << "<ICCTransform ";
+        os << "direction=" << TransformDirectionToString(t.getDirection()) << ", ";
+        os << ">\n";
+        return os;
+    }
+    
+    ///////////////////////////////////////////////////////////////////////////
+    
+    void BuildICCOps(OpRcPtrVec & ops,
+                     const Config& /*config*/,
+                     const ICCTransform & transform,
+                     TransformDirection dir)
+    {
+        TransformDirection combinedDir = CombineTransformDirections(dir,
+            transform.getDirection());
+        CreateICCOps(ops, transform, combinedDir);
+    }
+    
+}
+OCIO_NAMESPACE_EXIT
+
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef OCIO_UNIT_TEST
+
+namespace OCIO = OCIO_NAMESPACE;
+#include "UnitTest.h"
+#include "pystring/pystring.h"
+
+OIIO_ADD_TEST(ICCTransform, simpletest)
+{
+    
+    OCIO::ConfigRcPtr config = OCIO::Config::Create();
+    {
+        OCIO::ColorSpaceRcPtr cs = OCIO::ColorSpace::Create();
+        cs->setName("iccinput");
+        cs->setFamily("foo1");
+        config->addColorSpace(cs);
+    }
+    {
+        OCIO::ColorSpaceRcPtr cs = OCIO::ColorSpace::Create();
+        cs->setName("iccoutput");
+        cs->setFamily("foo2");
+        OCIO::ICCTransformRcPtr transform1 = OCIO::ICCTransform::Create();
+        // TODO: move these into the project, once we have the paths resolv correctly
+        transform1->setInput("/tmp/test1.icc");
+        transform1->setOutput("/tmp/test2.icc");
+        transform1->setIntent(OCIO::ICC_INTENT_ABSOLUTE_COLORIMETRIC);
+        cs->setTransform(transform1, OCIO::COLORSPACE_DIR_FROM_REFERENCE);
+        config->addColorSpace(cs);
+    }
+    
+    // check the transform round trip
+    OCIO::ConstProcessorRcPtr fwdproc;
+    OCIO::ConstProcessorRcPtr revproc;
+    
+    OIIO_CHECK_NO_THOW(fwdproc = config->getProcessor("iccinput", "iccoutput"));
+    OIIO_CHECK_NO_THOW(revproc = config->getProcessor("iccoutput", "iccinput"));
+    
+    float input[3] = {0.5f, 0.5f, 0.5f};
+    float output[3] = {0.51046f, 0.495933f, 0.517784f};
+    
+    if(fwdproc) OIIO_CHECK_NO_THOW(fwdproc->applyRGB(input));
+    if(revproc) OIIO_CHECK_NO_THOW(revproc->applyRGB(input));
+    
+    OIIO_CHECK_CLOSE(input[0], output[0], 1e-4);
+    OIIO_CHECK_CLOSE(input[1], output[1], 1e-4);
+    OIIO_CHECK_CLOSE(input[2], output[2], 1e-4);
+    
+    //
+    std::ostringstream os;
+    OIIO_CHECK_NO_THOW(config->serialize(os));
+    
+    std::string testconfig =
+    "---\n"
+    "ocio_profile_version: 1\n"
+    "\n"
+    "search_path: \"\"\n"
+    "strictparsing: true\n"
+    "luma: [0.2126, 0.7152, 0.0722]\n"
+    "\n"
+    "roles:\n"
+    "  {}\n"
+    "\n"
+    "displays:\n"
+    "  {}\n"
+    "active_displays: []\n"
+    "active_views: []\n"
+    "\n"
+    "colorspaces:\n"
+    "  - !<ColorSpace>\n"
+    "    name: iccinput\n"
+    "    family: foo1\n"
+    "    bitdepth: unknown\n"
+    "    isdata: false\n"
+    "    allocation: uniform\n"
+    "\n"
+    "  - !<ColorSpace>\n"
+    "    name: iccoutput\n"
+    "    family: foo2\n"
+    "    bitdepth: unknown\n"
+    "    isdata: false\n"
+    "    allocation: uniform\n"
+    "    from_reference: !<ICCTransform> {input: /tmp/test1.icc, output: /tmp/test2.icc, intent: absolute_colorimetric}\n";
+    
+    std::vector<std::string> osvec;
+    OCIO::pystring::splitlines(os.str(), osvec);
+    std::vector<std::string> testconfigvec;
+    OCIO::pystring::splitlines(testconfig, testconfigvec);
+    
+    OIIO_CHECK_EQUAL(osvec.size(), testconfigvec.size());
+    for(unsigned int i = 0; i < testconfigvec.size(); ++i)
+        OIIO_CHECK_EQUAL(osvec[i], testconfigvec[i]);
+    
+    std::istringstream is;
+    is.str(testconfig);
+    OCIO::ConstConfigRcPtr rtconfig;
+    OIIO_CHECK_NO_THOW(rtconfig = OCIO::Config::CreateFromStream(is));
+    
+}
+
+#endif // OCIO_UNIT_TEST

--- a/src/core/OCIOYaml.cpp
+++ b/src/core/OCIOYaml.cpp
@@ -176,6 +176,8 @@ OCIO_NAMESPACE_ENTER
             t = node.Read<MatrixTransformRcPtr>();
         else if(type == "TruelightTransform")
             t = node.Read<TruelightTransformRcPtr>();
+        else if(type == "ICCTransform")
+            t = node.Read<ICCTransformRcPtr>();
         else
         {
             // TODO: add a new empty (better name?) aka passthru Transform()
@@ -203,7 +205,6 @@ OCIO_NAMESPACE_ENTER
         else if(ConstColorSpaceTransformRcPtr ColorSpace_tran = \
             DynamicPtrCast<const ColorSpaceTransform>(t))
             out << ColorSpace_tran;
-        // ConstExponentTransformRcPtr
         else if(ConstExponentTransformRcPtr Exponent_tran = \
             DynamicPtrCast<const ExponentTransform>(t))
             out << Exponent_tran;
@@ -222,6 +223,9 @@ OCIO_NAMESPACE_ENTER
         else if(ConstTruelightTransformRcPtr Truelight_tran = \
             DynamicPtrCast<const TruelightTransform>(t))
             out << Truelight_tran;
+        else if(ConstICCTransformRcPtr ICC_tran = \
+            DynamicPtrCast<const ICCTransform>(t))
+            out << ICC_tran;
         else
             throw Exception("Unsupported Transform() type for serialization.");
         
@@ -636,6 +640,72 @@ OCIO_NAMESPACE_ENTER
         return out;
     }
     
+    void operator >> (const YAML::Node& node, ICCTransformRcPtr& t)
+    {
+        t = ICCTransform::Create();
+        if(node.FindValue("input") != NULL)
+            t->setInput(node["input"].Read<std::string>().c_str());
+        if(node.FindValue("profile") != NULL)
+            t->setOutput(node["output"].Read<std::string>().c_str());
+        if(node.FindValue("camera") != NULL)
+            t->setProof(node["proof"].Read<std::string>().c_str());
+        if(node.FindValue("intent") != NULL)
+            t->setIntent(node["intent"].Read<IccIntent>());
+        if(node.FindValue("blackpoint_compensation") != NULL)
+            t->setBlackpointCompensation(node["blackpoint_compensation"].Read<bool>());
+        if(node.FindValue("soft_proofing") != NULL)
+            t->setSoftProofing(node["soft_proofing"].Read<bool>());
+        if(node.FindValue("gamut_check") != NULL)
+            t->setGamutCheck(node["gamut_check"].Read<bool>());
+    }
+    
+    YAML::Emitter& operator << (YAML::Emitter& out, ConstICCTransformRcPtr t)
+    {
+        
+        out << YAML::VerbatimTag("ICCTransform");
+        out << YAML::Flow << YAML::BeginMap;
+        if(strcmp(t->getIntput(), "") != 0)
+        {
+            out << YAML::Key << "input";
+            out << YAML::Value << YAML::Flow << t->getIntput();
+        }
+        if(strcmp(t->getOutput(), "") != 0)
+        {
+            out << YAML::Key << "output";
+            out << YAML::Value << YAML::Flow << t->getOutput();
+        }
+        if(strcmp(t->getProof(), "") != 0)
+        {
+            out << YAML::Key << "output";
+            out << YAML::Value << YAML::Flow << t->getProof();
+        }
+        if(t->getIntent() != ICC_INTENT_UNKNOWN)
+        {
+            out << YAML::Key << "intent";
+            out << YAML::Value << YAML::Flow << t->getIntent();
+        }
+        if(t->getBlackpointCompensation() != false)
+        {
+            out << YAML::Key << "blackpoint_compensation";
+            out << YAML::Value << YAML::Flow << t->getBlackpointCompensation();
+        }
+        if(t->getSoftProofing() != false)
+        {
+            out << YAML::Key << "soft_proofing";
+            out << YAML::Value << YAML::Flow << t->getSoftProofing();
+        }
+        if(t->getGamutCheck() != false)
+        {
+            out << YAML::Key << "gamut_check";
+            out << YAML::Value << YAML::Flow << t->getGamutCheck();
+        }
+        
+        EmitBaseTransformKeyValues(out, t);
+        
+        out << YAML::EndMap;
+        return out;
+    }
+    
     ///////////////////////////////////////////////////////////////////////////
     //  Enums
     
@@ -687,6 +757,16 @@ OCIO_NAMESPACE_ENTER
     void operator >> (const YAML::Node& node, Interpolation& interp) {
         std::string str = node.Read<std::string>();
         interp = InterpolationFromString(str.c_str());
+    }
+    
+    YAML::Emitter& operator << (YAML::Emitter& out, IccIntent intent) {
+        out << IccIntentToString(intent);
+        return out;
+    }
+    
+    void operator >> (const YAML::Node& node, IccIntent& intent) {
+        std::string str = node.Read<std::string>();
+        intent = IccIntentFromString(str.c_str());
     }
     
 }

--- a/src/core/OCIOYaml.h
+++ b/src/core/OCIOYaml.h
@@ -92,6 +92,8 @@ OCIO_NAMESPACE_ENTER
     OCIOHIDDEN YAML::Emitter& operator << (YAML::Emitter& out, ConstAllocationTransformRcPtr t);
     OCIOHIDDEN void operator >> (const YAML::Node& node, TruelightTransformRcPtr& t);
     OCIOHIDDEN YAML::Emitter& operator << (YAML::Emitter& out, ConstTruelightTransformRcPtr t);
+    OCIOHIDDEN void operator >> (const YAML::Node& node, ICCTransformRcPtr& t);
+    OCIOHIDDEN YAML::Emitter& operator << (YAML::Emitter& out, ConstICCTransformRcPtr t);
     
     // Enums
     OCIOHIDDEN YAML::Emitter& operator << (YAML::Emitter& out, BitDepth depth);
@@ -104,6 +106,8 @@ OCIO_NAMESPACE_ENTER
     OCIOHIDDEN void operator >> (const YAML::Node& node, TransformDirection& dir);
     OCIOHIDDEN YAML::Emitter& operator << (YAML::Emitter& out, Interpolation iterp);
     OCIOHIDDEN void operator >> (const YAML::Node& node, Interpolation& iterp);
+    OCIOHIDDEN YAML::Emitter& operator << (YAML::Emitter& out, IccIntent intent);
+    OCIOHIDDEN void operator >> (const YAML::Node& node, IccIntent& intent);
     
 }
 OCIO_NAMESPACE_EXIT

--- a/src/core/OpBuilders.h
+++ b/src/core/OpBuilders.h
@@ -116,6 +116,11 @@ OCIO_NAMESPACE_ENTER
                            const TruelightTransform & transform,
                            TransformDirection dir);
     
+    void BuildICCOps(OpRcPtrVec & ops,
+                     const Config & config,
+                     const ICCTransform & transform,
+                     TransformDirection dir);
+    
     ////////////////////////////////////////////////////////////////////////
     
     

--- a/src/core/ParseUtils.cpp
+++ b/src/core/ParseUtils.cpp
@@ -195,6 +195,24 @@ OCIO_NAMESPACE_ENTER
         return GPU_LANGUAGE_UNKNOWN;
     }
     
+    const char * IccIntentToString(IccIntent intent)
+    {
+        if(intent == ICC_INTENT_PERCEPTUAL) return "perceptual";
+        else if(intent == ICC_INTENT_RELATIVE_COLORIMETRIC) return "relative_colorimetric";
+        else if(intent == ICC_INTENT_SATURATION) return "saturation";
+        else if(intent == ICC_INTENT_ABSOLUTE_COLORIMETRIC) return "absolute_colorimetric";
+        return "unknown";
+    }
+    
+    IccIntent IccIntentFromString(const char * s)
+    {
+        std::string str = pystring::lower(s);
+        if(str == "perceptual") return ICC_INTENT_PERCEPTUAL;
+        else if(str == "relative_colorimetric") return ICC_INTENT_RELATIVE_COLORIMETRIC;
+        else if(str == "saturation") return ICC_INTENT_SATURATION;
+        else if(str == "absolute_colorimetric") return ICC_INTENT_ABSOLUTE_COLORIMETRIC;
+        return ICC_INTENT_UNKNOWN;
+    }
     
     const char * ROLE_DEFAULT = "default";
     const char * ROLE_REFERENCE = "reference";

--- a/src/core/Transform.cpp
+++ b/src/core/Transform.cpp
@@ -100,6 +100,11 @@ OCIO_NAMESPACE_ENTER
         {
             BuildTruelightOps(ops, config, *truelightTransform, dir);
         }
+        else if(ConstICCTransformRcPtr iccTransform = \
+            DynamicPtrCast<const ICCTransform>(transform))
+        {
+            BuildICCOps(ops, config, *iccTransform, dir);
+        }
         else
         {
             std::ostringstream os;
@@ -156,6 +161,11 @@ OCIO_NAMESPACE_ENTER
             dynamic_cast<const TruelightTransform*>(t))
         {
             os << *truelightTransform;
+        }
+        else if(const ICCTransform * iccTransform = \
+            dynamic_cast<const ICCTransform*>(t))
+        {
+            os << *iccTransform;
         }
         else
         {

--- a/src/core_tests/CMakeLists.txt
+++ b/src/core_tests/CMakeLists.txt
@@ -13,7 +13,7 @@ include_directories(
 file( GLOB_RECURSE core_test_src_files "${CMAKE_SOURCE_DIR}/src/core/*.cpp" )
 
 add_executable(ocio_core_tests ${core_test_src_files})
-add_dependencies(ocio_core_tests tinyxml YAML_CPP_LOCAL)
+add_dependencies(ocio_core_tests tinyxml YAML_CPP_LOCAL LCMS)
 set_target_properties(ocio_core_tests PROPERTIES
     COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS}"
     LINK_FLAGS "${EXTERNAL_LINK_FLAGS}")


### PR DESCRIPTION
Had sometime on the plane so did a first pass at a ICCTransform, which will be needed for 'iv color profiles/LUTs' on the https://github.com/OpenImageIO/oiio/wiki/GSoC-Idea-Page.

Would like some feedback on where the filepath resolution should be? It's easy for me to add this in the Op but most other things have this in the Transform, is this where this logic should sit?

I have not implemented the setInputMem(const void \* inputPtr, int size) functions yet, but have added these to the transform interface, these would be used when loading icc profile embedded in file headers.
