### PR TITLE
Add description to Look object

### DIFF
--- a/export/OpenColorIO/OpenColorIO.h
+++ b/export/OpenColorIO/OpenColorIO.h
@@ -732,6 +732,11 @@ OCIO_NAMESPACE_ENTER
         ConstTransformRcPtr getInverseTransform() const;
         //!cpp:function:: Setting a transform to a non-null call makes it allowed.
         void setInverseTransform(const ConstTransformRcPtr & transform);
+
+        //!cpp:function::
+        const char * getDescription() const;
+        //!cpp:function::
+        void setDescription(const char * description);
     private:
         Look();
         ~Look();

--- a/src/core/Look.cpp
+++ b/src/core/Look.cpp
@@ -49,6 +49,7 @@ OCIO_NAMESPACE_ENTER
     public:
         std::string name_;
         std::string processSpace_;
+        std::string description_;
         TransformRcPtr transform_;
         TransformRcPtr inverseTransform_;
         
@@ -62,6 +63,7 @@ OCIO_NAMESPACE_ENTER
         {
             name_ = rhs.name_;
             processSpace_ = rhs.processSpace_;
+            description_ = rhs.description_;
             
             transform_ = rhs.transform_;
             if(transform_) transform_ = transform_->createEditableCopy();
@@ -136,7 +138,16 @@ OCIO_NAMESPACE_ENTER
         getImpl()->inverseTransform_ = transform->createEditableCopy();
     }
     
-    
+    const char * Look::getDescription() const
+    {
+        return getImpl()->description_.c_str();
+    }
+
+    void Look::setDescription(const char * description)
+    {
+        getImpl()->description_ = description;
+    }
+
     std::ostream& operator<< (std::ostream& os, const Look& look)
     {
         os << "<Look ";

--- a/src/core/OCIOYaml.cpp
+++ b/src/core/OCIOYaml.cpp
@@ -1369,6 +1369,11 @@ OCIO_NAMESPACE_ENTER
                     load(second, val);
                     look->setInverseTransform(val);
                 }
