### PR TITLE
external include dirs should always be last

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -4,8 +4,8 @@
 include_directories(
     ${CMAKE_SOURCE_DIR}/export/
     ${CMAKE_BINARY_DIR}/export/
-    ${EXTERNAL_INCLUDE_DIRS}
     ${CMAKE_SOURCE_DIR}/ext/oiio/src/include
+    ${EXTERNAL_INCLUDE_DIRS}
 )
 
 file(GLOB_RECURSE core_src_files "${CMAKE_SOURCE_DIR}/src/core/*.cpp")

--- a/src/core_tests/CMakeLists.txt
+++ b/src/core_tests/CMakeLists.txt
@@ -7,8 +7,8 @@ add_definitions("-DOCIO_SOURCE_DIR=${CMAKE_SOURCE_DIR}")
 include_directories(
     ${CMAKE_SOURCE_DIR}/export/
     ${CMAKE_BINARY_DIR}/export/
-    ${EXTERNAL_INCLUDE_DIRS}
     ${CMAKE_SOURCE_DIR}/ext/oiio/src/include
+    ${EXTERNAL_INCLUDE_DIRS}
     )
 
 file( GLOB_RECURSE core_test_src_files "${CMAKE_SOURCE_DIR}/src/core/*.cpp" )

--- a/src/jniglue/CMakeLists.txt
+++ b/src/jniglue/CMakeLists.txt
@@ -1,9 +1,9 @@
 
 include_directories(
-  ${JNI_INCLUDE_DIRS}
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_SOURCE_DIR}/export/
   ${CMAKE_BINARY_DIR}/export/
+  ${JNI_INCLUDE_DIRS}
 )
 
 set(JNIOCIO_CLASSES

--- a/src/pyglue/CMakeLists.txt
+++ b/src/pyglue/CMakeLists.txt
@@ -31,18 +31,18 @@ add_library(PyOpenColorIO MODULE ${pyglue_src_files} ${CMAKE_BINARY_DIR}/src/pyg
 
 if(OCIO_USE_BOOST_PTR)
     include_directories(
-        ${PYTHON_INCLUDE}
-        ${Boost_INCLUDE_DIR}
         ${CMAKE_SOURCE_DIR}/export/
         ${CMAKE_BINARY_DIR}/export/
         ${CMAKE_CURRENT_BINARY_DIR}
+        ${PYTHON_INCLUDE}
+        ${Boost_INCLUDE_DIR}
     )
 else()
     include_directories(
-        ${PYTHON_INCLUDE}
         ${CMAKE_SOURCE_DIR}/export/
         ${CMAKE_BINARY_DIR}/export/
         ${CMAKE_CURRENT_BINARY_DIR}
+        ${PYTHON_INCLUDE}
     )
 endif()
 


### PR DESCRIPTION
- compiles even if an older version of OCIO is installed