### PR TITLE
Cleanup of ostream inserter

### DIFF
--- a/src/core/AllocationTransform.cpp
+++ b/src/core/AllocationTransform.cpp
@@ -149,8 +149,22 @@ OCIO_NAMESPACE_ENTER
     
     std::ostream& operator<< (std::ostream& os, const AllocationTransform& t)
     {
+        Allocation allocation(t.getAllocation());
+        int numVars(t.getNumVars());
+        std::vector<float> vars(numVars);
+        t.getVars(&vars[0]);
+
         os << "<AllocationTransform ";
-        os << "direction=" << TransformDirectionToString(t.getDirection()) << ", ";
+        os << "direction=" << TransformDirectionToString(t.getDirection());
+        if (numVars)
+        {
+            os << ", allocation=" << AllocationToString(allocation) << ", ";
+            os << "vars=" << vars[0];
+            for (int i = 0; i < numVars; ++i)
+            {
+                os << " " << vars[i];
+            }
+        }
         os << ">\n";
         
         return os;

--- a/src/core/AllocationTransform.cpp
+++ b/src/core/AllocationTransform.cpp
@@ -160,12 +160,12 @@ OCIO_NAMESPACE_ENTER
         {
             os << ", allocation=" << AllocationToString(allocation) << ", ";
             os << "vars=" << vars[0];
-            for (int i = 0; i < numVars; ++i)
+            for (int i = 1; i < numVars; ++i)
             {
                 os << " " << vars[i];
             }
         }
-        os << ">\n";
+        os << ">";
         
         return os;
     }

--- a/src/core/CDLTransform.cpp
+++ b/src/core/CDLTransform.cpp
@@ -776,18 +776,16 @@ OCIO_NAMESPACE_ENTER
         float sop[9];
         t.getSOP(sop);
         
-        os << "<CDLTransform ";
-        os << "direction=" << TransformDirectionToString(t.getDirection()) << ", ";
-        os << "sop=";
+        os << "<CDLTransform";
+        os << " direction=" << TransformDirectionToString(t.getDirection());
+        os << ", sop=";
         for (unsigned int i=0; i<9; ++i)
         {
             if(i!=0) os << " ";
             os << sop[i];
         }
-        os << ", ";
-        os << "sat=" << t.getSat() << ",";
-        os << TransformDirectionToString(t.getDirection()) << ", ";
-        os << ">\n";
+        os << ", sat=" << t.getSat();
+        os << ">";
         return os;
     }
     

--- a/src/core/ColorSpace.cpp
+++ b/src/core/ColorSpace.cpp
@@ -258,23 +258,23 @@ OCIO_NAMESPACE_ENTER
         {
             os << ", allocation=" << AllocationToString(cs.getAllocation()) << ", ";
             os << "vars=" << vars[0];
-            for (int i = 0; i < numVars; ++i)
+            for (int i = 1; i < numVars; ++i)
             {
                 os << " " << vars[i];
             }
         }
-        os << ">\n";
+        os << ">";
         
         if(cs.getTransform(COLORSPACE_DIR_TO_REFERENCE))
         {
-            os << "\t" << cs.getName() << " --> Reference\n";
-            os << cs.getTransform(COLORSPACE_DIR_TO_REFERENCE);
+            os << "\n    " << cs.getName() << " --> Reference";
+            os << "\n\t" << *cs.getTransform(COLORSPACE_DIR_TO_REFERENCE);
         }
         
         if(cs.getTransform(COLORSPACE_DIR_FROM_REFERENCE))
         {
-            os << "\tReference --> " << cs.getName() << "\n";
-            os << cs.getTransform(COLORSPACE_DIR_FROM_REFERENCE);
+            os << "\n    Reference --> " << cs.getName();
+            os << "\n\t" << *cs.getTransform(COLORSPACE_DIR_FROM_REFERENCE);
         }
         return os;
     }

