### PR TITLE
Ensure whitespaces are ignored by "git apply".

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,7 +223,7 @@ else(USE_EXTERNAL_TINYXML)
         ExternalProject_Add(tinyxml
             URL             ${TINYXML_ZIPFILE}
             SOURCE_DIR      ${TINYXML_SOURCE_DIR}/tinyxml
-            PATCH_COMMAND   ${GIT_EXECUTABLE} apply ${TINYXML_PATCHFILE}
+            PATCH_COMMAND   ${GIT_EXECUTABLE} apply --ignore-whitespace ${TINYXML_PATCHFILE}
             BINARY_DIR      ext/build/tinyxml
             INSTALL_DIR     ext/dist
             CMAKE_ARGS      ${TINYXML_CMAKE_ARGS}
@@ -336,7 +336,7 @@ else(USE_EXTERNAL_YAML) ## provide 2 way to build this dependency
         ExternalProject_Add(YAML_CPP_LOCAL
             URL             ${YAML_CPP_ZIPFILE}
             SOURCE_DIR      ${YAML_CPP_SOURCE_DIR}/yaml-cpp
-            PATCH_COMMAND   ${GIT_EXECUTABLE} apply ${YAML_CPP_PATCHFILE}
+            PATCH_COMMAND   ${GIT_EXECUTABLE} apply --ignore-whitespace ${YAML_CPP_PATCHFILE}
             BINARY_DIR      ext/build/yaml-cpp
             INSTALL_DIR     ext/dist
             CMAKE_ARGS      ${YAML_CPP_CMAKE_ARGS}


### PR DESCRIPTION
Line endings in the patch file(s) are creating issues on Windows:

```
thomas@MORGOTH MINGW64 /d/Documents/Development/ThirdParty/opencolorio/build/yaml-cpp (master)
$ git apply -v yaml-cpp-0.3.0.patch
build/yaml-cpp/yaml-cpp-0.3.0.patch:8: trailing whitespace.
set(YAML_COMPILE_FLAGS "-fPIC -fvisibility=hidden")
build/yaml-cpp/yaml-cpp-0.3.0.patch:9: trailing whitespace.
if(OCIO_INLINES_HIDDEN)
build/yaml-cpp/yaml-cpp-0.3.0.patch:10: trailing whitespace.
    set(YAML_COMPILE_FLAGS "${YAML_COMPILE_FLAGS} -fvisibility-inlines-hidden")
build/yaml-cpp/yaml-cpp-0.3.0.patch:11: trailing whitespace.
endif()
build/yaml-cpp/yaml-cpp-0.3.0.patch:12: trailing whitespace.

Checking patch build/yaml-cpp/CMakeLists.txt...
error: while searching for:
        ${contrib_private_headers}?
)?
?
set_target_properties(yaml-cpp PROPERTIES?
        VERSION "${YAML_CPP_VERSION}"?
        SOVERSION "${YAML_CPP_VERSION_MAJOR}.${YAML_CPP_VERSION_MINOR}"?
        PROJECT_LABEL "yaml-cpp ${LABEL_SUFFIX}"?
)?
?
if(IPHONE)?

error: patch failed: build/yaml-cpp/CMakeLists.txt:235
error: build/yaml-cpp/CMakeLists.txt: patch does not apply
```