### PR TITLE
cmake support for OSX universal binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ endif()
 
 include(ParseArguments)
 include(OCIOMacros)
+include(OCIOFunctions)
 include(ExternalProject)
 
 enable_language(CXX)
@@ -69,6 +70,12 @@ if(APPLE OR IPHONE)
     if(CMAKE_FIRST_RUN)
         message(STATUS "Setting OSX Architectures to: ${CMAKE_OSX_ARCHITECTURES}")
     endif()
+    # Because of the way quoting works with CMAKE_ARGS I need to convert the ";"
+    # separated list into a string with another seperator and use the
+    # LIST_SEPARATOR option on ExternalProject_Add
+    string(REPLACE ";" "^^" CMAKE_OSX_ARCHITECTURES_STR "${CMAKE_OSX_ARCHITECTURES}")
+    
+    OCIOPrefixListItems("-arch " CMAKE_OSX_ARCHITECTURES OCIO_ARCH_FLAGS)
 endif()
 
 # Set the default built type
@@ -181,12 +188,16 @@ else(USE_EXTERNAL_TINYXML)
     if(CMAKE_TOOLCHAIN_FILE)
         set(TINYXML_CMAKE_ARGS ${TINYXML_CMAKE_ARGS} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
     endif()
+    if(APPLE OR IPHONE)
+        set(TINYXML_CMAKE_ARGS ${TINYXML_CMAKE_ARGS} -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES_STR})
+    endif()
     ExternalProject_Add(tinyxml
         URL ${CMAKE_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.tar.gz
         PATCH_COMMAND patch -f -p1 < ${CMAKE_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.patch
         BINARY_DIR ext/build/tinyxml
         INSTALL_DIR ext/dist
         CMAKE_ARGS ${TINYXML_CMAKE_ARGS}
+        LIST_SEPARATOR ^^
     )
     if(WIN32)
         set(TINYXML_STATIC_LIBRARIES ${PROJECT_BINARY_DIR}/ext/dist/lib/tinyxml.lib)
@@ -220,12 +231,16 @@ else(USE_EXTERNAL_YAML)
     if(CMAKE_TOOLCHAIN_FILE)
         set(YAML_CPP_CMAKE_ARGS ${YAML_CPP_CMAKE_ARGS} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
     endif()
+    if(APPLE OR IPHONE)
+        set(YAML_CPP_CMAKE_ARGS ${YAML_CPP_CMAKE_ARGS} -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES_STR})
+    endif()
     ExternalProject_Add(YAML_CPP_LOCAL
         URL ${CMAKE_SOURCE_DIR}/ext/yaml-cpp-${YAML_CPP_VERSION}.tar.gz
         BINARY_DIR ext/build/yaml-cpp
         PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/ext/yaml-cpp-${YAML_CPP_VERSION}.patch
         INSTALL_DIR ext/dist
         CMAKE_ARGS ${YAML_CPP_CMAKE_ARGS}
+        LIST_SEPARATOR ^^
     )
     set(YAML_CPP_INCLUDE_DIRS ${PROJECT_BINARY_DIR}/ext/dist/include)
     set(YAML_CPP_LIBRARY_DIRS ${PROJECT_BINARY_DIR}/ext/dist/lib)

--- a/share/cmake/OCIOFunctions.cmake
+++ b/share/cmake/OCIOFunctions.cmake
@@ -1,0 +1,8 @@
+function (OCIOPrefixListItems _PREFIX _LIST_NAME OUTPUT_VAR)
+  set(PREFIXED_LIST)
+  foreach(ITEM ${${_LIST_NAME}})
+    set(PREFIXED_LIST "${PREFIXED_LIST} ${_PREFIX}${ITEM}")
+  endforeach()
+  string(STRIP ${PREFIXED_LIST} PREFIXED_LIST)
+  set(${OUTPUT_VAR} "${PREFIXED_LIST}" PARENT_SCOPE)
+endfunction()

--- a/src/apps/ociobakelut/CMakeLists.txt
+++ b/src/apps/ociobakelut/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
     ExternalProject_Add(LCMS
         URL ${CMAKE_SOURCE_DIR}/ext/lcms2-${LCMS_VERSION}.tar.gz
         BUILD_IN_SOURCE 1
-        CONFIGURE_COMMAND ./configure --prefix=${PROJECT_BINARY_DIR}/ext/dist --without-jpeg --without-tiff --without-zlib
+        CONFIGURE_COMMAND ./configure --prefix=${PROJECT_BINARY_DIR}/ext/dist --disable-dependency-tracking --without-jpeg --without-tiff --without-zlib "CFLAGS=${OCIO_ARCH_FLAGS}"
         BUILD_COMMAND make
         INSTALL_COMMAND make install
     )

--- a/src/apps/ociobakelut/CMakeLists.txt
+++ b/src/apps/ociobakelut/CMakeLists.txt
@@ -1,6 +1,8 @@
 # LCMS
-include(FindPkgConfig FindPackageMessage)
-pkg_check_modules(LCMS QUIET lcms2)
+if(USE_EXTERNAL_LCMS)
+    include(FindPkgConfig FindPackageMessage)
+    pkg_check_modules(LCMS QUIET lcms2)
+endif()
 if(LCMS_FOUND AND (LCMS_VERSION VERSION_EQUAL 2.1 OR LCMS_VERSION VERSION_GREATER 2.1))
     FIND_PACKAGE_MESSAGE(LCMS "Found lcms: ${LCMS_LIBRARIES}"
         "${LCMS_INCLUDE_DIR}")


### PR DESCRIPTION
Added support to specify multiple architectures with CMAKE_OSX_ARCHITECTURES. Needed to pass architecture flags to ExternalProject_add.

Also implemented USE_EXTERNAL_LCMS which was in the main cmake file but not used in the ociobakelut cmake file.