--- a/src/core/ColorSpace.cpp
+++ b/src/core/ColorSpace.cpp
@@ -244,13 +244,25 @@ OCIO_NAMESPACE_ENTER
     
     std::ostream& operator<< (std::ostream& os, const ColorSpace& cs)
     {
+        int numVars(cs.getAllocationNumVars());
+        std::vector<float> vars(numVars);
+        cs.getAllocationVars(&vars[0]);
+
         os << "<ColorSpace ";
         os << "name=" << cs.getName() << ", ";
         os << "family=" << cs.getFamily() << ", ";
         os << "equalityGroup=" << cs.getEqualityGroup() << ", ";
         os << "bitDepth=" << BitDepthToString(cs.getBitDepth()) << ", ";
-        os << "isData=" << BoolToString(cs.isData()) << ", ";
-        os << "allocation=" << AllocationToString(cs.getAllocation()) << ", ";
+        os << "isData=" << BoolToString(cs.isData());
+        if (numVars)
+        {
+            os << ", allocation=" << AllocationToString(cs.getAllocation()) << ", ";
+            os << "vars=" << vars[0];
+            for (int i = 0; i < numVars; ++i)
+            {
+                os << " " << vars[i];
+            }
+        }
         os << ">\n";
         
         if(cs.getTransform(COLORSPACE_DIR_TO_REFERENCE))

--- a/src/core/ColorSpaceTransform.cpp
+++ b/src/core/ColorSpaceTransform.cpp
@@ -130,6 +130,8 @@ OCIO_NAMESPACE_ENTER
     {
         os << "<ColorSpaceTransform ";
         os << "direction=" << TransformDirectionToString(t.getDirection()) << ", ";
+        os << "src=" << t.getSrc() << ", ";
+        os << "dst=" << t.getDst();
         os << ">\n";
         return os;
     }

--- a/src/core/ColorSpaceTransform.cpp
+++ b/src/core/ColorSpaceTransform.cpp
@@ -132,7 +132,7 @@ OCIO_NAMESPACE_ENTER
         os << "direction=" << TransformDirectionToString(t.getDirection()) << ", ";
         os << "src=" << t.getSrc() << ", ";
         os << "dst=" << t.getDst();
-        os << ">\n";
+        os << ">";
         return os;
     }
     

--- a/src/core/Context.cpp
+++ b/src/core/Context.cpp
@@ -348,12 +348,17 @@ namespace
 
     std::ostream& operator<< (std::ostream& os, const Context& context)
     {
-        os << "Context:\n";
+        os << "<Context";
+        os << " searchPath=" << context.getSearchPath();
+        os << ", workingDir=" << context.getWorkingDir();
+        os << ", environmentMode=" << EnvironmentModeToString(context.getEnvironmentMode());
+        os << ", environment=";
         for(int i=0; i<context.getNumStringVars(); ++i)
         {
             const char * key = context.getStringVarNameByIndex(i);
-            os << key << "=" << context.getStringVar(key) << "\n";
+            os << "\n\t" << key << ": " << context.getStringVar(key);
         }
+        os << ">";
         return os;
     }
     

--- a/src/core/DisplayTransform.cpp
+++ b/src/core/DisplayTransform.cpp
@@ -231,7 +231,31 @@ OCIO_NAMESPACE_ENTER
         os << "direction=" << TransformDirectionToString(t.getDirection()) << ", ";
         os << "inputColorSpace=" << t.getInputColorSpaceName() << ", ";
         os << "display=" << t.getDisplay() << ", ";
-        os << "view=" << t.getView() << ", ";
+        os << "view=" << t.getView();
+        if (t.getLooksOverrideEnabled())
+        {
+            os << ", looksOverride=" << t.getLooksOverride();
+        }
+        ConstTransformRcPtr transform(t.getLinearCC());
+        if (transform)
+        {
+            os << ", linearCC: " << *transform;
+        }
+        transform = t.getColorTimingCC();
+        if (transform)
+        {
+            os << ", colorTimingCC: " << *transform;
+        }
+        transform = t.getChannelView();
+        if (transform)
+        {
+            os << ", channelView: " << *transform;
+        }
+        transform = t.getDisplayCC();
+        if (transform)
+        {
+            os << ", displayCC: " << *transform;
+        }
         os << ">\n";
         return os;
     }

--- a/src/core/DisplayTransform.cpp
+++ b/src/core/DisplayTransform.cpp
@@ -256,7 +256,7 @@ OCIO_NAMESPACE_ENTER
         {
             os << ", displayCC: " << *transform;
         }
-        os << ">\n";
+        os << ">";
         return os;
     }
     

--- a/src/core/ExponentTransform.cpp
+++ b/src/core/ExponentTransform.cpp
@@ -134,7 +134,7 @@ OCIO_NAMESPACE_ENTER
           os << " " << exp[i];
         }
 
-        os << ">\n";
+        os << ">";
         return os;
     }
     

