### PR TITLE
add admin files for gh-pages deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,3 +54,4 @@ deploy:
   on:
     tags: true
   local_dir: ./docs/build-html
+  fqdn: opencolorio.org

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -142,6 +142,13 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/build-html/
         PATTERN .* EXCLUDE
 )
 
+if(TARGET doc)
+    message(STATUS "Copying admin doc files to deploy area")
+    file(COPY ${CMAKE_SOURCE_DIR}/docs/.nojekyll
+              ${CMAKE_SOURCE_DIR}/docs/google2560df9c4b755196.html
+         DESTINATION ${CMAKE_BINARY_DIR}/docs/build-html)
+endif()
+
 find_package(LATEX)
 if(PDFLATEX_COMPILER)
     

--- a/docs/google2560df9c4b755196.html
+++ b/docs/google2560df9c4b755196.html
@@ -1,0 +1,1 @@
+google-site-verification: google2560df9c4b755196.html


### PR DESCRIPTION
In order to fix gh-pages deployment the ".nojekyll" file has to be
added to avoid ignoring _* directories containing our images.