### PR TITLE
Windows QOL Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,27 @@ endif()
 messageonce("Setting EXTDIST_BINPATH: ${EXTDIST_BINPATH}")
 messageonce("Setting EXTDIST_PYTHONPATH: ${EXTDIST_PYTHONPATH}")
 
+# Ensure GNU Patch is available on the local system if building 
+# TinyXML or YAMLCPP via the ExternalProject_Add() command
+if((NOT USE_EXTERNAL_TINYXML) OR (NOT USE_EXTERNAL_YAML))
+    find_program(
+        PATCH_EXECUTABLE
+        patch
+        PATHS
+            "C:/Program Files/GnuWin32/bin"
+            "C:/Program Files (x86)/GnuWin32/bin"
+            "/usr/local/bin"
+            "/usr/bin"
+            "/bin"
+        
+        DOC "Path to the Patch executable"    
+    )
+
+    if(${PATCH_EXECUTABLE} STREQUAL "PATCH_EXECUTABLE-NOTFOUND")
+        message(FATAL_ERROR "Cannot find GNU Patch utility.  Aborting")
+    endif()        
+endif()
+
 ###############################################################################
 ### tinyxml ###
 
@@ -183,7 +204,7 @@ else(USE_EXTERNAL_TINYXML)
     endif()
     ExternalProject_Add(tinyxml
         URL ${CMAKE_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.tar.gz
-        PATCH_COMMAND patch -f -p1 < ${CMAKE_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.patch
+        PATCH_COMMAND ${PATCH_EXECUTABLE} -f -p1 < ${CMAKE_SOURCE_DIR}/ext/tinyxml_${TINYXML_VERSION}.patch
         BINARY_DIR ext/build/tinyxml
         INSTALL_DIR ext/dist
         CMAKE_ARGS ${TINYXML_CMAKE_ARGS}
@@ -252,7 +273,7 @@ else(USE_EXTERNAL_YAML)
     ExternalProject_Add(YAML_CPP_LOCAL
         URL ${CMAKE_SOURCE_DIR}/ext/yaml-cpp-${YAML_CPP_VERSION}.tar.gz
         BINARY_DIR ext/build/yaml-cpp
-        PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/ext/yaml-cpp-${YAML_CPP_VERSION}.patch
+        PATCH_COMMAND ${PATCH_EXECUTABLE} -p1 < ${CMAKE_SOURCE_DIR}/ext/yaml-cpp-${YAML_CPP_VERSION}.patch
         INSTALL_DIR ext/dist
         CMAKE_ARGS ${YAML_CPP_CMAKE_ARGS}
     )

--- a/export/OpenColorIO/OpenColorABI.h.in
+++ b/export/OpenColorIO/OpenColorABI.h.in
@@ -79,10 +79,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     #endif
 #elif defined(_WIN32) || defined(_WIN64) || defined(_WINDOWS) || defined(_MSC_VER)
     // Windows requires you to export from the main library and then import in any others
-    #if defined OpenColorIO_EXPORTS
-        #define OCIOEXPORT __declspec(dllexport)
+    #if defined OCIO_STATIC
+        #define OCIOEXPORT 
     #else
-        #define OCIOEXPORT __declspec(dllimport)
+        #if defined OpenColorIO_EXPORTS
+            #define OCIOEXPORT __declspec(dllexport)
+        #else
+            #define OCIOEXPORT __declspec(dllimport)
+        #endif
     #endif
     #define OCIOHIDDEN
 #else // Others platforms not supported atm

--- a/ext/oiio/src/include/unittest.h
+++ b/ext/oiio/src/include/unittest.h
@@ -34,6 +34,7 @@
 #include <iostream>
 #include <cmath>
 #include <vector>
+#include <string>
 
 extern int unit_test_failures;
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -60,7 +60,15 @@ if(OCIO_BUILD_STATIC)
     list(REMOVE_ITEM core_src_files ${CMAKE_SOURCE_DIR}/src/core/UnitTest.cpp)
     add_library(OpenColorIO_STATIC STATIC ${core_src_files})
     add_dependencies(OpenColorIO_STATIC tinyxml YAML_CPP_LOCAL)
+
     if(WIN32)
+        get_target_property(OCIO_STATIC_DEFS OpenColorIO_STATIC COMPILE_DEFINITIONS)
+        list(APPEND OCIO_STATIC_DEFS OCIO_STATIC=1)
+        set_target_properties(
+            OpenColorIO_STATIC
+            PROPERTIES
+            COMPILE_DEFINITIONS ${OCIO_STATIC_DEFS}
+            )
         target_link_libraries(OpenColorIO_STATIC
             debug ${EXTERNAL_DEBUG_LIBRARIES}
             optimized ${EXTERNAL_OPTIMIZED_LIBRARIES}

--- a/src/core/Lut3DOp.cpp
+++ b/src/core/Lut3DOp.cpp
@@ -750,7 +750,10 @@ OCIO_NAMESPACE_EXIT
 
 #include <cstring>
 #include <cstdlib>
+
+#ifndef _WIN32
 #include <sys/time.h>
+#endif
 
 namespace OCIO = OCIO_NAMESPACE;
 #include "UnitTest.h"
@@ -908,6 +911,7 @@ OIIO_ADD_TEST(Lut3DOp, InverseComparisonCheck)
 OIIO_ADD_TEST(Lut3DOp, PerformanceCheck)
 {
     /*
+#ifndef _WIN32
     OCIO::Lut3D lut;
     
     lut.from_min[0] = 0.0f;
@@ -977,6 +981,7 @@ OIIO_ADD_TEST(Lut3DOp, PerformanceCheck)
 
     double speed_diff = totaltime_a/totaltime_b;
     printf("Tetra is %.04f speed of Linear\n", speed_diff);
+#endif
     */
 }
 #endif // OCIO_UNIT_TEST

--- a/src/core_tests/CMakeLists.txt
+++ b/src/core_tests/CMakeLists.txt
@@ -31,6 +31,13 @@ set_target_properties(ocio_core_tests PROPERTIES
     COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS}"
     LINK_FLAGS "${EXTERNAL_LINK_FLAGS}")
 if(WIN32)
+    get_target_property(OCIO_STATIC_DEFS ocio_core_tests COMPILE_DEFINITIONS)
+    list(APPEND OCIO_STATIC_DEFS OCIO_STATIC=1)
+    set_target_properties(
+        ocio_core_tests
+        PROPERTIES
+        COMPILE_DEFINITIONS ${OCIO_STATIC_DEFS}
+    )
     target_link_libraries(ocio_core_tests
             debug ${EXTERNAL_DEBUG_LIBRARIES}
             optimized ${EXTERNAL_OPTIMIZED_LIBRARIES}
@@ -44,13 +51,27 @@ endif()
 
 set(OCIO_TEST_AREA ${CMAKE_CURRENT_BINARY_DIR})
 
-message(STATUS "Create ocio_core_tests.sh.in from ocio_core_tests.sh")
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ocio_core_tests.sh.in
-    ${CMAKE_CURRENT_BINARY_DIR}/ocio_core_tests.sh @ONLY)
 
-add_custom_target(MainTests
-                  COMMAND /bin/sh ${CMAKE_CURRENT_BINARY_DIR}/ocio_core_tests.sh
-                  DEPENDS ocio_core_tests
-                  COMMENT "Setting Up and Running OCIO UNIT tests")
+
+if(WIN32)
+    message(STATUS "Create ocio_core_tests.bat.in from ocio_core_tests.bat")
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ocio_core_tests.bat.in
+        ${CMAKE_CURRENT_BINARY_DIR}/ocio_core_tests.bat @ONLY)
+
+    add_custom_target(MainTests
+                      COMMAND "${CMAKE_CURRENT_BINARY_DIR}/ocio_core_tests.bat"
+                      WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}"
+                      DEPENDS ocio_core_tests
+                      COMMENT "Setting Up and Running OCIO UNIT tests")
+else()
+    message(STATUS "Create ocio_core_tests.sh.in from ocio_core_tests.sh")
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ocio_core_tests.sh.in
+        ${CMAKE_CURRENT_BINARY_DIR}/ocio_core_tests.sh @ONLY)
+
+    add_custom_target(MainTests
+                      COMMAND /bin/sh ${CMAKE_CURRENT_BINARY_DIR}/ocio_core_tests.sh
+                      DEPENDS ocio_core_tests
+                      COMMENT "Setting Up and Running OCIO UNIT tests")
+endif()
 
 add_test(ocio_core_tests "${CMAKE_COMMAND}" --build ${CMAKE_BINARY_DIR} --target MainTests)

--- a/src/core_tests/ocio_core_tests.bat.in
+++ b/src/core_tests/ocio_core_tests.bat.in
@@ -1,0 +1,8 @@
+@ECHO ON
+
+set OCIO_DATA_ROOT=@OCIO_TEST_AREA@/test_search
+set OCIO_TEST1=foobar
+set OCIO_JOB=meatballs
+set OCIO_SEQ=cheesecake
+set OCIO_SHOT=mb-cc-001
+ocio_core_tests.exe --log_level=test_suite


### PR DESCRIPTION
I've added a few commits to help life when working under Windows.
- Attempt to locate the GNU Patch utility in the default GnuWin32 install location
- Static library builds no longer `#define OCIOEXPORT __declspec(dllimport)` in OpenColorABI.h
- Unit Tests now run under Visual Studio (tested in VS 2010)