--- a/src/core/ExponentTransform.cpp
+++ b/src/core/ExponentTransform.cpp
@@ -123,8 +123,17 @@ OCIO_NAMESPACE_ENTER
     
     std::ostream& operator<< (std::ostream& os, const ExponentTransform& t)
     {
+        float exp[4];
+        t.getValue(exp);
+
         os << "<ExponentTransform ";
         os << "direction=" << TransformDirectionToString(t.getDirection()) << ", ";
+        os << "value=" << exp[0];
+        for (int i = 1; i < 4; ++i)
+        {
+          os << " " << exp[i];
+        }
+
         os << ">\n";
         return os;
     }

--- a/src/core/FileTransform.cpp
+++ b/src/core/FileTransform.cpp
@@ -165,8 +165,8 @@ OCIO_NAMESPACE_ENTER
         os << "<FileTransform ";
         os << "direction=" << TransformDirectionToString(t.getDirection()) << ", ";
         os << "interpolation=" << InterpolationToString(t.getInterpolation()) << ", ";
-        os << "src='" << t.getSrc() << "', ";
-        os << "cccid='" << t.getCCCId() << "'";
+        os << "src=" << t.getSrc() << ", ";
+        os << "cccid=" << t.getCCCId();
         os << ">";
         
         return os;

--- a/src/core/GroupTransform.cpp
+++ b/src/core/GroupTransform.cpp
@@ -152,12 +152,17 @@ OCIO_NAMESPACE_ENTER
     
     std::ostream& operator<< (std::ostream& os, const GroupTransform& groupTransform)
     {
+        os << "<GroupTransform ";
+        os << "direction=" << TransformDirectionToString(groupTransform.getDirection()) << ", ";
+        os << "transforms=";
+        TransformDirection dir_;
         for(int i=0; i<groupTransform.size(); ++i)
         {
             if(i!=groupTransform.size()-1) os << "\n";
             ConstTransformRcPtr transform = groupTransform.getTransform(i);
             os << "\t" << *transform;
         }
+        os << ">\n";
         return os;
     }
     

--- a/src/core/GroupTransform.cpp
+++ b/src/core/GroupTransform.cpp
@@ -158,11 +158,10 @@ OCIO_NAMESPACE_ENTER
         TransformDirection dir_;
         for(int i=0; i<groupTransform.size(); ++i)
         {
-            if(i!=groupTransform.size()-1) os << "\n";
             ConstTransformRcPtr transform = groupTransform.getTransform(i);
-            os << "\t" << *transform;
+            os << "\n\t" << *transform;
         }
-        os << ">\n";
+        os << ">";
         return os;
     }
     

--- a/src/core/LogTransform.cpp
+++ b/src/core/LogTransform.cpp
@@ -122,8 +122,8 @@ OCIO_NAMESPACE_ENTER
     {
         os << "<LogTransform ";
         os << "base=" << t.getBase() << ", ";
-        os << "direction=" << TransformDirectionToString(t.getDirection()) << ", ";
-        os << ">\n";
+        os << "direction=" << TransformDirectionToString(t.getDirection());
+        os << ">";
         
         return os;
     }

--- a/src/core/Look.cpp
+++ b/src/core/Look.cpp
@@ -139,20 +139,20 @@ OCIO_NAMESPACE_ENTER
     
     std::ostream& operator<< (std::ostream& os, const Look& look)
     {
-        os << "<Look ";
-        os << "name=" << look.getName() << ", ";
-        os << "processSpace=" << look.getProcessSpace() << ", ";
+        os << "<Look";
+        os << " name=" << look.getName();
+        os << ", processSpace=" << look.getProcessSpace();
         
         if(look.getTransform())
         {
-            os << "\tTransform: ";
-            os << *look.getTransform();
+            os << ",\n    transform=";
+            os << "\n\t" << *look.getTransform();
         }
         
         if(look.getInverseTransform())
         {
-            os << "\tInverseTransform: ";
-            os << *look.getInverseTransform();
+            os << ",\n    inverseTransform=";
+            os << "\n\t" << *look.getInverseTransform();
         }
         
         os << ">";

--- a/src/core/LookTransform.cpp
+++ b/src/core/LookTransform.cpp
@@ -146,12 +146,12 @@ OCIO_NAMESPACE_ENTER
     
     std::ostream& operator<< (std::ostream& os, const LookTransform& t)
     {
-        os << "<LookTransform ";
-        os << "src=" << t.getSrc() << ", ";
-        os << "dst=" << t.getDst() << ", ";
-        os << "looks=" << t.getLooks() << ", ";
-        os << "direction=" << TransformDirectionToString(t.getDirection()) << ", ";
-        os << ">\n";
+        os << "<LookTransform";
+        os << " src=" << t.getSrc();
+        os << ", dst=" << t.getDst();
+        os << ", looks=" << t.getLooks();
+        os << ", direction=" << TransformDirectionToString(t.getDirection());
+        os << ">";
         return os;
     }
     

--- a/src/core/MatrixTransform.cpp
+++ b/src/core/MatrixTransform.cpp
@@ -356,11 +356,30 @@ OCIO_NAMESPACE_ENTER
     
     std::ostream& operator<< (std::ostream& os, const MatrixTransform& t)
     {
+        float matrix[16], offset[4];
+
+        t.getMatrix(matrix);
+        t.getOffset(offset);
+
         os << "<MatrixTransform ";
         os << "direction=" << TransformDirectionToString(t.getDirection()) << ", ";
+        os << "matrix=" << matrix[0];
+        for (int i = 1; i < 16; ++i)
+        {
+            os << " " << matrix[i];
+        }
+        os << ", offset=" << offset[0];
+        for (int i = 1; i < 4; ++i)
+        {
+            os << " " << offset[i];
+        }
         os << ">\n";
         return os;
     }
+        TransformDirection dir_;
+        float matrix_[16];
+        float offset_[4];
+        
     
     
     ///////////////////////////////////////////////////////////////////////////

--- a/src/core/MatrixTransform.cpp
+++ b/src/core/MatrixTransform.cpp
@@ -373,7 +373,7 @@ OCIO_NAMESPACE_ENTER
         {
             os << " " << offset[i];
         }
-        os << ">\n";
+        os << ">";
         return os;
     }
         TransformDirection dir_;

