### PR TITLE
Improve the debug Mutex implementation to trap more problems

### DIFF
--- a/src/core/Context.cpp
+++ b/src/core/Context.cpp
@@ -75,16 +75,18 @@ namespace
         
         Impl& operator= (const Impl & rhs)
         {
-            AutoMutex lock1(resultsCacheMutex_);
-            AutoMutex lock2(rhs.resultsCacheMutex_);
-            
-            searchPath_ = rhs.searchPath_;
-            workingDir_ = rhs.workingDir_;
-            envMap_ = rhs.envMap_;
-            
-            resultsCache_ = rhs.resultsCache_;
-            cacheID_ = rhs.cacheID_;
-            
+            if(this!=&rhs)
+            {
+                AutoMutex lock1(resultsCacheMutex_);
+                AutoMutex lock2(rhs.resultsCacheMutex_);
+                
+                searchPath_ = rhs.searchPath_;
+                workingDir_ = rhs.workingDir_;
+                envMap_ = rhs.envMap_;
+                
+                resultsCache_ = rhs.resultsCache_;
+                cacheID_ = rhs.cacheID_;
+            }
             return *this;
         }
     };

--- a/src/core/Mutex.h
+++ b/src/core/Mutex.h
@@ -67,7 +67,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
 #include "Platform.h"
 
-// #define DEBUG_THREADING
 
 /** For internal use only */
 
@@ -75,15 +74,19 @@ OCIO_NAMESPACE_ENTER
 {
 
 #ifndef NDEBUG
+    // In debug mode, try to trap recursive cases and lock/unlock debalancing cases
     template <class T>
     class DebugLock : public T {
-     public:
-	DebugLock() : _locked(0) {}
-	void lock()   { T::lock(); _locked = 1; }
-	void unlock() { assert(_locked); _locked = 0; T::unlock(); }
-	bool locked() { return _locked != 0; }
-     private:
-	int _locked;
+        public:
+            DebugLock() : _locked(0) {}
+            ~DebugLock() { assert(!_locked); }
+
+            void lock()   { assert(!_locked); _locked = 1; T::lock(); }
+            void unlock() { assert(_locked); _locked = 0; T::unlock(); }
+
+            bool locked() { return _locked != 0; }
+        private:
+            int _locked;
     };
 #endif
 

--- a/src/core/Platform.h
+++ b/src/core/Platform.h
@@ -143,6 +143,8 @@ OCIO_NAMESPACE_ENTER
 #else
     // assume linux/unix/posix
 
+    // Note: Not recursive mutex implementation
+
     class _Mutex {
      public:
 	_Mutex()      { pthread_mutex_init(&_mutex, 0); }


### PR DESCRIPTION
Following some current development not yet reviewed, I faced some problem with the mutex class. The current implementation is recursive on Windows and not recursive on Linux. The current debug implementation was partially trapping that problem as well as the 'debalancing' lock/unlock.
Changed the debug implementation only to trap more problems.