### PR TITLE
Fix MacOS >= 10.12 Deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,24 @@
 # travis-ci.org build file
 # https://docs.travis-ci.com/user/languages/cpp
 
-language: cpp
-
-compiler:
-  - clang
-  - gcc
-
-os:
-  - linux
-  - osx
+matrix:
+  include:
+    - os: linux
+      language: cpp
+      compiler: clang
+    - os: linux
+      language: cpp
+      compiler: gcc
+    - os: osx
+      language: cpp
+      compiler: clang
+    - os: osx
+      language: cpp
+      compiler: gcc
+    - os: osx
+      language: cpp
+      compiler: clang
+      osx_image: xcode9.1
 
 env:
   - OPTIONS="-DCMAKE_BUILD_TYPE=Release -DOCIO_BUILD_TESTS=yes -DOCIO_BUILD_DOCS=yes"

--- a/src/core/Mutex.h
+++ b/src/core/Mutex.h
@@ -98,16 +98,13 @@ OCIO_NAMESPACE_ENTER
     };
 
 #ifndef NDEBUG
-    // add debug wrappers to mutex and spinlock
+    // add debug wrappers to mutex
     typedef DebugLock<_Mutex> Mutex;
-    typedef DebugLock<_SpinLock> SpinLock;
 #else
     typedef _Mutex Mutex;
-    typedef _SpinLock SpinLock;
 #endif
 
     typedef AutoLock<Mutex> AutoMutex;
-    typedef AutoLock<SpinLock> AutoSpin;
 
 }
 OCIO_NAMESPACE_EXIT

--- a/src/core/Platform.h
+++ b/src/core/Platform.h
@@ -82,25 +82,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #include <process.h>
 
 #else
+// assume linux/unix/posix
 
-// linux/unix/posix
 #include <stdlib.h>
 #if !defined(__FreeBSD__)
 #include <alloca.h>
 #endif
 #include <string.h>
 #include <pthread.h>
-// OS for spinlock
-#ifdef __APPLE__
-#include <sys/types.h>
-#include <AvailabilityMacros.h>
-#ifdef AVAILABLE_MAC_OS_X_VERSION_10_12_AND_LATER
-#include <os/lock.h>
-#else
-#include <libkern/OSAtomic.h>
-#endif
-#endif
-#endif
+
+#endif // defined(_WIN32) || defined(_WIN64) || defined(_WINDOWS) || defined(_MSC_VER)
 
 // general includes
 #include <stdio.h>
@@ -123,7 +114,7 @@ inline double log2(double x) {
 
 #else
 typedef off_t FilePos;
-#endif
+#endif // WINDOWS
     
 
 OCIO_NAMESPACE_ENTER
@@ -134,7 +125,7 @@ OCIO_NAMESPACE_ENTER
 #define OCIO_LITTLE_ENDIAN 1  // This is correct on x86
 
     /*
-     * Mutex/SpinLock classes
+     * Mutex classes
      */
 
 #ifdef WINDOWS
@@ -147,16 +138,6 @@ OCIO_NAMESPACE_ENTER
 	void unlock() { ReleaseMutex(_mutex); }
     private:
 	HANDLE _mutex;
-    };
-
-    class _SpinLock {
-    public:
-	_SpinLock()    { InitializeCriticalSection(&_spinlock); }
-	~_SpinLock()   { DeleteCriticalSection(&_spinlock); }
-	void lock()   { EnterCriticalSection(&_spinlock); }
-	void unlock() { LeaveCriticalSection(&_spinlock); }
-    private:
-	CRITICAL_SECTION _spinlock;
     };
 
 #else
@@ -172,49 +153,6 @@ OCIO_NAMESPACE_ENTER
 	pthread_mutex_t _mutex;
     };
 
-#if __APPLE__
-#ifdef AVAILABLE_MAC_OS_X_VERSION_10_12_AND_LATER
-    class _SpinLock {
-    public:
-	_SpinLock()   { _spinlock = OS_UNFAIR_LOCK_INIT; }
-	~_SpinLock()  { }
-	void lock()   { os_unfair_lock_lock(&_spinlock); }
-	void unlock() { os_unfair_lock_unlock(&_spinlock); }
-    private:
-	os_unfair_lock _spinlock;
-    };
-#else
-    class _SpinLock {
-    public:
-	_SpinLock()   { _spinlock = 0; }
-	~_SpinLock()  { }
-	void lock()   { OSSpinLockLock(&_spinlock); }
-	void unlock() { OSSpinLockUnlock(&_spinlock); }
-    private:
-	OSSpinLock _spinlock;
-    };
-#endif
-#elif ANDROID
-    // we don't have access to pthread on andriod so we just make an empty
-    // class that does nothing.
-    class _SpinLock {
-    public:
-    _SpinLock()   { }
-    ~_SpinLock()  { }
-    void lock()   { }
-    void unlock() { }
-    };
-#else
-    class _SpinLock {
-    public:
-	_SpinLock()   { pthread_spin_init(&_spinlock, PTHREAD_PROCESS_PRIVATE); }
-	~_SpinLock()  { pthread_spin_destroy(&_spinlock); }
-	void lock()   { pthread_spin_lock(&_spinlock); }
-	void unlock() { pthread_spin_unlock(&_spinlock); }
-    private:
-	pthread_spinlock_t _spinlock;
-    };
-#endif // __APPLE__
 #endif // WINDOWS
 
   namespace Platform


### PR DESCRIPTION
MacOS >= 10.12 (Sierra) break OCIO builds via deprecated mutex functions. For example:
`error: 'OSSpinLock' is deprecated: first deprecated in macOS 10.12 - Use os_unfair_lock() from <os/lock.h> instead` 
and 
`error: 'OSSpinLockLock' is deprecated: first deprecated in macOS 10.12 - Use os_unfair_lock_lock() from <os/lock.h> instead`

I've swapped out the required functions, added the MacOS version logic, and added the build criteria to TravisCI.

@hodoulp and @lgritz could you take a look? Don't trust myself with mutex-y things just yet