--- a/src/core/Transform.cpp
+++ b/src/core/Transform.cpp
@@ -152,6 +152,16 @@ OCIO_NAMESPACE_ENTER
         {
             os << *groupTransform;
         }
+        else if(const LogTransform * logTransform = \
+            dynamic_cast<const LogTransform*>(t))
+        {
+            os << *logTransform;
+        }
+        else if(const LookTransform * lookTransform = \
+            dynamic_cast<const LookTransform*>(t))
+        {
+            os << *lookTransform;
+        }
         else if(const MatrixTransform * matrixTransform = \
             dynamic_cast<const MatrixTransform*>(t))
         {

--- a/src/core/TruelightTransform.cpp
+++ b/src/core/TruelightTransform.cpp
@@ -235,6 +235,16 @@ OCIO_NAMESPACE_ENTER
     {
         os << "<TruelightTransform ";
         os << "direction=" << TransformDirectionToString(t.getDirection()) << ", ";
+        os << "configroot=" << t.getConfigRoot() << ", ";
+        os << "profile=" << t.getProfile() << ", ";
+        os << "camera=" << t.getCamera() << ", ";
+        os << "inputdisplay=" << t.getInputDisplay() << ", ";
+        os << "recorder=" << t.getRecorder() << ", ";
+        os << "print=" << t.getPrint() << ", ";
+        os << "lamp=" << t.getLamp() << ", ";
+        os << "outputcamera=" << t.getOutputCamera() << ", ";
+        os << "display=" << t.getDisplay() << ", ";
+        os << "cubeinput=" << t.getCubeInput();
         os << ">\n";
         return os;
     }

--- a/src/core/TruelightTransform.cpp
+++ b/src/core/TruelightTransform.cpp
@@ -245,7 +245,7 @@ OCIO_NAMESPACE_ENTER
         os << "outputcamera=" << t.getOutputCamera() << ", ";
         os << "display=" << t.getDisplay() << ", ";
         os << "cubeinput=" << t.getCubeInput();
-        os << ">\n";
+        os << ">";
         return os;
     }
     

--- a/src/pyglue/PyColorSpace.cpp
+++ b/src/pyglue/PyColorSpace.cpp
@@ -28,6 +28,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <Python.h>
 #include <OpenColorIO/OpenColorIO.h>
+#include <sstream>
 
 #include "PyUtil.h"
 #include "PyDoc.h"
@@ -77,6 +78,7 @@ OCIO_NAMESPACE_ENTER
         
         int PyOCIO_ColorSpace_init(PyOCIO_ColorSpace * self, PyObject * args, PyObject * kwds);
         void PyOCIO_ColorSpace_delete(PyOCIO_ColorSpace * self, PyObject * args);
+        PyObject * PyOCIO_ColorSpace_str(PyObject * self);
         PyObject * PyOCIO_ColorSpace_isEditable(PyObject * self);
         PyObject * PyOCIO_ColorSpace_createEditableCopy(PyObject * self);
         PyObject * PyOCIO_ColorSpace_getName(PyObject * self);