+                else if(key == "description")
+                {
+                    load(second, stringval);
+                    look->setDescription(stringval.c_str());
+                }
                 else
                 {
                     LogUnknownKeyWarning(node.Tag(), first);
@@ -1382,6 +1387,13 @@ OCIO_NAMESPACE_ENTER
             out << YAML::BeginMap;
             out << YAML::Key << "name" << YAML::Value << look->getName();
             out << YAML::Key << "process_space" << YAML::Value << look->getProcessSpace();
+            if (look->getDescription() != NULL &&
+                strlen(look->getDescription()) > 0)
+            {
+                out << YAML::Key << "description";
+                out << YAML::Value << YAML::Literal << look->getDescription();
+            }
+
             
             if(look->getTransform())
             {

--- a/src/jniglue/JNILook.cpp
+++ b/src/jniglue/JNILook.cpp
@@ -88,6 +88,24 @@ Java_org_OpenColorIO_Look_setProcessSpace(JNIEnv * env, jobject self, jstring pr
     OCIO_JNITRY_EXIT()
 }
 
+JNIEXPORT jstring JNICALL
+Java_org_OpenColorIO_Look_getDescription(JNIEnv * env, jobject self)
+{
+    OCIO_JNITRY_ENTER()
+    ConstLookRcPtr lok = GetConstJOCIO<ConstLookRcPtr, LookJNI>(env, self);
+    return env->NewStringUTF(lok->getDescription());
+    OCIO_JNITRY_EXIT(NULL)
+}
+
+JNIEXPORT void JNICALL
+Java_org_OpenColorIO_Look_setDescription(JNIEnv * env, jobject self, jstring processSpace)
+{
+    OCIO_JNITRY_ENTER()
+    LookRcPtr lok = GetEditableJOCIO<LookRcPtr, LookJNI>(env, self);
+    lok->setDescription(GetJStringValue(env, processSpace)());
+    OCIO_JNITRY_EXIT()
+}
+
 JNIEXPORT jobject JNICALL
 Java_org_OpenColorIO_Look_getTransform(JNIEnv * env, jobject self)
 {

--- a/src/jniglue/org/OpenColorIO/Look.java
+++ b/src/jniglue/org/OpenColorIO/Look.java
@@ -40,6 +40,8 @@ public class Look extends LoadLibrary
     public native void setName(String name);
     public native String getProcessSpace();
     public native void setProcessSpace(String processSpace);
+    public native String getDescription();
+    public native void setDescription(String description);
     public native Transform getTransform();
     public native void setTransform(Transform transform);
     public native Transform getInverseTransform();

--- a/src/jniglue/tests/org/OpenColorIO/LookTest.java
+++ b/src/jniglue/tests/org/OpenColorIO/LookTest.java
@@ -16,6 +16,8 @@ public class LookTest extends TestCase {
         assertEquals("coollook", lk.getName());
         lk.setProcessSpace("somespace");
         assertEquals("somespace", lk.getProcessSpace());
+        lk.setDescription("this is a test");
+        assertEquals("this is a test", lk.getDescription());
         ExponentTransform et = new ExponentTransform().Create();
         et.setValue(new float[]{0.1f, 0.2f, 0.3f, 0.4f});
         lk.setTransform(et);

--- a/src/pyglue/DocStrings/Look.py
+++ b/src/pyglue/DocStrings/Look.py
@@ -27,6 +27,12 @@ class Look:
     def setProcessSpace(self, csname):
         pass
         
+    def getDescription(self):
+        pass
+        
+    def setDescription(self, desc):
+        pass
+        
     def getTransform(self):
         pass
         

--- a/src/pyglue/PyLook.cpp
+++ b/src/pyglue/PyLook.cpp
@@ -83,6 +83,8 @@ OCIO_NAMESPACE_ENTER
         PyObject * PyOCIO_Look_setName(PyObject * self, PyObject * args);
         PyObject * PyOCIO_Look_getProcessSpace(PyObject * self);
         PyObject * PyOCIO_Look_setProcessSpace(PyObject * self, PyObject * args);
+        PyObject * PyOCIO_Look_getDescription(PyObject * self);
+        PyObject * PyOCIO_Look_setDescription(PyObject * self, PyObject * args);
         PyObject * PyOCIO_Look_getTransform(PyObject * self);
         PyObject * PyOCIO_Look_setTransform(PyObject * self, PyObject * args);
         PyObject * PyOCIO_Look_getInverseTransform(PyObject * self);
@@ -104,6 +106,10 @@ OCIO_NAMESPACE_ENTER
             (PyCFunction) PyOCIO_Look_getProcessSpace, METH_NOARGS, LOOK_GETPROCESSSPACE__DOC__ },
             { "setProcessSpace",
             PyOCIO_Look_setProcessSpace, METH_VARARGS, LOOK_SETPROCESSSPACE__DOC__ },
+            { "getDescription",
+            (PyCFunction) PyOCIO_Look_getDescription, METH_NOARGS, LOOK_GETDESCRIPTION__DOC__ },
+            { "setDescription",
+            PyOCIO_Look_setDescription, METH_VARARGS, LOOK_SETDESCRIPTION__DOC__ },
             { "getTransform",
             (PyCFunction) PyOCIO_Look_getTransform, METH_NOARGS, LOOK_GETTRANSFORM__DOC__ },
             { "setTransform",
@@ -176,11 +182,12 @@ OCIO_NAMESPACE_ENTER
             /*int ret =*/ BuildPyObject<PyOCIO_Look, ConstLookRcPtr, LookRcPtr>(self, ptr);
             char* name = NULL;
             char* processSpace = NULL;
+            char* description = NULL;
             PyObject* pytransform = NULL;
-            const char* kwlist[] = { "name", "processSpace", "transform", NULL };
-            if(!PyArg_ParseTupleAndKeywords(args, kwds, "|ssO",
+            const char* kwlist[] = { "name", "processSpace", "transform", "description", NULL };
+            if(!PyArg_ParseTupleAndKeywords(args, kwds, "|ssOs",
                 const_cast<char **>(kwlist),
-                &name, &processSpace, &pytransform)) return -1;
+                &name, &processSpace, &pytransform, &description)) return -1;
             if(name) ptr->setName(name);
             if(processSpace) ptr->setProcessSpace(processSpace);
             if(pytransform)
@@ -188,6 +195,7 @@ OCIO_NAMESPACE_ENTER
                 ConstTransformRcPtr transform = GetConstTransform(pytransform, true);
                 ptr->setTransform(transform);
             }
+            if(description) ptr->setDescription(description);
             return 0;
             OCIO_PYTRY_EXIT(-1)
         }
@@ -247,6 +255,25 @@ OCIO_NAMESPACE_ENTER
                 &processSpace)) return NULL;
             LookRcPtr look = GetEditableLook(self);
             look->setProcessSpace(processSpace);
+            Py_RETURN_NONE;
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Look_getDescription(PyObject * self)
+        {
+            OCIO_PYTRY_ENTER()
+            ConstLookRcPtr look = GetConstLook(self, true);
+            return PyString_FromString(look->getDescription());
+            OCIO_PYTRY_EXIT(NULL)
+        }
+        
+        PyObject * PyOCIO_Look_setDescription(PyObject * self, PyObject * args)
+        {
+            OCIO_PYTRY_ENTER()
+            char* description = 0;
+            if (!PyArg_ParseTuple(args, "s:setDescription", &description)) return NULL;
+            LookRcPtr look = GetEditableLook(self);
+            look->setDescription(description);
             Py_RETURN_NONE;
             OCIO_PYTRY_EXIT(NULL)
         }

--- a/src/pyglue/tests/LookTest.py
+++ b/src/pyglue/tests/LookTest.py
@@ -11,6 +11,8 @@ class LookTest(unittest.TestCase):
         self.assertEqual("coollook", lk.getName())
         lk.setProcessSpace("somespace")
         self.assertEqual("somespace", lk.getProcessSpace())
+        lk.setDescription("this is a test")
+        self.assertEqual("this is a test", lk.getDescription())
         et = OCIO.ExponentTransform()
         et.setValue([0.1, 0.2, 0.3, 0.4])
         lk.setTransform(et)


### PR DESCRIPTION
Add a description field to look objects.  This addresses issue #344.
On the python binding the description was added as the last field to not break existing positional arguments.