### PR TITLE
Fixed the crash with missing role's color space

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -1959,4 +1959,13 @@ OIIO_ADD_TEST(Config, EnvCheck)
     }
 }
 
+OIIO_ADD_TEST(Config, RoleWithoutColorSpace)
+{
+    OCIO::ConfigRcPtr config = OCIO::Config::Create()->createEditableCopy();
+    config->setRole("reference", "UnknownColorSpace");
+
+    std::ostringstream os;
+    OIIO_CHECK_THOW(config->serialize(os), OCIO::Exception);
+}
+
 #endif // OCIO_UNIT_TEST

--- a/src/core/OCIOYaml.cpp
+++ b/src/core/OCIOYaml.cpp
@@ -1730,8 +1730,21 @@ OCIO_NAMESPACE_ENTER
             for(int i = 0; i < c->getNumRoles(); ++i)
             {
                 const char* role = c->getRoleName(i);
-                out << YAML::Key << role;
-                out << YAML::Value << c->getColorSpace(role)->getName();
+                if(role && *role)
+                {
+                    ConstColorSpaceRcPtr colorspace = c->getColorSpace(role);
+                    if(colorspace)
+                    {
+                        out << YAML::Key << role;
+                        out << YAML::Value << c->getColorSpace(role)->getName();
+                    }
+                    else
+                    {
+                        std::ostringstream os;
+                        os << "Colorspace associated to the role '" << role << "', does not exist.";
+                        throw Exception(os.str().c_str());
+                    }
+                }
             }
             out << YAML::EndMap;
 #ifndef OLDYAML


### PR DESCRIPTION
Fixed the crash when the color space associated to a role is not defined:
1. Fixed the problem by checking if the color space exists before trying to serialize anything.
2. Added a unit test to validate that it does not crash and trigger an OCIO exception.