@@ -165,7 +167,7 @@ OCIO_NAMESPACE_ENTER
         0,                                          //tp_as_mapping
         0,                                          //tp_hash 
         0,                                          //tp_call
-        0,                                          //tp_str
+        PyOCIO_ColorSpace_str,                      //tp_str
         0,                                          //tp_getattro
         0,                                          //tp_setattro
         0,                                          //tp_as_buffer
@@ -267,6 +269,16 @@ OCIO_NAMESPACE_ENTER
             DeletePyObject<PyOCIO_ColorSpace>(self);
         }
         
+        PyObject * PyOCIO_ColorSpace_str(PyObject * self)
+        {
+            OCIO_PYTRY_ENTER()
+            ConstColorSpaceRcPtr colorSpace = GetConstColorSpace(self, true);
+            std::ostringstream out;
+            out << *colorSpace;
+            return PyString_FromString(out.str().c_str());
+            OCIO_PYTRY_EXIT(NULL)
+        }
+
         PyObject * PyOCIO_ColorSpace_isEditable(PyObject * self)
         {
             return PyBool_FromLong(IsPyColorSpaceEditable(self));

--- a/src/pyglue/PyConfig.cpp
+++ b/src/pyglue/PyConfig.cpp
@@ -81,6 +81,7 @@ OCIO_NAMESPACE_ENTER
         PyObject * PyOCIO_Config_CreateFromStream(PyObject * cls, PyObject * args);
         int PyOCIO_Config_init(PyOCIO_Config * self, PyObject * args, PyObject * kwds);
         void PyOCIO_Config_delete(PyOCIO_Config * self, PyObject * args);
+        PyObject * PyOCIO_Config_repr(PyObject * self);
         PyObject * PyOCIO_Config_isEditable(PyObject * self);
         PyObject * PyOCIO_Config_createEditableCopy(PyObject * self);
         PyObject * PyOCIO_Config_sanityCheck(PyObject * self);
@@ -283,7 +284,7 @@ OCIO_NAMESPACE_ENTER
         0,                                          //tp_getattr
         0,                                          //tp_setattr
         0,                                          //tp_compare
-        0,                                          //tp_repr
+        PyOCIO_Config_repr,                         //tp_repr
         0,                                          //tp_as_number
         0,                                          //tp_as_sequence
         0,                                          //tp_as_mapping
@@ -361,6 +362,16 @@ OCIO_NAMESPACE_ENTER
             DeletePyObject<PyOCIO_Config>(self);
         }
         
+        PyObject * PyOCIO_Config_repr(PyObject * self)
+        {
+            OCIO_PYTRY_ENTER()
+            ConstConfigRcPtr config = GetConstConfig(self, true);
+            std::ostringstream out;
+            out << *config;
+            return PyString_FromString(out.str().c_str());
+            OCIO_PYTRY_EXIT(NULL)
+        }
+
         PyObject * PyOCIO_Config_isEditable(PyObject * self)
         {
             return PyBool_FromLong(IsPyConfigEditable(self));

--- a/src/pyglue/PyContext.cpp
+++ b/src/pyglue/PyContext.cpp
@@ -28,6 +28,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <Python.h>
 #include <OpenColorIO/OpenColorIO.h>
+#include <sstream>
 
 #include "PyUtil.h"
 #include "PyDoc.h"
@@ -77,6 +78,7 @@ OCIO_NAMESPACE_ENTER
         
         int PyOCIO_Context_init(PyOCIO_Context * self, PyObject * args, PyObject * kwds);
         void PyOCIO_Context_delete(PyOCIO_Context * self, PyObject * args);
+        PyObject * PyOCIO_Context_str(PyObject * self);
         PyObject * PyOCIO_Context_isEditable(PyObject * self);
         PyObject * PyOCIO_Context_createEditableCopy(PyObject * self);
         PyObject * PyOCIO_Context_getCacheID(PyObject * self);
@@ -157,7 +159,7 @@ OCIO_NAMESPACE_ENTER
         0,                                          //tp_as_mapping
         0,                                          //tp_hash 
         0,                                          //tp_call
-        0,                                          //tp_str
+        PyOCIO_Context_str,                         //tp_str
         0,                                          //tp_getattro
         0,                                          //tp_setattro
         0,                                          //tp_as_buffer
@@ -202,6 +204,16 @@ OCIO_NAMESPACE_ENTER
             DeletePyObject<PyOCIO_Context>(self);
         }
         
