### PR TITLE
docs: Minor updates

### DIFF
--- a/docs/CompatibleSoftware.rst
+++ b/docs/CompatibleSoftware.rst
@@ -239,20 +239,14 @@ display. If the transform was approved on a different monitor, then maybe you
 should choose its profile instead.
 
 
-RV (Beta)
+RV
 *********
 
 `Playback Tool - Tweak Software <http://www.tweaksoftware.com>`__
 
-`OCIO support in RV <https://github.com/imageworks/OpenColorIO/tree/master/src/rv>`__
-is currently being developed by Ben Dickson (dbr).
-
-See this `email thread <http://groups.google.com/group/ocio-dev/browse_thread/thread/955fc6271f89a28e>`__
-for additional details.
-
-This integration is currently considered a work in progress, and should not be
-relied upon for critical production work.
-
+RV has native OCIO support in version 4 onwards. For more details, see
+the OpenColorIO section of the `RV User Manual
+<http://www.tweaksoftware.com/static/documentation/rv/current/html/rv_manual.html#OpenColorIO>`__.
 
 Java (Beta)
 ***********
@@ -262,13 +256,6 @@ in the codebase.
 
 This integration is currently considered a work in progress, and should not be
 relied upon for critical production work.
-
-
-Ramen (Beta)
-************
-`Open Source Compositor <http://ramencomp.blogspot.com>`__
-
-Under development, with native OCIO color managment.
 
 
 CryEngine3 (Beta)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -49,7 +49,7 @@ The basic requirements are:
 
 - cmake >= 2.8
 - (optional) Python 2.x (for the Python bindings)
-- (optional) Nuke 6.x (for the Nuke nodes)
+- (optional) Nuke 6.x or newer (for the Nuke nodes)
 - (optional) OpenImageIO (for apps including ocioconvert)
 - (optional) Truelight SDK (for TruelightTransform)
 
@@ -229,6 +229,26 @@ Environment variables
 
    This variable needs to point to the global OCIO config file, e.g
    ``config.ocio``
+
+
+.. envvar:: OCIO_LOGGING_LEVEL
+
+    Configures OCIO's internal logging level. Valid values are
+    ``none``, ``warning``, ``info``, or ``debug`` (or their respective
+    numeric values ``0``, ``1``, ``2``, or ``3`` can be used)
+
+    Logging output is sent to STDERR output.
+
+.. envvar:: OCIO_ACTIVE_DISPLAYS
+
+   Overrides the :ref:`active_displays` configuration value.
+   Colon-separated list of displays, e.g ``sRGB:P3``
+
+.. envvar:: OCIO_ACTIVE_VIEWS
+
+   Overrides the :ref:`active_views` configuration
+   item. Colon-separated list of view names, e.g
+   ``internal:client:DI``
 
 .. envvar:: DYLD_LIBRARY_PATH
 


### PR DESCRIPTION
As per #451:

- RV support no longer in beta, Ramen no longer developed.
- List all env-vars
- Clarify newer versions of Nuke are supported