### PR TITLE
Enable all apps on windows

### DIFF
--- a/docs/configurations/index.rst
+++ b/docs/configurations/index.rst
@@ -19,10 +19,6 @@ Public Configs
     spi_vfx
     spi_anim
     nuke_default
-    aces_0.1.1
-    aces_0.7.1
-    aces_1.0.1
-    aces_1.0.2
     aces_1.0.3
     
 Config Creation

--- a/share/cmake/OCIOMacros.cmake
+++ b/share/cmake/OCIOMacros.cmake
@@ -27,15 +27,22 @@ MACRO(OCIOFindOpenGL)
     endif()
 
     # Find GLEW
+
+    if(GLEW_PATH)
+        message(STATUS "GLEW path explicitly specified: ${GLEW_PATH}")
+    endif()
+
     set(GLEW_VERSION 1.5.1)
     FIND_PATH(GLEW_INCLUDES GL/glew.h
+        ${GLEW_PATH}/include
         /usr/include
         /usr/local/include
         /sw/include
         /opt/local/include
         DOC "The directory where GL/glew.h resides")
     FIND_LIBRARY(GLEW_LIBRARIES
-        NAMES GLEW glew
+        NAMES GLEW glew glew32
+        ${GLEW_PATH}/lib
         /usr/lib64
         /usr/lib
         /usr/local/lib64
@@ -49,7 +56,7 @@ MACRO(OCIOFindOpenGL)
         message(STATUS "Found GLEW library ${GLEW_LIBRARIES}")
         message(STATUS "Found GLEW includes ${GLEW_INCLUDES}")
     else()
-        message(STATUS "GLEW not found")
+        message(STATUS "GLEW ${GLEW_VERSION} not found. Specify GLEW_PATH to locate it")
         set(GLEW_FOUND FALSE)
     endif()
 ENDMACRO()
@@ -89,6 +96,27 @@ MACRO(OCIOFindOpenImageIO)
         set(OIIO_FOUND TRUE)
         message(STATUS "Found OIIO library ${OIIO_LIBRARIES}")
         message(STATUS "Found OIIO includes ${OIIO_INCLUDES}")
+
+        # Unfortunately, OIIO hides a dependency to Ilmbase includes
+
+        if(ILMBASE_PATH)
+            message(STATUS "Ilmbase path explicitly specified: ${ILMBASE_PATH}")
+        endif()
+
+        FIND_PATH( ILMBASE_INCLUDES OpenEXR/half.h
+            ${ILMBASE_PATH}/include/
+            /usr/include
+            /usr/local/include
+            /sw/include
+            /opt/local/include
+            DOC "The directory where OpenEXR/half.h resides")
+
+        if(ILMBASE_INCLUDES)
+            message(STATUS "Found Ilmbase includes ${ILMBASE_INCLUDES}")
+        else()
+            set(OIIO_FOUND FALSE)
+            message(STATUS "Ilmbase not found. Specify ILMBASE_PATH to locate it")
+        endif()
     else()
         set(OIIO_FOUND FALSE)
         message(STATUS "OIIO not found. Specify OIIO_PATH to locate it")

--- a/src/apps/ocioconvert/CMakeLists.txt
+++ b/src/apps/ocioconvert/CMakeLists.txt
@@ -4,6 +4,7 @@ if (OIIO_FOUND)
         ${CMAKE_BINARY_DIR}/export/
         ${CMAKE_SOURCE_DIR}/src/apps/share/
         ${OIIO_INCLUDES}
+        ${ILMBASE_INCLUDES}
     )
     
     file(GLOB_RECURSE share_src_files "${CMAKE_SOURCE_DIR}/src/apps/share/*.cpp")