+        PyObject * PyOCIO_Context_str(PyObject * self)
+        {
+            OCIO_PYTRY_ENTER()
+            ConstContextRcPtr context = GetConstContext(self, true);
+            std::ostringstream out;
+            out << *context;
+            return PyString_FromString(out.str().c_str());
+            OCIO_PYTRY_EXIT(NULL)
+        }
+
         PyObject * PyOCIO_Context_isEditable(PyObject * self)
         {
             return PyBool_FromLong(IsPyContextEditable(self));

--- a/src/pyglue/PyLook.cpp
+++ b/src/pyglue/PyLook.cpp
@@ -28,6 +28,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <Python.h>
 #include <OpenColorIO/OpenColorIO.h>
+#include <sstream>
 
 #include "PyUtil.h"
 #include "PyDoc.h"
@@ -77,6 +78,7 @@ OCIO_NAMESPACE_ENTER
         
         int PyOCIO_Look_init(PyOCIO_Look * self, PyObject * args, PyObject * kwds);
         void PyOCIO_Look_delete(PyOCIO_Look * self, PyObject * args);
+        PyObject * PyOCIO_Look_str(PyObject * self);
         PyObject * PyOCIO_Look_isEditable(PyObject * self);
         PyObject * PyOCIO_Look_createEditableCopy(PyObject * self);
         PyObject * PyOCIO_Look_getName(PyObject * self);
@@ -136,7 +138,7 @@ OCIO_NAMESPACE_ENTER
         0,                                          //tp_as_mapping
         0,                                          //tp_hash 
         0,                                          //tp_call
-        0,                                          //tp_str
+        PyOCIO_Look_str,                            //tp_str
         0,                                          //tp_getattro
         0,                                          //tp_setattro
         0,                                          //tp_as_buffer
@@ -197,6 +199,16 @@ OCIO_NAMESPACE_ENTER
             DeletePyObject<PyOCIO_Look>(self);
         }
         
+        PyObject * PyOCIO_Look_str(PyObject * self)
+        {
+            OCIO_PYTRY_ENTER()
+            ConstLookRcPtr look = GetConstLook(self, true);
+            std::ostringstream out;
+            out << *look;
+            return PyString_FromString(out.str().c_str());
+            OCIO_PYTRY_EXIT(NULL)
+        }
+
         PyObject * PyOCIO_Look_isEditable(PyObject * self)
         {
             return PyBool_FromLong(IsPyLookEditable(self));

--- a/src/pyglue/PyTransform.cpp
+++ b/src/pyglue/PyTransform.cpp
@@ -184,6 +184,7 @@ OCIO_NAMESPACE_ENTER
         
         int PyOCIO_Transform_init(PyOCIO_Transform * self, PyObject * args, PyObject * kwds);
         void PyOCIO_Transform_delete(PyOCIO_Transform * self, PyObject * args);
+        PyObject * PyOCIO_Transform_str(PyObject * self);
         PyObject * PyOCIO_Transform_isEditable(PyObject * self);
         PyObject * PyOCIO_Transform_createEditableCopy(PyObject * self);
         PyObject * PyOCIO_Transform_getDirection(PyObject * self);
@@ -225,7 +226,7 @@ OCIO_NAMESPACE_ENTER
         0,                                          //tp_as_mapping
         0,                                          //tp_hash 
         0,                                          //tp_call
-        0,                                          //tp_str
+        PyOCIO_Transform_str,                       //tp_str
         0,                                          //tp_getattro
         0,                                          //tp_setattro
         0,                                          //tp_as_buffer
@@ -273,6 +274,16 @@ OCIO_NAMESPACE_ENTER
             DeletePyObject<PyOCIO_Transform>(self);
         }
         
+        PyObject * PyOCIO_Transform_str(PyObject * self)
+        {
+            OCIO_PYTRY_ENTER()
+            ConstTransformRcPtr transform = GetConstTransform(self, true);
+            std::ostringstream out;
+            out << *transform;
+            return PyString_FromString(out.str().c_str());
+            OCIO_PYTRY_EXIT(NULL)
+        }
+
         PyObject * PyOCIO_Transform_isEditable(PyObject * self)
         {
             return PyBool_FromLong(IsPyTransformEditable(self));


### PR DESCRIPTION
The ostream operator<< is mainly used for debugging purposes.  Not all Transforms were outputting the complete state which made it hard to use for debugging.  For Python, __str__ methods were added to all objects that supported the ostream inserter.