### PR TITLE
Add matrix inverse unit tests for GPU and CPU

### DIFF
--- a/ext/oiio/src/include/unittest.h
+++ b/ext/oiio/src/include/unittest.h
@@ -35,6 +35,7 @@
 #include <cmath>
 #include <vector>
 #include <string>
+#include <iomanip>
 
 extern int unit_test_failures;
 
@@ -110,7 +111,8 @@ struct AddTest { AddTest(OIIOTest* test); };
 
 #define OIIO_CHECK_CLOSE(x,y,tol)                                       \
     ((std::abs((x) - (y)) < (tol)) ? ((void)0)                          \
-         : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
+         : ((std::cout << std::setprecision(10)                         \
+             << __FILE__ << ":" << __LINE__ << ":\n"                    \
              << "FAILED: abs(" << #x << " - " << #y << ") < " << #tol << "\n" \
              << "\tvalues were '" << (x) << "', '" << (y) << "' and '" << (tol) << "'\n"), \
             (void)++unit_test_failures))

--- a/src/core_gpu_tests/MatrixOps_test.cpp
+++ b/src/core_gpu_tests/MatrixOps_test.cpp
@@ -13,7 +13,23 @@ OCIO_NAMESPACE_USING
 
 
 
-const float epsilon = 1e-6f;
+// Helper method to build unit tests
+void AddMatrixTest(OCIOGPUTest & test, TransformDirection direction, 
+                   const float * m, const float * o, float epsilon)
+{
+    OCIO::MatrixTransformRcPtr matrix = OCIO::MatrixTransform::Create();
+    matrix->setDirection(direction);
+    if(m)
+    {
+        matrix->setMatrix(m);
+    }
+    if(o)
+    {
+        matrix->setOffset(o);
+    }
+
+    test.setContext(matrix->createEditableCopy(), epsilon);
+}
 
 
 OCIO_ADD_GPU_TEST(MatrixOps, matrix)
@@ -23,10 +39,7 @@ OCIO_ADD_GPU_TEST(MatrixOps, matrix)
                           0.2f, 0.1f, 1.1f, 0.2f,
                           0.3f, 0.4f, 0.5f, 1.6f };
 
-    OCIO::MatrixTransformRcPtr matrix = OCIO::MatrixTransform::Create();
-    matrix->setMatrix(m);
-
-    test.setContext(matrix->createEditableCopy(), epsilon);
+    AddMatrixTest(test, TRANSFORM_DIR_FORWARD, m, 0x0, 1e-6f);
 }
 
 
@@ -37,10 +50,7 @@ OCIO_ADD_GPU_TEST(MatrixOps, scale)
                           0.0f, 0.0f, 0.6f, 0.0f,
                           0.0f, 0.0f, 0.0f, 1.0f };
 
-    OCIO::MatrixTransformRcPtr matrix = OCIO::MatrixTransform::Create();
-    matrix->setMatrix(m);
-
-    test.setContext(matrix->createEditableCopy(), epsilon);
+    AddMatrixTest(test, TRANSFORM_DIR_FORWARD, m, 0x0, 1e-6f);
 }
 
 
@@ -48,10 +58,7 @@ OCIO_ADD_GPU_TEST(MatrixOps, offset)
 {
     const float o[4] = { -0.5f, +0.25f, -0.25f, 0.0f };
 
-    OCIO::MatrixTransformRcPtr matrix = OCIO::MatrixTransform::Create();
-    matrix->setOffset(o);
-
-    test.setContext(matrix->createEditableCopy(), epsilon);
+    AddMatrixTest(test, TRANSFORM_DIR_FORWARD, 0x0, o, 1e-6f);
 }
 
 
@@ -64,9 +71,48 @@ OCIO_ADD_GPU_TEST(MatrixOps, matrix_offset)
 
     const float o[4] = { -0.5f, -0.25f, 0.25f, 0.0f };
     
-    OCIO::MatrixTransformRcPtr matrix = OCIO::MatrixTransform::Create();
-    matrix->setMatrix(m);
-    matrix->setOffset(o);
+    AddMatrixTest(test, TRANSFORM_DIR_FORWARD, m, o, 1e-6f);
+}
 
-    test.setContext(matrix->createEditableCopy(), epsilon);
+
+OCIO_ADD_GPU_TEST(MatrixOps, matrix_inverse)
+{
+    const float m[16] = { 1.1f, 0.2f, 0.3f, 0.4f,
+                          0.5f, 1.6f, 0.7f, 0.8f,
+                          0.2f, 0.1f, 1.1f, 0.2f,
+                          0.3f, 0.4f, 0.5f, 1.6f };
+
+    AddMatrixTest(test, TRANSFORM_DIR_INVERSE, m, 0x0, 1e-5f);
+}
+
+
+OCIO_ADD_GPU_TEST(MatrixOps, scale_inverse)
+{
+    const float m[16] = { 1.0f, 0.0f, 0.0f, 0.0f,
+                          0.0f, -0.3f, 0.0f, 0.0f,
+                          0.0f, 0.0f, 0.6f, 0.0f,
+                          0.0f, 0.0f, 0.0f, 1.0f };
+
+    AddMatrixTest(test, TRANSFORM_DIR_INVERSE, m, 0x0, 1e-5f);
+}
+
+
+OCIO_ADD_GPU_TEST(MatrixOps, offset_inverse)
+{
+    const float o[4] = { -0.5f, +0.25f, -0.25f, 0.0f };
+
+    AddMatrixTest(test, TRANSFORM_DIR_INVERSE, 0x0, o, 1e-5f);
+}
+
+
+OCIO_ADD_GPU_TEST(MatrixOps, matrix_offset_inverse)
+{
+    const float m[16] = { 1.1f, 0.2f, 0.3f, 0.4f,
+                          0.5f, 1.6f, 0.7f, 0.8f,
+                          0.2f, 0.1f, 1.1f, 0.2f,
+                          0.3f, 0.4f, 0.5f, 1.6f };
+
+    const float o[4] = { -0.5f, -0.25f, 0.25f, 0.0f };
+    
+    AddMatrixTest(test, TRANSFORM_DIR_INVERSE, m, o, 1e-5f);
 }


### PR DESCRIPTION
The goal is to add more GPU & CPU unit tests around the matrix inverse.
I've also improved the error reporting to have a better float precision when printing the error.