### PR TITLE
typo

### DIFF
--- a/docs/userguide/config_syntax.rst
+++ b/docs/userguide/config_syntax.rst
@@ -5,7 +5,7 @@ Config syntax
 
 OpenColorIO is primarily controlled by a central configuration file,
 usually named ``config.ocio``. This page will only describe how to
-*syntactically* write this OCIO config - e.g what transforms are
+*syntactically* write this OCIO config - e.g. what transforms are
 available, or what sections are optional.
 
 This page alone will not help you to write a useful config file! See
@@ -62,7 +62,7 @@ always ``1`` (one)
 Optional. Default is an empty search path.
 
 ``search_path`` is a colon-seperated list of directories. Each
-directory is checked in order to locate a file (e.g a LUT).
+directory is checked in order to locate a file (e.g. a LUT).
 
 This works is very similar to how the UNIX ``$PATH`` env-var works for
 executables.
@@ -85,7 +85,7 @@ to the LUT ``lg10_to_lnf.spi1d``. It will look in the ``luts``
 directory, relative to the ``config.ocio`` file's location.
 
 Paths can be relative (to the directory containing ``config.ocio``),
-or absolute (e.g ``/mnt/path/to/my/luts``)
+or absolute (e.g. ``/mnt/path/to/my/luts``)
 
 Multiple paths can be specified, including a mix of relative and
 absolute paths. Each path is separated with a colon ``:``
@@ -130,7 +130,7 @@ If the colorspace cannot be determined and ``strictparsing: false``,
 the default role will be used. This allows unhandled images to operate
 in "non-color managed" mode.
 
-Application authors should note: when no config is present (e.g via
+Application authors should note: when no config is present (e.g. via
 ``$OCIO``), the default internal profile specifies
 ``strictparsing=false``, and the default color space role is
 ``raw``. This means that ANY string passed to OCIO will be parsed as
@@ -149,7 +149,7 @@ Deprecated. Optional. Default is the Rec.709 primaries specified by the ASC:
     luma: [0.2126, 0.7152, 0.0722]
 
 These are the luminance coeficients, which can be used by
-OCIO-supporting applications when adjusting saturation (e.g in an
+OCIO-supporting applications when adjusting saturation (e.g. in an
 image-viewer when displaying a single channel)
 
 .. note::
@@ -208,10 +208,10 @@ use these differently.
 
 * ``color_picking`` - colors in a color-selection UI can be displayed
   in this space, while selecting colors in a different working space
-  (e.g ``scene_linear`` or ``texture_paint``)
+  (e.g. ``scene_linear`` or ``texture_paint``)
 
 * ``color_timing`` - colorspace used for applying color corrections,
-  e.g user-specified grade within an image viewer (if the application
+  e.g. user-specified grade within an image viewer (if the application
   uses the ``DisplayTransform::setDisplayCC`` API method)
 
 * ``compositing_log`` - a log colorspace used for certain processing
@@ -355,7 +355,7 @@ final grade.
 When the look is defined in the config, you must specify a name, the
 color transform, and the colorspace in which the grade is performed
 (the "process space"). You can optionally specify an inverse transform
-for when the look transform is not trivially invertable (e.g it
+for when the look transform is not trivially invertable (e.g. it
 applies a 3D LUT)
 
 When an application applies a look, OCIO ensures the grade is applied
@@ -583,7 +583,7 @@ colorspace works.
 
 
 To explain how this all ties together to display an image, say we have
-an image in the ``lnf`` colorspace (e.g a linear EXR) and wish to
+an image in the ``lnf`` colorspace (e.g. a linear EXR) and wish to
 convert it to ``srgb8`` - the transform steps are:
 
 * ``ColorSpaceTransform`` is applied, converting from lnf to lg16
@@ -685,7 +685,7 @@ at different bit-depths.
 For example, see the ``lg10`` and ``lg16`` colorspaces in the
 :ref:`config-spivfx` config. If loading a ``lg10`` image and
 converting to ``lg16``, no transform is required. This is of course
-faster, but may cause an unexpected increase in precision (e.g it skip
+faster, but may cause an unexpected increase in precision (e.g. it skip
 potential clamping caused by a LUT)
 
 .. code-block:: yaml


### PR DESCRIPTION
replace `e.g` with `e.g.`