### PR TITLE
Fix the documentation build under Windows & nmake (e.g. html, tex & pdf)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,6 @@ platform:
 environment:
   global:
       CMAKE_PREFIX_PATH: C:/Libraries/boost
-      CMAKE_INSTALL_PREFIX: ../_install
       BOOST_ROOT: 'C:\Libraries\boost'
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
@@ -27,8 +26,8 @@ build_script:
   - cd _build
   - cmake 
     -G "%CMAKE_PLATFORM%"
+    -DCMAKE_INSTALL_PREFIX=..\_install
     -DOCIO_USE_BOOST_PTR=ON
-    -DOCIO_BUILD_TESTS=ON
     -DCMAKE_BUILD_TYPE=%CONFIGURATION%
     ..
   - cmake --build . --target install --config %CONFIGURATION%

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ option(OCIO_BUILD_STATIC "Set to OFF to disable building the static core library
 option(OCIO_BUILD_TRUELIGHT "Set to OFF to disable truelight" ON)
 option(OCIO_BUILD_APPS "Set to OFF to disable command-line apps" ON)
 option(OCIO_BUILD_NUKE "Set to OFF to disable building nuke plugins" ON)
-option(OCIO_BUILD_DOCS "Specify whether to build documentation" OFF)
-option(OCIO_BUILD_TESTS "Specify whether to build unittests" OFF)
+option(OCIO_BUILD_DOCS "Specify whether to build documentation" UNIX)
+option(OCIO_BUILD_TESTS "Specify whether to build unittests" ON)
 option(OCIO_BUILD_PYGLUE "Specify whether to build python bindings" ON)
 option(OCIO_BUILD_JNIGLUE "Specify whether to build java bindings" OFF)
 option(OCIO_STATIC_JNIGLUE "Specify whether to statically link ocio to the java bindings" ON)
@@ -150,7 +150,15 @@ set(EXTDIST_ROOT ${CMAKE_BINARY_DIR}/ext/dist)
 set(EXTDIST_BINPATH ${EXTDIST_ROOT}/bin)
 if(PYTHON_OK)
     set(EXTDIST_PYTHONPATH ${EXTDIST_ROOT}/${PYTHON_VARIANT_PATH})
-    set(PYTHONPATH ${EXTDIST_PYTHONPATH}:$ENV{PYTHONPATH})
+    if(UNIX)
+        set(PYTHONPATH ${EXTDIST_PYTHONPATH}:$ENV{PYTHONPATH})
+    else()
+        # The line below should work but ';' is always replaced by a space
+        #   which breaks the build. Anyway in the worst scenario, no expected
+        #   modules are present in the local python so install them.
+        #set(PYTHONPATH ${EXTDIST_PYTHONPATH}\\;$ENV{PYTHONPATH})
+        set(PYTHONPATH ${EXTDIST_PYTHONPATH})
+    endif()
 endif()
 
 messageonce("Setting EXTDIST_BINPATH: ${EXTDIST_BINPATH}")

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -2,15 +2,34 @@
 ###############################################################################
 ### External Doc Apps ###
 
+if (WIN32)
+    # Workaround to mimic *nix '> PYTHONPATH=XXX CMD' 
+    #  on windows, it becomes  '> set PYTHONPATH=XXX \n call CMD'
+    #   '\n' is here because '\\&' does not work.
+    set(PYT_PRE_CMD set PYTHONPATH=${PYTHONPATH} "\n" call )
+    # Unfortunately some windows tools require to have
+    #  the paths with the '\' (not working with '//').
+    set(PYT_LIB_OUTPUT ${EXTDIST_ROOT})
+    string(REGEX REPLACE "/" "\\\\" PYT_LIB_OUTPUT ${PYT_LIB_OUTPUT})
+    set(PYT_EXTDIST_BINPATH ${EXTDIST_BINPATH})
+    string(REGEX REPLACE "/" "\\\\" PYT_EXTDIST_BINPATH ${PYT_EXTDIST_BINPATH})
+else()
+    set(PYT_PRE_CMD PYTHONPATH=${PYTHONPATH})
+    set(PYT_LIB_OUTPUT ${EXTDIST_ROOT})
+    set(PYT_EXTDIST_BINPATH ${EXTDIST_BINPATH})
+endif()
+
 # setuptools
 # https://pypi.python.org/pypi/setuptools
 set(SETUPTOOLS_VERSION 1.1.6)
+
 ExternalProject_Add(setuptools
     URL ${CMAKE_SOURCE_DIR}/ext/setuptools-${SETUPTOOLS_VERSION}.tar.gz
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ${CMAKE_COMMAND} -E make_directory ${EXTDIST_PYTHONPATH}
-    BUILD_COMMAND PYTHONPATH=${PYTHONPATH} ${PYTHON} setup.py build
-    INSTALL_COMMAND PYTHONPATH=${PYTHONPATH} ${PYTHON} setup.py install --prefix=${EXTDIST_ROOT}
+    BUILD_COMMAND ${PYT_PRE_CMD} ${PYTHON} setup.py build
+    INSTALL_COMMAND ${PYT_PRE_CMD} ${PYTHON} setup.py install --prefix=${PYT_LIB_OUTPUT}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/setuptools-prefix/src/setuptools
 )
 
 # docutils
@@ -21,8 +40,9 @@ ExternalProject_Add(docutils
     URL ${CMAKE_SOURCE_DIR}/ext/docutils-${DOCUTILS_VERSION}.tar.gz
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ${CMAKE_COMMAND} -E make_directory ${EXTDIST_PYTHONPATH}
-    BUILD_COMMAND PYTHONPATH=${PYTHONPATH} ${PYTHON} setup.py build
-    INSTALL_COMMAND PYTHONPATH=${PYTHONPATH} ${PYTHON} setup.py install --prefix=${EXTDIST_ROOT}
+    BUILD_COMMAND ${PYT_PRE_CMD} ${PYTHON} setup.py build
+    INSTALL_COMMAND ${PYT_PRE_CMD} ${PYTHON} setup.py install --prefix=${PYT_LIB_OUTPUT}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/docutils-prefix/src/docutils
 )
 
 # jinja2
@@ -33,8 +53,9 @@ ExternalProject_Add(Jinja2
     URL ${CMAKE_SOURCE_DIR}/ext/Jinja2-${JINJA2_VERSION}.tar.gz
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ${CMAKE_COMMAND} -E make_directory ${EXTDIST_PYTHONPATH}
-    BUILD_COMMAND PYTHONPATH=${PYTHONPATH} ${PYTHON} setup.py build
-    INSTALL_COMMAND PYTHONPATH=${PYTHONPATH} ${PYTHON} setup.py install --prefix=${EXTDIST_ROOT}
+    BUILD_COMMAND ${PYT_PRE_CMD} ${PYTHON} setup.py build
+    INSTALL_COMMAND ${PYT_PRE_CMD} ${PYTHON} setup.py install --prefix=${PYT_LIB_OUTPUT}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Jinja2-prefix/src/Jinja2
 )
 
 # Pygments
@@ -45,8 +66,9 @@ ExternalProject_Add(Pygments
     URL ${CMAKE_SOURCE_DIR}/ext/Pygments-${PYGMENTS_VERSION}.tar.gz
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ${CMAKE_COMMAND} -E make_directory ${EXTDIST_PYTHONPATH}
-    BUILD_COMMAND PYTHONPATH=${PYTHONPATH} ${PYTHON} setup.py build
-    INSTALL_COMMAND PYTHONPATH=${PYTHONPATH} ${PYTHON} setup.py install --prefix=${EXTDIST_ROOT}
+    BUILD_COMMAND ${PYT_PRE_CMD} ${PYTHON} setup.py build
+    INSTALL_COMMAND ${PYT_PRE_CMD} ${PYTHON} setup.py install --prefix=${PYT_LIB_OUTPUT}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Pygments-prefix/src/Pygments
 )
 
 # sphinx
@@ -58,8 +80,9 @@ ExternalProject_Add(Sphinx
     PATCH_COMMAND patch -p1 < ${CMAKE_SOURCE_DIR}/ext/Sphinx-${SPHINX_VERSION}.patch
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND ${CMAKE_COMMAND} -E make_directory ${EXTDIST_PYTHONPATH}
-    BUILD_COMMAND PYTHONPATH=${PYTHONPATH} ${PYTHON} setup.py build
-    INSTALL_COMMAND PYTHONPATH=${PYTHONPATH} ${PYTHON} setup.py install --prefix=${EXTDIST_ROOT} --install-scripts=${EXTDIST_ROOT}/bin
+    BUILD_COMMAND ${PYT_PRE_CMD} ${PYTHON} setup.py build
+    INSTALL_COMMAND ${PYT_PRE_CMD} ${PYTHON} setup.py install --prefix=${PYT_LIB_OUTPUT} --install-scripts=${PYT_EXTDIST_BINPATH}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Sphinx-prefix/src/Sphinx
 )
 
 ###############################################################################
@@ -88,9 +111,9 @@ list(APPEND DOCFILES ${CMAKE_SOURCE_DIR}/share/nuke/ocionuke/viewer.py)
 CopyFiles(RSTDOC ${DOCFILES})
 
 message(STATUS "Extracting .rst files from C++ headers")
-ExtractRstCPP(${CMAKE_SOURCE_DIR}/export/OpenColorIO/OpenColorIO.h developers/api/OpenColorIO.rst)
-ExtractRstCPP(${CMAKE_SOURCE_DIR}/export/OpenColorIO/OpenColorTransforms.h developers/api/OpenColorTransforms.rst)
-ExtractRstCPP(${CMAKE_SOURCE_DIR}/export/OpenColorIO/OpenColorTypes.h developers/api/OpenColorTypes.rst)
+ExtractRstCPP(${CMAKE_SOURCE_DIR}/export/OpenColorIO/OpenColorIO.h ${CMAKE_BINARY_DIR}/docs/developers/api/OpenColorIO.rst)
+ExtractRstCPP(${CMAKE_SOURCE_DIR}/export/OpenColorIO/OpenColorTransforms.h ${CMAKE_BINARY_DIR}/docs/developers/api/OpenColorTransforms.rst)
+ExtractRstCPP(${CMAKE_SOURCE_DIR}/export/OpenColorIO/OpenColorTypes.h ${CMAKE_BINARY_DIR}/docs/developers/api/OpenColorTypes.rst)
 
 if(OCIO_BUILD_PYGLUE)
     set(DEPLIBS OpenColorIO PyOpenColorIO)
@@ -99,7 +122,7 @@ else()
 endif()
 
 add_custom_target(doc ALL
-    COMMAND PYTHONPATH=${PYTHONPATH} ${EXTDIST_BINPATH}/sphinx-build -b html . ${CMAKE_CURRENT_BINARY_DIR}/build-html
+    COMMAND ${PYT_PRE_CMD} ${EXTDIST_BINPATH}/sphinx-build -b html . ${CMAKE_CURRENT_BINARY_DIR}/build-html
     DEPENDS
         ${DEPLIBS}
         ${CMAKE_BINARY_DIR}/docs/conf.py
@@ -123,7 +146,7 @@ find_package(LATEX)
 if(PDFLATEX_COMPILER)
     
     add_custom_target(latex
-        COMMAND PYTHONPATH=${PYTHONPATH} ${EXTDIST_BINPATH}/sphinx-build -b latex . ${CMAKE_CURRENT_BINARY_DIR}/build-latex
+        COMMAND ${PYT_PRE_CMD} ${EXTDIST_BINPATH}/sphinx-build -b latex . ${CMAKE_CURRENT_BINARY_DIR}/build-latex
         DEPENDS
             OpenColorIO
             ${CMAKE_BINARY_DIR}/docs/conf.py

--- a/share/cmake/OCIOMacros.cmake
+++ b/share/cmake/OCIOMacros.cmake
@@ -209,10 +209,19 @@ MACRO(OCIOFindPython)
     if(OCIO_PYGLUE_RESPECT_ABI)
         # Respect Python major/minor version, and UCS version (unicode
         # content system). E.g install into "lib/python2.6/ucs4/site-packages"
-        set(PYTHON_VARIANT_PATH "lib${LIB_SUFFIX}/python${PYTHON_VERSION}/${PYTHON_UCS}/site-packages")
+        # Windows & *nix does not use the same path, refer to https://docs.python.org/2/install/
+        if(WIN32)
+            set(PYTHON_VARIANT_PATH "lib${LIB_SUFFIX}/${PYTHON_UCS}/site-packages")
+        else()
+            set(PYTHON_VARIANT_PATH "lib${LIB_SUFFIX}/python${PYTHON_VERSION}/${PYTHON_UCS}/site-packages")
+        endif()
     else()
         # Ignore UCS value and install into lib/python2.6/site-packages dir
-        set(PYTHON_VARIANT_PATH "lib${LIB_SUFFIX}/python${PYTHON_VERSION}/site-packages")
+        if(WIN32)
+            set(PYTHON_VARIANT_PATH "lib${LIB_SUFFIX}/site-packages")
+        else()
+            set(PYTHON_VARIANT_PATH "lib${LIB_SUFFIX}/python${PYTHON_VERSION}/site-packages")
+        endif()
     endif()
 
 ENDMACRO()
@@ -319,8 +328,9 @@ ENDMACRO()
 
 MACRO(ExtractRstCPP INFILE OUTFILE)
    add_custom_command(
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
       OUTPUT ${OUTFILE}
-      COMMAND ${CMAKE_SOURCE_DIR}/share/sphinx/ExtractRstFromSourceCPP.py ${INFILE} ${OUTFILE}
+      COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/share/sphinx/ExtractRstFromSourceCPP.py ${INFILE} ${OUTFILE}
       DEPENDS ${INFILE}
       COMMENT "Extracting reStructuredText from ${INFILE} (using old process)"
    )
@@ -328,8 +338,9 @@ ENDMACRO()
 
 MACRO(ExtractRstSimple INFILE OUTFILE)
    add_custom_command(
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
       OUTPUT ${OUTFILE}
-      COMMAND ${CMAKE_SOURCE_DIR}/share/sphinx/ExtractRstFromSourceSimple.py ${INFILE} ${OUTFILE}
+      COMMAND ${PYTHON} ${CMAKE_SOURCE_DIR}/share/sphinx/ExtractRstFromSourceSimple.py ${INFILE} ${OUTFILE}
       DEPENDS ${INFILE}
       COMMENT "Extracting reStructuredText from ${INFILE}"
    )

--- a/share/sphinx/ExtractRstFromSourceCPP.py
+++ b/share/sphinx/ExtractRstFromSourceCPP.py
@@ -229,7 +229,7 @@ if __name__ == "__main__":
             sys.exit(1)
         
         src = open(sys.argv[1]).read()
-        output = open(sys.argv[2], 'w')
+        output = open(sys.argv[2], 'w+')
         ExtractRst(src, output)
         output.close()
         


### PR DESCRIPTION
This branch is fixing the doc generation on the windows platform but using nmake. 
Unfortunately using a Visual Studio project adds a new set of issues.

In order to have the html, tex & pdf documentation one should install extra tools such as [MiKTex](https://miktex.org/) and [GnuWin32](http://gnuwin32.sourceforge.net/) tools.