--- a/src/apps/ociodisplay/CMakeLists.txt
+++ b/src/apps/ociodisplay/CMakeLists.txt
@@ -1,14 +1,20 @@
-include_directories(
-    ${CMAKE_SOURCE_DIR}/export/
-    ${CMAKE_BINARY_DIR}/export/
-    ${OPENGL_INCLUDE_DIR}
-    ${OIIO_INCLUDES}
-    ${GLEW_INCLUDES}
-	${GLUT_INCLUDE_DIR}
-)
-add_executable(ociodisplay main.cpp)
-# set_target_properties(ociodisplay PROPERTIES INSTALL_RPATH ${OIIO_LIBRARIES} )
-set_target_properties(ociodisplay PROPERTIES COMPILE_FLAGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
-target_link_libraries(ociodisplay ${GLEW_LIBRARIES} ${GLUT_LIBRARY} ${OPENGL_LIBRARY} ${OIIO_LIBRARIES})
-target_link_OCIO(ociodisplay)
-install(TARGETS ociodisplay EXPORT OpenColorIO DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/bin)
+if (OIIO_FOUND)
+    include_directories(
+        ${CMAKE_SOURCE_DIR}/export/
+        ${CMAKE_BINARY_DIR}/export/
+        ${OPENGL_INCLUDE_DIR}
+        ${OIIO_INCLUDES}
+        ${ILMBASE_INCLUDES}
+        ${GLEW_INCLUDES}
+    	${GLUT_INCLUDE_DIR}
+    )
+
+    add_executable(ociodisplay main.cpp)
+
+    # set_target_properties(ociodisplay PROPERTIES INSTALL_RPATH ${OIIO_LIBRARIES} )
+    set_target_properties(ociodisplay PROPERTIES COMPILE_FLAGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+    target_link_libraries(ociodisplay ${GLEW_LIBRARIES} ${GLUT_LIBRARY} ${OPENGL_LIBRARY} ${OIIO_LIBRARIES})
+    target_link_OCIO(ociodisplay)
+
+    install(TARGETS ociodisplay EXPORT OpenColorIO DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/bin)
+endif()

--- a/src/apps/ociodisplay/main.cpp
+++ b/src/apps/ociodisplay/main.cpp
@@ -36,6 +36,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sstream>
 #include <vector>
 
+#include <OpenColorIO/OpenColorIO.h>
+namespace OCIO = OCIO_NAMESPACE;
+
+#include <OpenImageIO/imageio.h>
+#include <OpenImageIO/typedesc.h>
+#if (OIIO_VERSION < 10100)
+namespace OIIO = OIIO_NAMESPACE;
+#endif
+
 #ifdef __APPLE__
 #include <OpenGL/gl.h>
 #include <OpenGL/glext.h>
@@ -50,14 +59,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <GL/glut.h>
 #endif
 
-#include <OpenColorIO/OpenColorIO.h>
-namespace OCIO = OCIO_NAMESPACE;
 
-#include <OpenImageIO/imageio.h>
-#include <OpenImageIO/typedesc.h>
-#if (OIIO_VERSION < 10100)
-namespace OIIO = OIIO_NAMESPACE;
-#endif
+bool g_verbose = false;
+std::string g_filename;
+
 
 GLint g_win = 0;
 int g_winWidth = 0;
@@ -78,6 +83,7 @@ std::string g_shadercacheid;
 std::string g_inputColorSpace;
 std::string g_display;
 std::string g_transformName;
+std::string g_look;
 
 float g_exposure_fstop = 0.0f;
 float g_display_gamma = 1.0f;
@@ -95,7 +101,7 @@ static void InitImageTexture(const char * filename)
     int texHeight = 512;
     int components = 4;
     
-    if(filename)
+    if(filename && *filename)
     {
         std::cout << "loading: " << filename << std::endl;
         try
@@ -120,12 +126,12 @@ static void InitImageTexture(const char * filename)
             texWidth = spec.width;
             texHeight = spec.height;
             components = spec.nchannels;
-            
+
             img.resize(texWidth*texHeight*components);
             memset(&img[0], 0, texWidth*texHeight*components*sizeof(float));
             
-            f->read_image(OIIO::TypeDesc::TypeFloat, &img[0]);
-            delete f;
+            f->read_image(OIIO::TypeFloat, &img[0]);
+            OIIO::ImageInput::destroy(f);
         }
         catch(...)
         {
@@ -185,9 +191,10 @@ void InitOCIO(const char * filename)
     OCIO::ConstConfigRcPtr config = OCIO::GetCurrentConfig();
     g_display = config->getDefaultDisplay();
     g_transformName = config->getDefaultView(g_display.c_str());
+    g_look = config->getDisplayLooks(g_display.c_str(), g_transformName.c_str());
     
     g_inputColorSpace = OCIO::ROLE_SCENE_LINEAR;
-    if(filename)
+    if(filename && *filename)
     {
         std::string cs = config->parseColorSpaceFromString(filename);
         if(!cs.empty())
@@ -197,7 +204,8 @@ void InitOCIO(const char * filename)
         }
         else
         {
-            std::cout << "colorspace: " << g_inputColorSpace << " \t(could not determine from filename, using default)" << std::endl;
+            std::cout << "colorspace: " << g_inputColorSpace 
+                << " \t(could not determine from filename, using default)" << std::endl;
         }
     }
 }
@@ -475,6 +483,26 @@ void UpdateOCIOGLState()
     transform->setInputColorSpaceName( g_inputColorSpace.c_str() );
     transform->setDisplay( g_display.c_str() );
     transform->setView( g_transformName.c_str() );
+    transform->setLooksOverride( g_look.c_str() );
+
+    if(g_verbose)
+    {
+        std::cout << std::endl;
+        std::cout << "Color transformation composed of:" << std::endl;
+        std::cout << "      Image ColorSpace is:\t" << g_inputColorSpace << std::endl;
+        std::cout << "      Transform is:\t\t" << g_transformName << std::endl;
+        std::cout << "      Device is:\t\t" << g_display << std::endl;
+        std::cout << "      Looks Override is:\t'" << g_look << "'" << std::endl;
+        std::cout << "  with:" << std::endl;
+        std::cout << "    exposure_fstop = " << g_exposure_fstop << std::endl;
+        std::cout << "    display_gamma  = " << g_display_gamma << std::endl;
+        std::cout << "    channels       = " 
+                  << (g_channelHot[0] ? "R" : "")
+                  << (g_channelHot[1] ? "G" : "")
+                  << (g_channelHot[2] ? "B" : "")
+                  << (g_channelHot[3] ? "A" : "") << std::endl;
+
+    }
     
     // Add optional transforms to create a full-featured, "canonical" display pipeline
     // Fstop exposure control (in SCENE_LINEAR)
@@ -601,7 +629,9 @@ void displayDevice_CB(int id)
     {
         g_transformName = config->getDefaultView(g_display.c_str());
     }
-    
+
+    g_look = config->getDisplayLooks(g_display.c_str(), g_transformName.c_str());
+
     UpdateOCIOGLState();
     glutPostRedisplay();
 }
