### PR TITLE
Color space transform accept env variable

### DIFF
--- a/ext/oiio/src/include/unittest.h
+++ b/ext/oiio/src/include/unittest.h
@@ -109,20 +109,27 @@ struct AddTest { AddTest(OIIOTest* test); };
             (void)++unit_test_failures))
 
 #define OIIO_CHECK_CLOSE(x,y,tol)                                       \
-    ((std::abs((x) - (y)) < tol) ? ((void)0)                            \
+    ((std::abs((x) - (y)) < (tol)) ? ((void)0)                          \
          : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
              << "FAILED: abs(" << #x << " - " << #y << ") < " << #tol << "\n" \
              << "\tvalues were '" << (x) << "', '" << (y) << "' and '" << (tol) << "'\n"), \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_THOW(S, E)                                           \
+#define OIIO_CHECK_THROW(S, E)                                          \
     try { S; throw "throwanything"; } catch( E const& ) { } catch (...) { \
         std::cout << __FILE__ << ":" << __LINE__ << ":\n"               \
         << "FAILED: " << #E << " is expected to be thrown\n";           \
         ++unit_test_failures; }
 
-#define OIIO_CHECK_NO_THOW(S)                                           \
-    try { S; } catch (...) {                                            \
+#define OIIO_CHECK_NO_THROW(S)                                          \
+    try {                                                               \
+        S;                                                              \
+    } catch (OCIO_NAMESPACE::Exception & ex ) {                         \
+        std::cout << __FILE__ << ":" << __LINE__ << ":\n"               \
+            << "FAILED: exception thrown from " << #S << ": \""         \
+            << ex.what() << "\"\n";                                     \
+        ++unit_test_failures;                                           \
+    } catch (...) {                                                     \
         std::cout << __FILE__ << ":" << __LINE__ << ":\n"               \
         << "FAILED: exception thrown from " << #S <<"\n";               \
         ++unit_test_failures; }

--- a/src/core/ColorSpaceTransform.cpp
+++ b/src/core/ColorSpaceTransform.cpp
@@ -152,13 +152,13 @@ OCIO_NAMESPACE_ENTER
         
         if(combinedDir == TRANSFORM_DIR_FORWARD)
         {
-            src = config.getColorSpace( colorSpaceTransform.getSrc() );
-            dst = config.getColorSpace( colorSpaceTransform.getDst() );
+            src = config.getColorSpace( context->resolveStringVar( colorSpaceTransform.getSrc() ) );
+            dst = config.getColorSpace( context->resolveStringVar( colorSpaceTransform.getDst() ) );
         }
         else if(combinedDir == TRANSFORM_DIR_INVERSE)
         {
-            dst = config.getColorSpace( colorSpaceTransform.getSrc() );
-            src = config.getColorSpace( colorSpaceTransform.getDst() );
+            dst = config.getColorSpace( context->resolveStringVar( colorSpaceTransform.getSrc() ) );
+            src = config.getColorSpace( context->resolveStringVar( colorSpaceTransform.getDst() ) );
         }
         
         BuildColorSpaceOps(ops, config, context, src, dst);

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -1969,7 +1969,7 @@ OIIO_ADD_TEST(Config, RoleWithoutColorSpace)
     config->setRole("reference", "UnknownColorSpace");
 
     std::ostringstream os;
-    OIIO_CHECK_THOW(config->serialize(os), OCIO::Exception);
+    OIIO_CHECK_THROW(config->serialize(os), OCIO::Exception);
 }
 
 OIIO_ADD_TEST(Config, Env_colorspace_name)

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -2034,7 +2034,7 @@ OIIO_ADD_TEST(Config, Env_colorspace_name)
     }
 
     {
-        char * env = "CAMERARAW=lnh";
+        const char * env = "CAMERARAW=lnh";
         putenv(env);
 
         std::istringstream is;
@@ -2049,7 +2049,7 @@ OIIO_ADD_TEST(Config, Env_colorspace_name)
     {
         // Test when the env. variable content is wrong
 
-        char * env = "CAMERARAW=FaultyColorSpaceName";
+        const char * env = "CAMERARAW=FaultyColorSpaceName";
         putenv(env);
 
         std::istringstream is;

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -2034,7 +2034,8 @@ OIIO_ADD_TEST(Config, Env_colorspace_name)
     }
 
     {
-        putenv("CAMERARAW=lnh");
+        char * env = "CAMERARAW=lnh";
+        putenv(env);
 
         std::istringstream is;
         is.str(MY_OCIO_CONFIG);
@@ -2048,7 +2049,8 @@ OIIO_ADD_TEST(Config, Env_colorspace_name)
     {
         // Test when the env. variable content is wrong
 
-        putenv("CAMERARAW=FaultyColorSpaceName");
+        char * env = "CAMERARAW=FaultyColorSpaceName";
+        putenv(env);
 
         std::istringstream is;
         is.str(MY_OCIO_CONFIG);

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -2034,7 +2034,7 @@ OIIO_ADD_TEST(Config, Env_colorspace_name)
     }
 
     {
-        const char * env = "CAMERARAW=lnh";
+        char * env = (char *)"CAMERARAW=lnh";
         putenv(env);
 
         std::istringstream is;
@@ -2049,7 +2049,7 @@ OIIO_ADD_TEST(Config, Env_colorspace_name)
     {
         // Test when the env. variable content is wrong
 
-        const char * env = "CAMERARAW=FaultyColorSpaceName";
+        char * env = (char *)"CAMERARAW=FaultyColorSpaceName";
         putenv(env);
 
         std::istringstream is;

--- a/src/core/Context.cpp
+++ b/src/core/Context.cpp
@@ -446,12 +446,12 @@ OIIO_ADD_TEST(Context, ABSPath)
     con->setStringVar("non_abs", "src/core/Context.cpp");
     con->setStringVar("is_abs", contextpath.c_str());
     
-    OIIO_CHECK_NO_THOW(con->resolveFileLocation("${non_abs}"));
+    OIIO_CHECK_NO_THROW(con->resolveFileLocation("${non_abs}"));
 
     OIIO_CHECK_ASSERT(strcmp(sanatizepath(con->resolveFileLocation("${non_abs}")).c_str(), 
                                             contextpath.c_str()) == 0);
     
-    OIIO_CHECK_NO_THOW(con->resolveFileLocation("${is_abs}"));
+    OIIO_CHECK_NO_THROW(con->resolveFileLocation("${is_abs}"));
     OIIO_CHECK_ASSERT(strcmp(con->resolveFileLocation("${is_abs}"), contextpath.c_str()) == 0);
    
 }
@@ -463,7 +463,7 @@ OIIO_ADD_TEST(Context, VarSearchPath)
     context->setStringVar("SOURCE_DIR", ociodir.c_str());
     context->setSearchPath("${SOURCE_DIR}/src/core");
 
-    OIIO_CHECK_NO_THOW(context->resolveFileLocation("Context.cpp"));
+    OIIO_CHECK_NO_THROW(context->resolveFileLocation("Context.cpp"));
     OIIO_CHECK_ASSERT(strcmp(sanatizepath(context->resolveFileLocation("Context.cpp")).c_str(), 
                                 contextpath.c_str()) == 0);
 

--- a/src/core/FileFormatCSP.cpp
+++ b/src/core/FileFormatCSP.cpp
@@ -1364,7 +1364,7 @@ OIIO_ADD_TEST(FileFormatCSP, lessStrictParse)
     // Load file
     OCIO::LocalFileFormat tester;
     OCIO::CachedFileRcPtr cachedFile;
-    OIIO_CHECK_NO_THOW(cachedFile = tester.Read(simple3D));
+    OIIO_CHECK_NO_THROW(cachedFile = tester.Read(simple3D));
     OCIO::CachedFileCSPRcPtr csplut = OCIO::DynamicPtrCast<OCIO::CachedFileCSP>(cachedFile);   
     
     // check metadata

--- a/src/core/FileFormatTruelight.cpp
+++ b/src/core/FileFormatTruelight.cpp
@@ -491,7 +491,7 @@ OIIO_ADD_TEST(FileFormatTruelight, ShaperAndLut3D)
     // Read file
     OCIO::LocalFileFormat tester;
     OCIO::CachedFileRcPtr cachedFile;
-    OIIO_CHECK_NO_THOW(cachedFile = tester.Read(lutIStream));
+    OIIO_CHECK_NO_THROW(cachedFile = tester.Read(lutIStream));
     OCIO::LocalCachedFileRcPtr lut = OCIO::DynamicPtrCast<OCIO::LocalCachedFile>(cachedFile);
     
     OIIO_CHECK_ASSERT(lut->has1D);
@@ -559,7 +559,7 @@ OIIO_ADD_TEST(FileFormatTruelight, Shaper)
     // Read file
     OCIO::LocalFileFormat tester;
     OCIO::CachedFileRcPtr cachedFile;
-    OIIO_CHECK_NO_THOW(cachedFile = tester.Read(lutIStream));
+    OIIO_CHECK_NO_THROW(cachedFile = tester.Read(lutIStream));
     
     OCIO::LocalCachedFileRcPtr lut = OCIO::DynamicPtrCast<OCIO::LocalCachedFile>(cachedFile);
     
@@ -646,7 +646,7 @@ OIIO_ADD_TEST(FileFormatTruelight, Lut3D)
     // Read file
     OCIO::LocalFileFormat tester;
     OCIO::CachedFileRcPtr cachedFile;
-    OIIO_CHECK_NO_THOW(cachedFile = tester.Read(lutIStream));
+    OIIO_CHECK_NO_THROW(cachedFile = tester.Read(lutIStream));
     OCIO::LocalCachedFileRcPtr lut = OCIO::DynamicPtrCast<OCIO::LocalCachedFile>(cachedFile);
     
     OIIO_CHECK_ASSERT(!lut->has1D);

--- a/src/core/NoOps.cpp
+++ b/src/core/NoOps.cpp
@@ -508,9 +508,9 @@ OIIO_ADD_TEST(NoOps, PartitionGPUOps)
     OIIO_CHECK_EQUAL(gpuLatticeOps.size(), 0);
     OIIO_CHECK_EQUAL(gpuPostOps.size(), 0);
     
-    OIIO_CHECK_NO_THOW( AssertPartitionIntegrity(gpuPreOps,
-                                                 gpuLatticeOps,
-                                                 gpuPostOps) );
+    OIIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
+                                                  gpuLatticeOps,
+                                                  gpuPostOps) );
     }
     
     {
@@ -524,9 +524,9 @@ OIIO_ADD_TEST(NoOps, PartitionGPUOps)
     OIIO_CHECK_EQUAL(gpuLatticeOps.size(), 0);
     OIIO_CHECK_EQUAL(gpuPostOps.size(), 0);
     
-    OIIO_CHECK_NO_THOW( AssertPartitionIntegrity(gpuPreOps,
-                                                 gpuLatticeOps,
-                                                 gpuPostOps) );
+    OIIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
+                                                  gpuLatticeOps,
+                                                  gpuPostOps) );
     }
     
     {
@@ -542,9 +542,9 @@ OIIO_ADD_TEST(NoOps, PartitionGPUOps)
     OIIO_CHECK_EQUAL(gpuLatticeOps.size(), 0);
     OIIO_CHECK_EQUAL(gpuPostOps.size(), 0);
     
-    OIIO_CHECK_NO_THOW( AssertPartitionIntegrity(gpuPreOps,
-                                                 gpuLatticeOps,
-                                                 gpuPostOps) );
+    OIIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
+                                                  gpuLatticeOps,
+                                                  gpuPostOps) );
     }
     
     {
@@ -561,9 +561,9 @@ OIIO_ADD_TEST(NoOps, PartitionGPUOps)
     OIIO_CHECK_EQUAL(gpuLatticeOps.size(), 4);
     OIIO_CHECK_EQUAL(gpuPostOps.size(), 1);
     
-    OIIO_CHECK_NO_THOW( AssertPartitionIntegrity(gpuPreOps,
-                                                 gpuLatticeOps,
-                                                 gpuPostOps) );
+    OIIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
+                                                  gpuLatticeOps,
+                                                  gpuPostOps) );
     }
     
     {
@@ -578,9 +578,9 @@ OIIO_ADD_TEST(NoOps, PartitionGPUOps)
     OIIO_CHECK_EQUAL(gpuLatticeOps.size(), 1);
     OIIO_CHECK_EQUAL(gpuPostOps.size(), 0);
     
-    OIIO_CHECK_NO_THOW( AssertPartitionIntegrity(gpuPreOps,
-                                                 gpuLatticeOps,
-                                                 gpuPostOps) );
+    OIIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
+                                                  gpuLatticeOps,
+                                                  gpuPostOps) );
     }
     
     {
@@ -600,9 +600,9 @@ OIIO_ADD_TEST(NoOps, PartitionGPUOps)
     OIIO_CHECK_EQUAL(gpuLatticeOps.size(), 4);
     OIIO_CHECK_EQUAL(gpuPostOps.size(), 2);
     
-    OIIO_CHECK_NO_THOW( AssertPartitionIntegrity(gpuPreOps,
-                                                 gpuLatticeOps,
-                                                 gpuPostOps) );
+    OIIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
+                                                  gpuLatticeOps,
+                                                  gpuPostOps) );
     }
     
     {
@@ -624,9 +624,9 @@ OIIO_ADD_TEST(NoOps, PartitionGPUOps)
     OIIO_CHECK_EQUAL(gpuLatticeOps.size(), 8);
     OIIO_CHECK_EQUAL(gpuPostOps.size(), 2);
     
-    OIIO_CHECK_NO_THOW( AssertPartitionIntegrity(gpuPreOps,
-                                                 gpuLatticeOps,
-                                                 gpuPostOps) );
+    OIIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
+                                                  gpuLatticeOps,
+                                                  gpuPostOps) );
     /*
     std::cerr << "gpuPreOps" << std::endl;
     std::cerr << SerializeOpVec(gpuPreOps, 4) << std::endl;

--- a/src/core/TruelightTransform.cpp
+++ b/src/core/TruelightTransform.cpp
@@ -301,25 +301,25 @@ OIIO_ADD_TEST(TruelightTransform, simpletest)
     OCIO::ConstProcessorRcPtr tolog;
     
 #ifdef OCIO_TRUELIGHT_SUPPORT
-    OIIO_CHECK_NO_THOW(tosrgb = config->getProcessor("log", "sRGB"));
-    OIIO_CHECK_NO_THOW(tolog = config->getProcessor("sRGB", "log"));
+    OIIO_CHECK_NO_THROW(tosrgb = config->getProcessor("log", "sRGB"));
+    OIIO_CHECK_NO_THROW(tolog = config->getProcessor("sRGB", "log"));
 #else
-    OIIO_CHECK_THOW(tosrgb = config->getProcessor("log", "sRGB"), OCIO::Exception);
-    OIIO_CHECK_THOW(tolog = config->getProcessor("sRGB", "log"), OCIO::Exception);
+    OIIO_CHECK_THROW(tosrgb = config->getProcessor("log", "sRGB"), OCIO::Exception);
+    OIIO_CHECK_THROW(tolog = config->getProcessor("sRGB", "log"), OCIO::Exception);
 #endif
     
 #ifdef OCIO_TRUELIGHT_SUPPORT
     float input[3] = {0.5f, 0.5f, 0.5f};
     float output[3] = {0.500098f, 0.500317f, 0.501134f};
-    OIIO_CHECK_NO_THOW(tosrgb->applyRGB(input));
-    OIIO_CHECK_NO_THOW(tolog->applyRGB(input));
+    OIIO_CHECK_NO_THROW(tosrgb->applyRGB(input));
+    OIIO_CHECK_NO_THROW(tolog->applyRGB(input));
     OIIO_CHECK_CLOSE(input[0], output[0], 1e-4);
     OIIO_CHECK_CLOSE(input[1], output[1], 1e-4);
     OIIO_CHECK_CLOSE(input[2], output[2], 1e-4);
 #endif
     
     std::ostringstream os;
-    OIIO_CHECK_NO_THOW(config->serialize(os));
+    OIIO_CHECK_NO_THROW(config->serialize(os));
     
     std::string referenceconfig =
     "ocio_profile_version: 1\n"
@@ -368,7 +368,7 @@ OIIO_ADD_TEST(TruelightTransform, simpletest)
     std::istringstream is;
     is.str(referenceconfig);
     OCIO::ConstConfigRcPtr rtconfig;
-    OIIO_CHECK_NO_THOW(rtconfig = OCIO::Config::CreateFromStream(is));
+    OIIO_CHECK_NO_THROW(rtconfig = OCIO::Config::CreateFromStream(is));
     
 }
 


### PR DESCRIPTION
A cleaned version of #477 fixing merge conflicts and git history

The Color space transform is now accepting env. variable for the src and dst color space names.

Accept env. variables for the color space names
Add unit tests
Fix a typo and improve a unit test macro