### PR TITLE
Adding an interface for defining custom transform without changes to the core

### DIFF
--- a/export/OpenColorIO/OpenColorTransforms.h
+++ b/export/OpenColorIO/OpenColorTransforms.h
@@ -274,6 +274,38 @@ OCIO_NAMESPACE_ENTER
     
     
     //!rst:: //////////////////////////////////////////////////////////////////
+
+    class Op;
+    typedef OCIO_SHARED_PTR<Op> OpRcPtr;
+    typedef std::vector<OpRcPtr> OpRcPtrVec;
+    
+    //!cpp:class::
+    class OCIOEXPORT CustomTransform : public Transform
+    {
+    public:
+	virtual ~CustomTransform();
+
+        //!cpp:function::
+        virtual TransformRcPtr createEditableCopy() const = 0;
+        
+        //!cpp:function::
+        virtual TransformDirection getDirection() const = 0;
+        //!cpp:function::
+        virtual void setDirection(TransformDirection dir) = 0;
+
+	virtual std::ostream& operator<< (std::ostream&) const = 0;
+
+	virtual void buildOps(OpRcPtrVec & ops,
+                              const Config& config,
+                              const ConstContextRcPtr &,
+                              TransformDirection dir) const = 0;
+    };
+    
+    //!cpp:function::
+    extern OCIOEXPORT std::ostream& operator<< (std::ostream&, const CustomTransform&);
+    
+    
+    //!rst:: //////////////////////////////////////////////////////////////////
     
     //!cpp:class::
     class OCIOEXPORT DisplayTransform : public Transform

--- a/src/core/CustomTransform.cpp
+++ b/src/core/CustomTransform.cpp
@@ -26,38 +26,35 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-
-#ifndef INCLUDED_OCIO_OP_H
-#define INCLUDED_OCIO_OP_H
+#include <cstring>
 
 #include <OpenColorIO/OpenColorIO.h>
 
-#include <sstream>
-#include <vector>
+#include "ExponentOps.h"
+#include "OpBuilders.h"
+
 
 OCIO_NAMESPACE_ENTER
 {
-    struct AllocationData
+    CustomTransform::~CustomTransform()
+    { }
+
+    std::ostream& operator<< (std::ostream& os, const CustomTransform& t)
     {
-        Allocation allocation;
-        std::vector<float> vars;
-        
-        AllocationData():
-            allocation(ALLOCATION_UNIFORM)
-            {};
-        
-        std::string getCacheID() const;
-    };
+        os << t;
+        return os;
+    }
     
-    std::ostream& operator<< (std::ostream&, const AllocationData&);
     
-    std::string SerializeOpVec(const OpRcPtrVec & ops, int indent=0);
-    bool IsOpVecNoOp(const OpRcPtrVec & ops);
+    ///////////////////////////////////////////////////////////////////////////////////////////////////////
     
-    void FinalizeOpVec(OpRcPtrVec & opVec, bool optimize=true);
-    
-    void OptimizeOpVec(OpRcPtrVec & result);
+    void BuildCustomOps(OpRcPtrVec & ops,
+                        const Config& config,
+                        const ConstContextRcPtr & context,
+                        const CustomTransform & transform,
+                        TransformDirection dir)
+    {
+        transform.buildOps(ops, config, context, dir);
+    }
 }
 OCIO_NAMESPACE_EXIT
-
-#endif

--- a/src/core/OpBuilders.h
+++ b/src/core/OpBuilders.h
@@ -69,6 +69,12 @@ OCIO_NAMESPACE_ENTER
                             const ConstColorSpaceRcPtr & srcColorSpace,
                             const ConstColorSpaceRcPtr & dstColorSpace);
     
+    void BuildCustomOps(OpRcPtrVec & ops,
+                        const Config& config,
+                        const ConstContextRcPtr & context,
+                        const CustomTransform & transform,
+                        TransformDirection dir);
+    
     void BuildDisplayOps(OpRcPtrVec & ops,
                          const Config & config,
                          const ConstContextRcPtr & context,

--- a/src/core/Transform.cpp
+++ b/src/core/Transform.cpp
@@ -65,6 +65,11 @@ OCIO_NAMESPACE_ENTER
         {
             BuildColorSpaceOps(ops, config, context, *colorSpaceTransform, dir);
         }
+        else if(ConstCustomTransformRcPtr customTransform = \
+            DynamicPtrCast<const CustomTransform>(transform))
+        {
+            BuildCustomOps(ops, config, context, *customTransform, dir);
+        }
         else if(ConstDisplayTransformRcPtr displayTransform = \
             DynamicPtrCast<const DisplayTransform>(transform))
         {
@@ -131,6 +136,11 @@ OCIO_NAMESPACE_ENTER
             dynamic_cast<const ColorSpaceTransform*>(t))
         {
             os << *colorSpaceTransform;
+        }
+        else if(const CustomTransform * customTransform = \
+            dynamic_cast<const CustomTransform*>(t))
+        {
+            os << *customTransform;
         }
         else if(const DisplayTransform * displayTransform = \
             dynamic_cast<const DisplayTransform*>(t))


### PR DESCRIPTION
This patch allows developers to use self-defined transforms inside their OpenColorIO pipeline without maintaining a modified version of the library by adding the CustomTransform, a class that can be inherited to implement arbitrary transforms and Ops.