@@ -614,6 +644,21 @@ void transform_CB(int id)
     if(!transform) return;
     
     g_transformName = transform;
+
+    g_look = config->getDisplayLooks(g_display.c_str(), g_transformName.c_str());
+    
+    UpdateOCIOGLState();
+    glutPostRedisplay();
+}
+
+void look_CB(int id)
+{
+    OCIO::ConstConfigRcPtr config = OCIO::GetCurrentConfig();
+    
+    const char * look = config->getLookNameByIndex(id);
+    if(!look || !*look) return;
+    
+    g_look = look;
     
     UpdateOCIOGLState();
     glutPostRedisplay();
@@ -623,11 +668,41 @@ static void PopulateOCIOMenus()
 {
     OCIO::ConstConfigRcPtr config = OCIO::GetCurrentConfig();
     
-    
     int csMenuID = glutCreateMenu(imageColorSpace_CB);
+
+    std::map<std::string, int> families;
     for(int i=0; i<config->getNumColorSpaces(); ++i)
     {
-        glutAddMenuEntry(config->getColorSpaceNameByIndex(i), i);
+        const char * csName = config->getColorSpaceNameByIndex(i);
+        if(csName && *csName)
+        {
+            OCIO::ConstColorSpaceRcPtr cs = config->getColorSpace(csName);
+            if(cs)
+            {
+                const char * family = cs->getFamily();
+                if(family && *family)
+                {
+                    if(families.find(family)==families.end())
+                    {
+                        families[family] = glutCreateMenu(imageColorSpace_CB);
+                        glutAddMenuEntry(csName, i);
+
+                        glutSetMenu(csMenuID);
+                        glutAddSubMenu(family, families[family]);
+                    }
+                    else
+                    {
+                        glutSetMenu(families[family]);
+                        glutAddMenuEntry(csName, i);
+                    }
+                }
+                else
+                {
+                    glutSetMenu(csMenuID);
+                    glutAddMenuEntry(csName, i);
+                }
+            }
+        }
     }
     
     int deviceMenuID = glutCreateMenu(displayDevice_CB);
@@ -643,10 +718,17 @@ static void PopulateOCIOMenus()
         glutAddMenuEntry(config->getView(defaultDisplay, i), i);
     }
     
+    int lookMenuID = glutCreateMenu(look_CB);
+    for(int i=0; i<config->getNumLooks(); ++i)
+    {
+        glutAddMenuEntry(config->getLookNameByIndex(i), i);
+    }
+    
     glutCreateMenu(menuCallback);
     glutAddSubMenu("Image ColorSpace", csMenuID);
     glutAddSubMenu("Transform", transformMenuID);
     glutAddSubMenu("Device", deviceMenuID);
+    glutAddSubMenu("Looks Override", lookMenuID);
     
     glutAttachMenu(GLUT_RIGHT_BUTTON);
 }
@@ -668,9 +750,52 @@ const char * USAGE_TEXT = "\n"
 "\tA:   View Alpha\n"
 "\tL:   View Luma\n"
 "\n"
-"\tRight-Mouse Button:   Configure Display / Transform / ColorSpace\n"
+"\tRight-Mouse Button:   Configure Display / Transform / ColorSpace / Looks\n"
 "\n"
 "\tEsc: Quit\n";
