### PR TITLE
Add the pdf doc generation on linux platform only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ os:
 env:
   - OPTIONS="-DCMAKE_BUILD_TYPE=Release -DOCIO_BUILD_TESTS=yes -DOCIO_BUILD_DOCS=yes"
 
+# Install missing packages
+install:
+  - if [[ $TRAVIS_OS_NAME = linux ]]; then sudo apt-get update -qq; fi
+  - if [[ $TRAVIS_OS_NAME = linux ]]; then sudo apt-get install -qq texlive-full; fi
+
 # Run the Build script
 script:
  - mkdir _build
@@ -21,6 +26,7 @@ script:
  - cmake .. -DCMAKE_INSTALL_PREFIX=../_install $OPTIONS
  - cmake --build . --target install
  - ctest --output-on-failure .
+ - if [[ $TRAVIS_OS_NAME = linux ]]; then cmake --build . --target pdf; fi
 
 deploy:
   provider: pages


### PR DESCRIPTION
The idea is to have at least one platform generating all the potential documentation outputs to ensure that the CMake 'mechanism' is working. A side effect is also to document (through the travis file) how to produce the pdf documentation.