### PR TITLE
Fix black pixels returned by Lut1D_Linear in certain cases

### DIFF
--- a/src/core/Lut1DOp.cpp
+++ b/src/core/Lut1DOp.cpp
@@ -296,6 +296,11 @@ OCIO_NAMESPACE_ENTER
         {
             int indexLow = clamp(std::floor(index), 0.0f, maxIndex);
             int indexHigh = clamp(std::ceil(index), 0.0f, maxIndex);
+            if (indexLow == indexHigh) {
+                // Happens when index outside of the LUT range is requested. We do early
+                // output here to avoid possible precision issues during interpolation.
+                return simple_lut[indexLow];
+            }
             float delta = index - (float)indexLow;
             return (1.0f-delta) * simple_lut[indexLow] + delta * simple_lut[indexHigh];
         }


### PR DESCRIPTION
It was possible to have linear lookup returning black pixel for values
which are far beyond lookup table range. This was caused by precision
issues with floating point. Basically, if index is really high, then
it'll make delta really high and for such high values delta will be
equal to (1.0f - delta) because of the way how machine math works.
This will then produce 0 as the output value.

This patch performs early output check to avoid any possible floating
point precision issues in such cases.