### PR TITLE
Improve the OCIO exception

### DIFF
--- a/export/OpenColorIO/OpenColorIO.h
+++ b/export/OpenColorIO/OpenColorIO.h
@@ -30,7 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef INCLUDED_OCIO_OPENCOLORIO_H
 #define INCLUDED_OCIO_OPENCOLORIO_H
 
-#include <exception>
+#include <stdexcept>
 #include <iosfwd>
 #include <string>
 #include <cstddef>
@@ -85,32 +85,13 @@ OCIO_NAMESPACE_ENTER
     //
     // .. warning:: 
     //    All functions in the Config class can potentially throw this exception.
-    class OCIOEXPORT Exception : public std::exception
+    class OCIOEXPORT Exception : public std::runtime_error
     {
     public:
         //!cpp:function:: Constructor that takes a string as the exception message.
         Exception(const char *) throw();
-        //!cpp:function:: Constructor that takes an exception pointer.
+        //!cpp:function:: Constructor that takes an existing exception.
         Exception(const Exception&) throw();
-        //!cpp:function:: Constructor that takes an exception pointer and returns an exception pointer (???).
-        Exception& operator=(const Exception&) throw();
-        //!cpp:function::
-        virtual ~Exception() throw();
-        //!cpp:function::
-        virtual const char* what() const throw();
-        
-    private:
-        //Add pragma warnings, STL member is private and not consumed by client of DLL
-        #ifdef _WIN32
-        #pragma warning(push)
-        #pragma warning(disable:4251)
-        #endif // _WIN32
-
-        std::string msg_;
-
-        #ifdef _WIN32
-        #pragma warning(pop)
-        #endif // _WIN32
     };
     
     //!cpp:class:: An exception class for errors detected at

--- a/src/core/Exception.cpp
+++ b/src/core/Exception.cpp
@@ -32,32 +32,12 @@ OCIO_NAMESPACE_ENTER
 {
   
     Exception::Exception(const char * msg) throw()
-    : std::exception(),
-      msg_(msg)
+    : std::runtime_error(msg)
     {}
 
     Exception::Exception(const Exception& e) throw()
-    : std::exception(),
-      msg_(e.msg_)
+    : std::runtime_error(e)
     {}
-
-    //*** operator=
-    Exception& Exception::operator=(const Exception& e) throw()
-    {
-        msg_ = e.msg_;
-        return *this;
-    }
-
-    //*** ~Exception
-    Exception::~Exception() throw()
-    {
-    }
-
-    //*** what
-    const char* Exception::what() const throw()
-    {
-        return msg_.c_str();
-    }
 
   
   
@@ -72,3 +52,85 @@ OCIO_NAMESPACE_ENTER
 
 }
 OCIO_NAMESPACE_EXIT
+
+
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef OCIO_UNIT_TEST
+
+namespace OCIO = OCIO_NAMESPACE;
+#include "UnitTest.h"
+
+
+
+OIIO_ADD_TEST(Exception, Basic)
+{
+    static const char* dummyErrorStr = "Dummy error";
+
+    // Test 0 - Trivial one...
+
+    try
+    {
+        throw OCIO::Exception(dummyErrorStr);
+    }
+    catch(const OCIO::Exception& ex)
+    {
+        OIIO_CHECK_EQUAL(strcmp(ex.what(), dummyErrorStr), 0);
+    }
+    catch(...)
+    {
+        OIIO_CHECK_ASSERT(!"Wrong exception type");
+    }
+
+    // Test 1
+
+    try
+    {
+        throw OCIO::Exception(dummyErrorStr);
+    }
+    catch(const std::exception& ex)
+    {
+        OIIO_CHECK_EQUAL(strcmp(ex.what(), dummyErrorStr), 0);
+    }
+    catch(...)
+    {
+        OIIO_CHECK_ASSERT(!"Wrong exception type");
+    }
+
+    // Test 2
+
+    try
+    {
+        OCIO::Exception ex(dummyErrorStr);
+        throw OCIO::Exception(ex);
+    }
+    catch(const std::exception& ex)
+    {
+        OIIO_CHECK_EQUAL(strcmp(ex.what(), dummyErrorStr), 0);
+    }
+    catch(...)
+    {
+        OIIO_CHECK_ASSERT(!"Wrong exception type");
+    }
+}
+
+
+OIIO_ADD_TEST(Exception, MissingFile)
+{
+    static const char* dummyErrorStr = "Dummy error";
+
+    try
+    {
+        throw OCIO::ExceptionMissingFile(dummyErrorStr);
+    }
+    catch(const std::exception& ex)
+    {
+        OIIO_CHECK_EQUAL(strcmp(ex.what(), dummyErrorStr), 0);
+    }
+    catch(...)
+    {
+        OIIO_CHECK_ASSERT(!"Wrong exception type");
+    }
+}
+
+#endif // OCIO_UNIT_TEST

--- a/src/core/Exception.cpp
+++ b/src/core/Exception.cpp
@@ -61,6 +61,7 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 #include "UnitTest.h"
 
+#include <string.h>
 
 
 OIIO_ADD_TEST(Exception, Basic)


### PR DESCRIPTION
The PR removes the private dependency on std::string from the public API.

That change was reverted from master in order to remove any changes from the OCIO public API for the 1.1 branch. Now that the branch is ready, I revert the revert :)  The global idea is to avoid any STL dependencies in a dynamic library public API.