+
+void parseArguments(int argc, char **argv)
+{
+    for(int i=1; i<argc; ++i)
+    {
+        if(0==strcmp(argv[i], "-v"))
+        {
+            g_verbose = true;
+        }
+        else if(0==strcmp(argv[i], "-h"))
+        {
+            std::cout << std::endl;
+            std::cout << "help:" << std::endl;
+            std::cout << "  ociodisplay [OPTIONS] [image]  where" << std::endl;
+            std::cout << std::endl;
+            std::cout << "  OPTIONS:" << std::endl;
+            std::cout << "     -h :  displays the help and exit" << std::endl;
+            std::cout << "     -v :  displays the color space information" << std::endl;
+            std::cout << std::endl;
+            exit(0);
+        }
+        else
+        {
+            g_filename = argv[i];
+        }
+    }
+
+    if(g_verbose)
+    {
+        std::cout << std::endl;
+        if(!g_filename.empty())
+        {
+            std::cout << "Image:" << std::endl
+                      << "\t" << g_filename << std::endl;
+        }
+        std::cout << std::endl;
+        std::cout << "OCIO: " << std::endl
+                  << "\tversion       = " << OCIO::GetVersion() << std::endl
+                  << "\tconfiguration = " << getenv("OCIO") << std::endl;
+        OCIO::ConstConfigRcPtr config = OCIO::GetCurrentConfig();
+        std::cout << "\tsearch_path   = " << config->getSearchPath() << std::endl;
+    }
+}
 
 int main(int argc, char **argv)
 {
@@ -679,6 +804,8 @@ int main(int argc, char **argv)
     glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE | GLUT_DEPTH);
     glutInitWindowSize(512, 512);
     glutInitWindowPosition (100, 100);
+
+    parseArguments(argc, argv);
     
     g_win = glutCreateWindow(argv[0]);
     
@@ -696,19 +823,18 @@ int main(int argc, char **argv)
     glutSpecialFunc(SpecialKey);
     glutDisplayFunc(Redisplay);
     
-    const char * filename = 0;
-    if(argc>1) filename = argv[1];
-    
     std::cout << USAGE_TEXT << std::endl;
     
     // TODO: switch profiles based on shading language
-    // std::cout << "GL_SHADING_LANGUAGE_VERSION: " << glGetString(GL_SHADING_LANGUAGE_VERSION) << std::endl;
+    std::cout << "GL_SHADING_LANGUAGE_VERSION: " << glGetString(GL_SHADING_LANGUAGE_VERSION) << std::endl;
+    std::cout << std::endl;
+
     AllocateLut3D();
     
-    InitImageTexture(filename);
+    InitImageTexture(g_filename.c_str());
     try
     {
-        InitOCIO(filename);
+        InitOCIO(g_filename.c_str());
     }
     catch(OCIO::Exception & e)
     {
@@ -732,6 +858,6 @@ int main(int argc, char **argv)
     */
     
     glutMainLoop();
-    
+
     return 0;
 }

--- a/src/apps/ociodisplay/main.cpp
+++ b/src/apps/ociodisplay/main.cpp
@@ -790,10 +790,13 @@ void parseArguments(int argc, char **argv)
         }
         std::cout << std::endl;
         std::cout << "OCIO: " << std::endl
-                  << "\tversion       = " << OCIO::GetVersion() << std::endl
-                  << "\tconfiguration = " << getenv("OCIO") << std::endl;
-        OCIO::ConstConfigRcPtr config = OCIO::GetCurrentConfig();
-        std::cout << "\tsearch_path   = " << config->getSearchPath() << std::endl;
+                  << "\tversion       = " << OCIO::GetVersion() << std::endl;
+        if(getenv("OCIO"))
+        {
+            std::cout << "\tconfiguration = " << getenv("OCIO") << std::endl;
+            OCIO::ConstConfigRcPtr config = OCIO::GetCurrentConfig();
+            std::cout << "\tsearch_path   = " << config->getSearchPath() << std::endl;
+        }
     }
 }
 

--- a/src/apps/ociolutimage/CMakeLists.txt
+++ b/src/apps/ociolutimage/CMakeLists.txt
@@ -4,6 +4,7 @@ if (OIIO_FOUND)
         ${CMAKE_BINARY_DIR}/export/
         ${CMAKE_SOURCE_DIR}/src/apps/share/
         ${OIIO_INCLUDES}
+        ${ILMBASE_INCLUDES}
     )
     
     file(GLOB_RECURSE share_src_files "${CMAKE_SOURCE_DIR}/src/apps/share/*.cpp")


### PR DESCRIPTION
The goal is to have all apps working on the Windows platform. Obviously, the OIIO library (and all its third-party libraries) compilation must have been done prior to OCIO.
In order to demonstrate the success, I've added the family classification in the color space menu of the ociodisplay apps.