### PR TITLE
Update Travis-CI build file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 # travis-ci.org build file
+# https://docs.travis-ci.com/user/languages/cpp
 
-# As CMake is not officially supported we use erlang VMs
-language: erlang
+language: cpp
 
-# Settings to try
+compiler:
+  - clang
+  - gcc
+
+os:
+  - linux
+  - osx
+
 env:
   - OPTIONS="-DCMAKE_BUILD_TYPE=Release -DOCIO_BUILD_TESTS=yes"
-
-# Make sure CMake is installed
-install:
- - sudo apt-get install cmake
 
 # Run the Build script
 script:


### PR DESCRIPTION
The old config was set up before Travis-CI properly supported C++ projects

New one also tests against clang and GCC on both OS X and Linux

To get working requires signing in to the "imageworks" TravisCI account (it authenticates with Github) and enabling the OpenColorIO project
