### PR TITLE
Unit tests for ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,6 +475,7 @@ messageonce("Build GPU Unit Tests: ${OCIO_BUILD_GPU_TESTS}")
 if(OCIO_BUILD_GPU_TESTS)
     if(NOT OPENGL_FOUND OR NOT GLUT_FOUND OR NOT GLEW_FOUND OR NOT OCIO_BUILD_SHARED)
         messageonce("Not building gpu unit tests. Requirement(s) found, OpenColorIO:${OCIO_BUILD_SHARED}, OpenGL:${OPENGL_FOUND}, GLUT:${GLUT_FOUND}, GLEW:${GLEW_FOUND}")
+        set(OCIO_BUILD_GPU_TESTS OFF)
     else()
         add_subdirectory(src/core_gpu_tests)
     endif()
@@ -575,9 +576,17 @@ include(CPack)
 ###############################################################################
 ### CTEST ###
 
+if(OCIO_BUILD_TESTS)
+    set(TEST_DEPENDS ocio_core_tests)
+endif()
+
+if(OCIO_BUILD_GPU_TESTS)
+    set(TEST_DEPENDS ${TEST_DEPENDS} ocio_core_gpu_tests)
+endif()
+
 add_custom_target(test_verbose
                   COMMAND ctest -VV
-                  DEPENDS ocio_core_tests ocio_core_gpu_tests
+                  DEPENDS ${TEST_DEPENDS}
                   COMMENT "Running ctest with verbose output")
 
 # Log CMake first run done

--- a/ext/oiio/src/include/unittest.h
+++ b/ext/oiio/src/include/unittest.h
@@ -123,6 +123,23 @@ struct AddTest { AddTest(OIIOTest* test); };
         << "FAILED: " << #E << " is expected to be thrown\n";           \
         ++unit_test_failures; }
 
+// Check that an exception E is thrown and that what() contains W
+// When a function can throw different exceptions this can be used
+// to verify that the right one is thrown.
+#define OIIO_CHECK_THROW_WHAT(S, E, W)                                  \
+    try { S; throw "throwanything"; } catch (E const& ex) {             \
+        std::string what(ex.what());                                    \
+        if (what.find(W) == std::string::npos) {                        \
+            std::cout << __FILE__ << ":" << __LINE__ << ":\n"           \
+            << "FAILED: " << #E << " was thrown with \"" << what <<     \
+            "\". Expecting to contain \"" << W << "\"\n";               \
+            ++unit_test_failures;                                       \
+        }                                                               \
+    } catch (...) {                                                     \
+        std::cout << __FILE__ << ":" << __LINE__ << ":\n"               \
+        << "FAILED: " << #E << " is expected to be thrown\n";           \
+        ++unit_test_failures; }
+
 #define OIIO_CHECK_NO_THROW(S)                                          \
     try {                                                               \
         S;                                                              \

--- a/src/core/AllocationOp.cpp
+++ b/src/core/AllocationOp.cpp
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Op.h"
 
 #include <OpenColorIO/OpenColorIO.h>
+#include <string.h>
 
 OCIO_NAMESPACE_ENTER
 {
@@ -126,3 +127,168 @@ OCIO_NAMESPACE_ENTER
     
 }
 OCIO_NAMESPACE_EXIT
+
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef OCIO_UNIT_TEST
+
+OCIO_NAMESPACE_USING
+
+namespace OCIO = OCIO_NAMESPACE;
+#include "UnitTest.h"
+
+OIIO_ADD_TEST(AllocationOps, Create)
+{
+    OpRcPtrVec ops;
+    AllocationData allocData;
+    allocData.allocation = ALLOCATION_UNKNOWN;
+    OIIO_CHECK_THROW_WHAT(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_FORWARD),
+        OCIO::Exception, "Unsupported Allocation Type");
+    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OIIO_CHECK_THROW_WHAT(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_INVERSE),
+        OCIO::Exception, "Unsupported Allocation Type");
+    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OIIO_CHECK_THROW_WHAT(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_UNKNOWN),
+        OCIO::Exception, "Unsupported Allocation Type");
+    OIIO_CHECK_EQUAL(ops.size(), 0);
+
+    allocData.allocation = ALLOCATION_UNIFORM;
+    // No allocation data leads to identity, not transform will be created
+    OIIO_CHECK_NO_THROW(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_UNKNOWN));
+    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OIIO_CHECK_NO_THROW(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OIIO_CHECK_NO_THROW(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_INVERSE));
+    OIIO_CHECK_EQUAL(ops.size(), 0);
+
+    // adding data to avoid identity. Fit transform will be created (if valid).
+    allocData.vars.push_back(0.0f);
+    allocData.vars.push_back(10.0f);
+    OIIO_CHECK_THROW_WHAT(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_UNKNOWN),
+        OCIO::Exception, "unspecified transform direction");
+    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OIIO_CHECK_NO_THROW(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_EQUAL(ops.size(), 1);
+    const OpRcPtr forwardFitOp = ops[0];
+    ops.clear();
+    OIIO_CHECK_NO_THROW(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_INVERSE));
+    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OIIO_CHECK_EQUAL(forwardFitOp->isInverse(ops[0]), true);
+    ops.clear();
+
+    allocData.allocation = ALLOCATION_LG2;
+
+    // default is not identity
+    allocData.vars.clear();
+    OIIO_CHECK_NO_THROW(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_EQUAL(ops.size(), 2);
+    // second op is a fit transform
+    OIIO_CHECK_EQUAL(forwardFitOp->isSameType(ops[1]), true);
+    OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops));
+    OIIO_CHECK_EQUAL(ops.size(), 2);
+    const OpRcPtr defaultLogOp = ops[0];
+    const OpRcPtr defaultFitOp = ops[1];
+
+    const float error = 1e-6f;
+    const unsigned NB_PIXELS = 3;
+    const float src[NB_PIXELS * 4] = {
+         0.16f,  0.2f,  0.3f,   0.4f,
+        -0.16f, -0.2f, 32.0f, 123.4f,
+         1.0f,  1.0f,  1.0f,   1.0f };
+
+    const float dstLog[NB_PIXELS * 4] = {
+        -2.64385629f,  -2.32192802f,  -1.73696554f,   0.4f,
+        -126.0f, -126.0f, 5.0f, 123.4f,
+        0.0f,  0.0f,  0.0f,   1.0f };
+
+    const float dstFit[NB_PIXELS * 4] = {
+        0.635f,  0.6375f, 0.64375f, 0.4f,
+        0.615f,  0.6125f, 2.625f, 123.4f,
+        0.6875f, 0.6875f, 0.6875f,  1.0f };
+
+    float tmp[NB_PIXELS * 4];
+    memcpy(tmp, &src[0], 4 * NB_PIXELS * sizeof(float));
+
+    ops[0]->apply(tmp, NB_PIXELS);
+
+    for (unsigned idx = 0; idx<(NB_PIXELS * 4); ++idx)
+    {
+        OIIO_CHECK_CLOSE(dstLog[idx], tmp[idx], error);
+    }
+
+    memcpy(tmp, &src[0], 4 * NB_PIXELS * sizeof(float));
+
+    ops[1]->apply(tmp, NB_PIXELS);
+
+    for (unsigned idx = 0; idx<(NB_PIXELS * 4); ++idx)
+    {
+        OIIO_CHECK_CLOSE(dstFit[idx], tmp[idx], error);
+    }
+
+    ops.clear();
+
+    OIIO_CHECK_NO_THROW(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_INVERSE));
+    OIIO_CHECK_EQUAL(ops.size(), 2);
+    OIIO_CHECK_EQUAL(defaultFitOp->isInverse(ops[0]), true);
+    OIIO_CHECK_EQUAL(defaultLogOp->isInverse(ops[1]), true);
+
+    ops.clear();
+    OIIO_CHECK_THROW_WHAT(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_UNKNOWN),
+        OCIO::Exception, "unspecified transform direction");
+    OIIO_CHECK_EQUAL(ops.size(), 0);
+
+    // adding data to target identity, only Log op is created (if valid)
+    allocData.vars.push_back(0.0f);
+    allocData.vars.push_back(1.0f);
+
+    OIIO_CHECK_NO_THROW(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OIIO_CHECK_EQUAL(defaultLogOp->isSameType(ops[0]), true);
+    ops.clear();
+    OIIO_CHECK_NO_THROW(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_INVERSE));
+    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OIIO_CHECK_EQUAL(defaultLogOp->isSameType(ops[0]), true);
+    ops.clear();
+    OIIO_CHECK_THROW_WHAT(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_UNKNOWN),
+        OCIO::Exception, "unspecified transform direction");
+    OIIO_CHECK_EQUAL(ops.size(), 0);
+
+    // change log intercept
+    allocData.vars.push_back(10.0f);
+    OIIO_CHECK_NO_THROW(
+        CreateAllocationOps(ops, allocData, TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_EQUAL(ops.size(), 1);
+    ops[0]->finalize();
+
+    memcpy(tmp, &src[0], 4 * NB_PIXELS * sizeof(float));
+
+    const float dstLogShift[NB_PIXELS * 4] = {
+        3.34482837f, 3.35049725f, 3.36457253f, 0.4f,
+        3.29865813f, 3.29278183f, 5.39231730f, 123.4f,
+        3.45943165f, 3.45943165f, 3.45943165f, 1.0f };
+
+    ops[0]->apply(tmp, NB_PIXELS);
+
+    for (unsigned idx = 0; idx<(NB_PIXELS * 4); ++idx)
+    {
+        OIIO_CHECK_CLOSE(dstLogShift[idx], tmp[idx], error);
+    }
+
+}
+
+#endif

--- a/src/core/LogOps.cpp
+++ b/src/core/LogOps.cpp
@@ -386,17 +386,17 @@ namespace OCIO = OCIO_NAMESPACE;
 
 OIIO_ADD_TEST(LogOps, LinToLog)
 {
-    float k[3] = { 0.18f, 0.18f, 0.18f };
-    float m[3] = { 2.0f, 2.0f, 2.0f };
-    float b[3] = { 0.1f, 0.1f, 0.1f };
-    float base[3] = { 10.0f, 10.0f, 10.0f };
-    float kb[3] = { 1.0f, 1.0f, 1.0f };
+    const float k[3] = { 0.18f, 0.18f, 0.18f };
+    const float m[3] = { 2.0f, 2.0f, 2.0f };
+    const float b[3] = { 0.1f, 0.1f, 0.1f };
+    const float base[3] = { 10.0f, 10.0f, 10.0f };
+    const float kb[3] = { 1.0f, 1.0f, 1.0f };
     
     
     float data[8] = { 0.01f, 0.1f, 1.0f, 1.0f,
                       10.0f, 100.0f, 1000.0f, 1.0f, };
     
-    float result[8] = { 0.8342526242885725f,
+    const float result[8] = { 0.8342526242885725f,
                         0.90588182584953925f,
                         1.057999473052105462f,
                         1.0f,
@@ -406,9 +406,23 @@ OIIO_ADD_TEST(LogOps, LinToLog)
                         1.0f };
     
     OCIO::OpRcPtrVec ops;
-    CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_FORWARD);
-    
-    FinalizeOpVec(ops);
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_FORWARD));
+
+    // one operator has been created
+    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OIIO_CHECK_NE(ops[0], NULL);
+
+    // no chache ID before operator has been finalized
+    std::string opCache = ops[0]->getCacheID();
+    OIIO_CHECK_EQUAL(opCache.size(), 0);
+
+    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
+
+    // validate properties
+    opCache = ops[0]->getCacheID();
+    OIIO_CHECK_NE(opCache.size(), 0);
+    OIIO_CHECK_EQUAL(ops[0]->isNoOp(), false);
+    OIIO_CHECK_EQUAL(ops[0]->hasChannelCrosstalk(), false);
     
     // Apply the result
     for(OCIO::OpRcPtrVec::size_type i = 0, size = ops.size(); i < size; ++i)
@@ -424,11 +438,11 @@ OIIO_ADD_TEST(LogOps, LinToLog)
 
 OIIO_ADD_TEST(LogOps, LogToLin)
 {
-    float k[3] = { 0.18f, 0.18f, 0.18f };
-    float m[3] = { 2.0f, 2.0f, 2.0f };
-    float b[3] = { 0.1f, 0.1f, 0.1f };
-    float base[3] = { 10.0f, 10.0f, 10.0f };
-    float kb[3] = { 1.0f, 1.0f, 1.0f };
+    const float k[3] = { 0.18f, 0.18f, 0.18f };
+    const float m[3] = { 2.0f, 2.0f, 2.0f };
+    const float b[3] = { 0.1f, 0.1f, 0.1f };
+    const float base[3] = { 10.0f, 10.0f, 10.0f };
+    const float kb[3] = { 1.0f, 1.0f, 1.0f };
     
     float data[8] = { 0.8342526242885725f,
                       0.90588182584953925f,
@@ -439,13 +453,13 @@ OIIO_ADD_TEST(LogOps, LogToLin)
                       1.59418930777214063f,
                       1.0f };
     
-    float result[8] = { 0.01f, 0.1f, 1.0f, 1.0f,
+    const float result[8] = { 0.01f, 0.1f, 1.0f, 1.0f,
                         10.0f, 100.0f, 1000.0f, 1.0f, };
     
     OCIO::OpRcPtrVec ops;
-    CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_INVERSE);
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_INVERSE));
     
-    FinalizeOpVec(ops);
+    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
     
     // Apply the result
     for(OCIO::OpRcPtrVec::size_type i = 0, size = ops.size(); i < size; ++i)
@@ -461,20 +475,20 @@ OIIO_ADD_TEST(LogOps, LogToLin)
 
 OIIO_ADD_TEST(LogOps, Inverse)
 {
-    float k[3] = { 0.18f, 0.5f, 0.3f };
-    float m[3] = { 2.0f, 4.0f, 8.0f };
-    float b[3] = { 0.1f, 0.1f, 0.1f };
+    const float k[3] = { 0.18f, 0.5f, 0.3f };
+    const float m[3] = { 2.0f, 4.0f, 8.0f };
+    const float b[3] = { 0.1f, 0.1f, 0.1f };
     float base[3] = { 10.0f, 5.0f, 2.0f };
-    float kb[3] = { 1.0f, 1.0f, 1.0f };
+    const float kb[3] = { 1.0f, 1.0f, 1.0f };
     
     OCIO::OpRcPtrVec ops;
-    CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_FORWARD);
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_FORWARD));
     
-    CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_INVERSE);
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_INVERSE));
     
     base[0] += 1e-5f;
-    CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_INVERSE);
-    CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_FORWARD);
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_INVERSE));
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_FORWARD));
     
     OIIO_CHECK_EQUAL(ops.size(), 4);
     
@@ -496,7 +510,7 @@ OIIO_ADD_TEST(LogOps, Inverse)
     
     OIIO_CHECK_EQUAL(ops[3]->isInverse(ops[3]), false);
 
-    float result[12] = { 0.01f, 0.1f, 1.0f, 1.0f,
+    const float result[12] = { 0.01f, 0.1f, 1.0f, 1.0f,
                         1.0f, 10.0f, 100.0f, 1.0f,
                         1000.0f, 1.0f, 0.5f, 1.0f
                       };
@@ -524,6 +538,155 @@ OIIO_ADD_TEST(LogOps, Inverse)
     {
         OIIO_CHECK_CLOSE( data[i], result[i], 1.0e-3 );
     }
+}
+
+OIIO_ADD_TEST(LogOps, CacheID)
+{
+    const float k[3] = { 0.18f, 0.18f, 0.18f };
+    const float m[3] = { 2.0f, 2.0f, 2.0f };
+    const float b[3] = { 0.1f, 0.1f, 0.1f };
+    const float base[3] = { 10.0f, 10.0f, 10.0f };
+    float kb[3] = { 1.0f, 1.0f, 1.0f };
+
+    OCIO::OpRcPtrVec ops;
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_FORWARD));
+    kb[0] += 1.0f;
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_FORWARD));
+    kb[0] -= 1.0f;
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_FORWARD));
+
+    // 3 operators have been created
+    OIIO_CHECK_EQUAL(ops.size(), 3);
+    OIIO_CHECK_NE(ops[0], NULL);
+    OIIO_CHECK_NE(ops[1], NULL);
+    OIIO_CHECK_NE(ops[2], NULL);
+
+    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
+
+    const std::string opCacheID0 = ops[0]->getCacheID();
+    const std::string opCacheID1 = ops[1]->getCacheID();
+    const std::string opCacheID2 = ops[2]->getCacheID();
+    OIIO_CHECK_EQUAL(opCacheID0, opCacheID2);
+    OIIO_CHECK_NE(opCacheID0, opCacheID1);
+}
+
+OIIO_ADD_TEST(LogOps, ThrowDirection)
+{
+    const float k[3] = { 0.18f, 0.18f, 0.18f };
+    const float m[3] = { 2.0f, 2.0f, 2.0f };
+    const float b[3] = { 0.1f, 0.1f, 0.1f };
+    const float base[3] = { 10.0f, 10.0f, 10.0f };
+    const float kb[3] = { 1.0f, 1.0f, 1.0f };
+
+    OCIO::OpRcPtrVec ops;
+    OIIO_CHECK_THROW_WHAT(
+        CreateLogOp(ops, k, m, b, base, kb, OCIO::TRANSFORM_DIR_UNKNOWN),
+        OCIO::Exception, "unspecified transform direction");
+}
+
+OIIO_ADD_TEST(LogOps, ThrowBase)
+{
+    const float k[3] = { 0.18f, 0.18f, 0.18f };
+    const float m[3] = { 2.0f, 2.0f, 2.0f };
+    const float b[3] = { 0.1f, 0.1f, 0.1f };
+    const float base0[3] = { 1.0f, 10.0f, 10.0f };
+    const float base1[3] = { 10.0f, 1.0f, 10.0f };
+    const float base2[3] = { 10.0f, 10.0f, 1.0f };
+    const float kb[3] = { 1.0f, 1.0f, 1.0f };
+
+    // Can't use base 1 for forward log transform
+    OCIO::OpRcPtrVec ops;
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m, b, base0, kb, OCIO::TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_THROW_WHAT(FinalizeOpVec(ops),
+        OCIO::Exception, "base cannot be 1");
+
+    ops.clear();
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m, b, base1, kb, OCIO::TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_THROW_WHAT(FinalizeOpVec(ops),
+        OCIO::Exception, "base cannot be 1");
+
+    ops.clear();
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m, b, base2, kb, OCIO::TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_THROW_WHAT(FinalizeOpVec(ops),
+        OCIO::Exception, "base cannot be 1");
+
+    // Base 1 is valid for inverse log transform
+    ops.clear();
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m, b, base0, kb, OCIO::TRANSFORM_DIR_INVERSE));
+    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
+
+    const std::string opCacheID = ops[0]->getCacheID();
+    OIIO_CHECK_NE(opCacheID.size(), 0);
+}
+
+OIIO_ADD_TEST(LogOps, ThrowSlope)
+{
+    const float k[3] = { 0.18f, 0.18f, 0.18f };
+    const float m0[3] = { 0.0f, 2.0f, 2.0f };
+    const float m1[3] = { 2.0f, 0.0f, 2.0f };
+    const float m2[3] = { 2.0f, 2.0f, 0.0f };
+    const float b[3] = { 0.1f, 0.1f, 0.1f };
+    const float base[3] = { 10.0f, 10.0f, 10.0f };
+    const float kb[3] = { 1.0f, 1.0f, 1.0f };
+
+    // Can't use slope 0 for inverse log transform
+    OCIO::OpRcPtrVec ops;
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m0, b, base, kb, OCIO::TRANSFORM_DIR_INVERSE));
+    OIIO_CHECK_THROW_WHAT(FinalizeOpVec(ops),
+        OCIO::Exception, "m (slope) cannot be 0");
+    ops.clear();
+
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m1, b, base, kb, OCIO::TRANSFORM_DIR_INVERSE));
+    OIIO_CHECK_THROW_WHAT(FinalizeOpVec(ops),
+        OCIO::Exception, "m (slope) cannot be 0");
+    ops.clear();
+
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m2, b, base, kb, OCIO::TRANSFORM_DIR_INVERSE));
+    OIIO_CHECK_THROW_WHAT(FinalizeOpVec(ops),
+        OCIO::Exception, "m (slope) cannot be 0");
+    ops.clear();
+
+    // Slope 0 is valid for forward log transform
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k, m0, b, base, kb, OCIO::TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
+
+    const std::string opCacheID = ops[0]->getCacheID();
+    OIIO_CHECK_NE(opCacheID.size(), 0);
+}
+
+OIIO_ADD_TEST(LogOps, ThrowMultiplier)
+{
+    const float k0[3] = { 0.0f, 0.18f, 0.18f };
+    const float k1[3] = { 0.18f, 0.0f, 0.18f };
+    const float k2[3] = { 0.18f, 0.18f, 0.0f };
+    const float m[3] = { 2.0f, 2.0f, 2.0f };
+    const float b[3] = { 0.1f, 0.1f, 0.1f };
+    const float base[3] = { 10.0f, 10.0f, 10.0f };
+    const float kb[3] = { 1.0f, 1.0f, 1.0f };
+
+    // Can't use multiplier 0 for inverse log transform
+    OCIO::OpRcPtrVec ops;
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k0, m, b, base, kb, OCIO::TRANSFORM_DIR_INVERSE));
+    OIIO_CHECK_THROW_WHAT(FinalizeOpVec(ops),
+        OCIO::Exception, "k (multiplier) cannot be 0");
+    ops.clear();
+
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k1, m, b, base, kb, OCIO::TRANSFORM_DIR_INVERSE));
+    OIIO_CHECK_THROW_WHAT(FinalizeOpVec(ops),
+        OCIO::Exception, "k (multiplier) cannot be 0");
+    ops.clear();
+
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k2, m, b, base, kb, OCIO::TRANSFORM_DIR_INVERSE));
+    OIIO_CHECK_THROW_WHAT(FinalizeOpVec(ops),
+        OCIO::Exception, "k (multiplier) cannot be 0");
+    ops.clear();
+
+    // Multiplier 0 is valid for forward log transform
+    OIIO_CHECK_NO_THROW(CreateLogOp(ops, k0, m, b, base, kb, OCIO::TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
+
+    const std::string opCacheID = ops[0]->getCacheID();
+    OIIO_CHECK_NE(opCacheID.size(), 0);
 }
 
 #endif // OCIO_UNIT_TEST

--- a/src/core/Lut1DOp.cpp
+++ b/src/core/Lut1DOp.cpp
@@ -678,10 +678,10 @@ OIIO_ADD_TEST(Lut1DOp, NoOp)
     lut->from_max[1] = 1.0f;
     lut->from_max[2] = 1.0f;
     
-    int size = 256;
+    const int size = 256;
     for(int i=0; i<size; ++i)
     {
-        float x = (float)i / (float)(size-1);
+        const float x = (float)i / (float)(size-1);
         for(int c=0; c<3; ++c)
         {
             lut->luts[c].push_back(x);
@@ -690,12 +690,20 @@ OIIO_ADD_TEST(Lut1DOp, NoOp)
     
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::ERROR_RELATIVE;
-    OIIO_CHECK_EQUAL(lut->isNoOp(), true);
+    bool isNoOp = false;
+    OIIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
+    OIIO_CHECK_EQUAL(isNoOp, true);
     
     lut->unfinalize();
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::ERROR_ABSOLUTE;
-    OIIO_CHECK_EQUAL(lut->isNoOp(), true);
+    OIIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
+    OIIO_CHECK_EQUAL(isNoOp, true);
+
+    OCIO::OpRcPtrVec ops;
+    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut,
+        OCIO::INTERP_NEAREST, OCIO::TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_EQUAL(ops.size(), 0);
     
     // Edit the lut
     // These should NOT be identity
@@ -703,12 +711,14 @@ OIIO_ADD_TEST(Lut1DOp, NoOp)
     lut->luts[0][125] += 1e-3f;
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::ERROR_RELATIVE;
-    OIIO_CHECK_EQUAL(lut->isNoOp(), false);
+    OIIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
+    OIIO_CHECK_EQUAL(isNoOp, false);
     
     lut->unfinalize();
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::ERROR_ABSOLUTE;
-    OIIO_CHECK_EQUAL(lut->isNoOp(), false);
+    OIIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
+    OIIO_CHECK_EQUAL(isNoOp, false);
 }
 
 
@@ -724,11 +734,11 @@ OIIO_ADD_TEST(Lut1DOp, FiniteValue)
     lut->from_max[1] = 1.0f;
     lut->from_max[2] = 1.0f;
     
-    int size = 256;
+    const int size = 256;
     for(int i=0; i<size; ++i)
     {
-        float x = (float)i / (float)(size-1);
-        float x2 = x*x;
+        const float x = (float)i / (float)(size-1);
+        const float x2 = x*x;
         
         for(int c=0; c<3; ++c)
         {
@@ -738,10 +748,12 @@ OIIO_ADD_TEST(Lut1DOp, FiniteValue)
     
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::ERROR_RELATIVE;
-    OIIO_CHECK_EQUAL(lut->isNoOp(), false);
+    bool isNoOp = true;
+    OIIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
+    OIIO_CHECK_EQUAL(isNoOp, false);
     
     float inputBuffer_linearforward[4] = { 0.5f, 0.6f, 0.7f, 0.5f };
-    float outputBuffer_linearforward[4] = { 0.25f, 0.36f, 0.49f, 0.5f };
+    const float outputBuffer_linearforward[4] = { 0.25f, 0.36f, 0.49f, 0.5f };
     OCIO::Lut1D_Linear(inputBuffer_linearforward, 1, *lut);
     for(int i=0; i <4; ++i)
     {
@@ -749,14 +761,14 @@ OIIO_ADD_TEST(Lut1DOp, FiniteValue)
     }
     
     float inputBuffer_nearestforward[4] = { 0.5f, 0.6f, 0.7f, 0.5f };
-    float outputBuffer_nearestforward[4] = { 0.25f, 0.36f, 0.49f, 0.5f };
+    const float outputBuffer_nearestforward[4] = { 0.2519647f, 0.36f, 0.492749f, 0.5f };
     OCIO::Lut1D_Nearest(inputBuffer_nearestforward, 1, *lut);
     for(int i=0; i <4; ++i)
     {
-        OIIO_CHECK_CLOSE(inputBuffer_nearestforward[i], outputBuffer_nearestforward[i], 1e-2f);
+        OIIO_CHECK_CLOSE(inputBuffer_nearestforward[i], outputBuffer_nearestforward[i], 1e-5f);
     }
     
-    float inputBuffer_linearinverse[4] = { 0.5f, 0.6f, 0.7f, 0.5f };
+    const float inputBuffer_linearinverse[4] = { 0.5f, 0.6f, 0.7f, 0.5f };
     float outputBuffer_linearinverse[4] = { 0.25f, 0.36f, 0.49f, 0.5f };
     OCIO::Lut1D_LinearInverse(outputBuffer_linearinverse, 1, *lut);
     for(int i=0; i <4; ++i)
@@ -764,12 +776,12 @@ OIIO_ADD_TEST(Lut1DOp, FiniteValue)
         OIIO_CHECK_CLOSE(inputBuffer_linearinverse[i], outputBuffer_linearinverse[i], 1e-5f);
     }
     
-    float inputBuffer_nearestinverse[4] = { 0.5f, 0.6f, 0.7f, 0.5f };
+    const float inputBuffer_nearestinverse[4] = { 0.498039f, 0.6f, 0.698039f, 0.5f };
     float outputBuffer_nearestinverse[4] = { 0.25f, 0.36f, 0.49f, 0.5f };
     OCIO::Lut1D_NearestInverse(outputBuffer_nearestinverse, 1, *lut);
     for(int i=0; i <4; ++i)
     {
-        OIIO_CHECK_CLOSE(inputBuffer_nearestinverse[i], outputBuffer_nearestinverse[i], 1e-2f);
+        OIIO_CHECK_CLOSE(inputBuffer_nearestinverse[i], outputBuffer_nearestinverse[i], 1e-5f);
     }
 }
 
@@ -795,19 +807,23 @@ OIIO_ADD_TEST(Lut1DOp, ExtrapolationErrors)
 
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::ERROR_RELATIVE;
-    OIIO_CHECK_EQUAL(lut->isNoOp(), false);
+    bool isNoOp = true;
+    OIIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
+    OIIO_CHECK_EQUAL(isNoOp, false);
 
     const int PIXELS = 5;
-    float inputBuffer_linearforward[PIXELS*4] = { -0.1f, -0.2f, -10.0f, 0.0f,
-                                                   0.5f, 1.0f, 1.1f, 0.0f,
-                                                   10.1f, 55.0f, 2.3f, 0.0f,
-                                                   9.1f, 1.0e6f, 1.0e9f, 0.0f,
-                                                   4.0e9f, 9.5e7f, 0.5f, 0.0f };
-    float outputBuffer_linearforward[PIXELS*4] = { 0.1f, 0.1f, 0.1f, 0.0f,
-                                                   0.6f, 1.1f, 1.1f, 0.0f,
-                                                   1.1f, 1.1f, 1.1f, 0.0f,
-                                                   1.1f, 1.1f, 1.1f, 0.0f,
-                                                   1.1f, 1.1f, 0.6f, 0.0f };
+    float inputBuffer_linearforward[PIXELS*4] = {
+        -0.1f, -0.2f, -10.0f, 0.0f,
+        0.5f, 1.0f, 1.1f, 0.0f,
+        10.1f, 55.0f, 2.3f, 0.0f,
+        9.1f, 1.0e6f, 1.0e9f, 0.0f,
+        4.0e9f, 9.5e7f, 0.5f, 0.0f };
+    const float outputBuffer_linearforward[PIXELS*4] = {
+        0.1f, 0.1f, 0.1f, 0.0f,
+        0.6f, 1.1f, 1.1f, 0.0f,
+        1.1f, 1.1f, 1.1f, 0.0f,
+        1.1f, 1.1f, 1.1f, 0.0f,
+        1.1f, 1.1f, 0.6f, 0.0f };
     OCIO::Lut1D_Linear(inputBuffer_linearforward, PIXELS, *lut);
     for(size_t i=0; i <sizeof(inputBuffer_linearforward)/sizeof(inputBuffer_linearforward[0]); ++i)
     {
@@ -827,11 +843,11 @@ OIIO_ADD_TEST(Lut1DOp, Inverse)
     lut_a->from_max[0] = 1.0f;
     lut_a->from_max[1] = 1.0f;
     lut_a->from_max[2] = 1.0f;
-    int size = 256;
+    const int size = 256;
     for(int i=0; i<size; ++i)
     {
-        float x = (float)i / (float)(size-1);
-        float x2 = x*x;
+        const float x = (float)i / (float)(size-1);
+        const float x2 = x*x;
         
         for(int c=0; c<3; ++c)
         {
@@ -851,11 +867,11 @@ OIIO_ADD_TEST(Lut1DOp, Inverse)
     lut_b->from_max[0] = 1.0f;
     lut_b->from_max[1] = 1.0f;
     lut_b->from_max[2] = 1.0f;
-    int size = 256;
+    const int size = 256;
     for(int i=0; i<size; ++i)
     {
-        float x = (float)i / (float)(size-1);
-        float x2 = x*x;
+        const float x = (float)i / (float)(size-1);
+        const float x2 = x*x;
         
         for(int c=0; c<3; ++c)
         {
@@ -867,22 +883,43 @@ OIIO_ADD_TEST(Lut1DOp, Inverse)
     }
     
     OCIO::OpRcPtrVec ops;
-    CreateLut1DOp(ops, lut_a, OCIO::INTERP_NEAREST, OCIO::TRANSFORM_DIR_FORWARD);
-    CreateLut1DOp(ops, lut_a, OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_INVERSE);
-    CreateLut1DOp(ops, lut_b, OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_FORWARD);
-    CreateLut1DOp(ops, lut_b, OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_INVERSE);
+    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut_a,
+        OCIO::INTERP_NEAREST, OCIO::TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut_a,
+        OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_INVERSE));
+    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut_b,
+        OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut_b,
+        OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_INVERSE));
     
     OIIO_CHECK_EQUAL(ops.size(), 4);
     
     OIIO_CHECK_ASSERT(ops[0]->isSameType(ops[1]));
     OIIO_CHECK_ASSERT(ops[0]->isSameType(ops[2]));
-    OIIO_CHECK_ASSERT(ops[0]->isSameType(ops[3]->clone()));
-    
+    OCIO::OpRcPtr clonedOp;
+    OIIO_CHECK_NO_THROW(clonedOp = ops[3]->clone());
+    OIIO_CHECK_ASSERT(ops[0]->isSameType(clonedOp));
+
     OIIO_CHECK_EQUAL( ops[0]->isInverse(ops[1]), true);
     OIIO_CHECK_EQUAL( ops[0]->isInverse(ops[2]), false);
     OIIO_CHECK_EQUAL( ops[0]->isInverse(ops[2]), false);
     OIIO_CHECK_EQUAL( ops[0]->isInverse(ops[3]), false);
     OIIO_CHECK_EQUAL( ops[2]->isInverse(ops[3]), true);
+
+    // add same as first
+    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut_a,
+        OCIO::INTERP_NEAREST, OCIO::TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_EQUAL(ops.size(), 5);
+
+    OCIO::FinalizeOpVec(ops, false);
+    OIIO_CHECK_EQUAL(ops.size(), 5);
+
+    OIIO_CHECK_EQUAL(ops[0]->getCacheID(), ops[4]->getCacheID());
+    OIIO_CHECK_NE(ops[2]->getCacheID(), ops[3]->getCacheID());
+
+    // optimize will remove forward and inverse (0+1 and 2+3)
+    OCIO::FinalizeOpVec(ops, true);
+    OIIO_CHECK_EQUAL(ops.size(), 1);
 }
 
 
@@ -899,11 +936,11 @@ OIIO_ADD_TEST(Lut1DOp, SSE)
     lut->from_max[1] = 1.0f;
     lut->from_max[2] = 1.0f;
     
-    int size = 256;
+    const int size = 256;
     for(int i=0; i<size; ++i)
     {
-        float x = (float)i / (float)(size-1);
-        float x2 = x*x;
+        const float x = (float)i / (float)(size-1);
+        const float x2 = x*x;
         
         for(int c=0; c<3; ++c)
         {
@@ -913,15 +950,17 @@ OIIO_ADD_TEST(Lut1DOp, SSE)
     
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::ERROR_RELATIVE;
-    OIIO_CHECK_EQUAL(lut->isNoOp(), false);
-    
-    int NUM_TEST_PIXELS = 1024;
+    bool isNoOp = true;
+    OIIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
+    OIIO_CHECK_EQUAL(isNoOp, false);
+
+    const int NUM_TEST_PIXELS = 1024;
     std::vector<float> testValues(NUM_TEST_PIXELS*4);
     std::vector<float> outputBuffer_cpu(NUM_TEST_PIXELS*4);
     std::vector<float> outputBuffer_sse(NUM_TEST_PIXELS*4);
     
     float val = -1.0f;
-    float delta = 0.00123456789f;
+    const float delta = 0.00123456789f;
     
     for(int i=0; i<NUM_TEST_PIXELS*4; ++i)
     {
@@ -1077,6 +1116,163 @@ OIIO_ADD_TEST(Lut1DOp, NanInf)
         }
     }
     */
+}
+
+OIIO_ADD_TEST(Lut1DOp, ThrowNoOp)
+{
+    // Make an identity lut
+    OCIO::Lut1DRcPtr lut = OCIO::Lut1D::Create();
+    lut->from_min[0] = 0.0f;
+    lut->from_min[1] = 0.0f;
+    lut->from_min[2] = 0.0f;
+
+    lut->from_max[0] = 1.0f;
+    lut->from_max[1] = 1.0f;
+    lut->from_max[2] = 1.0f;
+
+    const int size = 2;
+    for (int i = 0; i < size; ++i)
+    {
+        const float x = (float)i / (float)(size - 1);
+        for (int c = 0; c < 3; ++c)
+        {
+            lut->luts[c].push_back(x);
+        }
+    }
+
+    lut->maxerror = 1e-5f;
+    lut->errortype = (OCIO::ErrorType)0;
+    OIIO_CHECK_THROW_WHAT(lut->isNoOp(),
+        OCIO::Exception, "Unknown error type");
+
+    lut->errortype = OCIO::ERROR_RELATIVE;
+    OIIO_CHECK_NO_THROW(lut->isNoOp());
+    lut->unfinalize();
+
+    lut->luts[0].clear();
+    OIIO_CHECK_THROW_WHAT(lut->isNoOp(),
+        OCIO::Exception, "invalid Lut1D");
+
+    lut->luts[0] = lut->luts[1];
+    lut->luts[1].clear();
+    OIIO_CHECK_THROW_WHAT(lut->isNoOp(),
+        OCIO::Exception, "invalid Lut1D");
+
+    lut->luts[1] = lut->luts[2];
+    lut->luts[2].clear();
+    OIIO_CHECK_THROW_WHAT(lut->isNoOp(),
+        OCIO::Exception, "invalid Lut1D");
+
+    lut->luts[2] = lut->luts[0];
+    OIIO_CHECK_NO_THROW(lut->isNoOp());
+}
+
+OIIO_ADD_TEST(Lut1DOp, ThrowOp)
+{
+    OCIO::Lut1DRcPtr lut = OCIO::Lut1D::Create();
+    lut->from_min[0] = 0.0f;
+    lut->from_min[1] = 0.0f;
+    lut->from_min[2] = 0.0f;
+    lut->from_max[0] = 1.0f;
+    lut->from_max[1] = 1.0f;
+    lut->from_max[2] = 1.0f;
+    for (int c = 0; c<3; ++c)
+    {
+        lut->luts[c].push_back(0.1f);
+        lut->luts[c].push_back(1.1f);
+    }
+    lut->maxerror = 1e-5f;
+    lut->errortype = OCIO::ERROR_RELATIVE;
+    OCIO::OpRcPtrVec ops;
+    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut,
+        OCIO::INTERP_NEAREST, OCIO::TRANSFORM_DIR_UNKNOWN));
+    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OIIO_CHECK_THROW_WHAT(ops[0]->finalize(),
+        OCIO::Exception, "unspecified transform direction");
+    ops.clear();
+    
+    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut,
+        OCIO::INTERP_UNKNOWN, OCIO::TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OIIO_CHECK_THROW_WHAT(ops[0]->finalize(),
+        OCIO::Exception, "unspecified interpolation");
+    ops.clear();
+
+    // INTERP_TETRAHEDRAL not allowed for 1d lut.
+    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut,
+        OCIO::INTERP_TETRAHEDRAL, OCIO::TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OIIO_CHECK_THROW_WHAT(ops[0]->finalize(),
+        OCIO::Exception, "tetrahedral interpolation is not allowed");
+    ops.clear();
+
+    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut,
+        OCIO::INTERP_BEST, OCIO::TRANSFORM_DIR_FORWARD));
+    OIIO_CHECK_EQUAL(ops.size(), 1);
+    lut->luts[0].clear();
+    OIIO_CHECK_THROW_WHAT(ops[0]->finalize(),
+        OCIO::Exception, "no lut data provided");
+}
+
+OIIO_ADD_TEST(Lut1DOp, GPU)
+{
+    OCIO::Lut1DRcPtr lut = OCIO::Lut1D::Create();
+    lut->from_min[0] = 0.0f;
+    lut->from_min[1] = 0.0f;
+    lut->from_min[2] = 0.0f;
+    lut->from_max[0] = 1.0f;
+    lut->from_max[1] = 1.0f;
+    lut->from_max[2] = 1.0f;
+    for (int c = 0; c < 3; ++c)
+    {
+        lut->luts[c].push_back(0.1f);
+        lut->luts[c].push_back(1.1f);
+    }
+    lut->maxerror = 1e-5f;
+    lut->errortype = OCIO::ERROR_RELATIVE;
+    OCIO::OpRcPtrVec ops;
+    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut,
+        OCIO::INTERP_NEAREST, OCIO::TRANSFORM_DIR_FORWARD));
+    
+    OCIO::FinalizeOpVec(ops);
+    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OIIO_CHECK_EQUAL(ops[0]->supportsGpuShader(), false);
+
+    std::ostringstream shader;
+    std::string pixelName = "";
+    OCIO::GpuShaderDesc shaderDesc;
+
+    OIIO_CHECK_THROW_WHAT(
+        ops[0]->writeGpuShader(shader, pixelName,shaderDesc),
+        OCIO::Exception, "does not support analytical shader generation");
+}
+
+
+OIIO_ADD_TEST(Lut1DOp, IdentityLut1D)
+{
+    int size = 3;
+    int channels = 2;
+    std::vector<float> data(size*channels);
+    OCIO::GenerateIdentityLut1D(&data[0], size, channels);
+    OIIO_CHECK_EQUAL(data[0], 0.0f);
+    OIIO_CHECK_EQUAL(data[1], 0.0f);
+    OIIO_CHECK_EQUAL(data[2], 0.5f);
+    OIIO_CHECK_EQUAL(data[3], 0.5f);
+    OIIO_CHECK_EQUAL(data[4], 1.0f);
+    OIIO_CHECK_EQUAL(data[5], 1.0f);
+
+    size = 4;
+    channels = 3;
+    data.resize(size*channels);
+    OCIO::GenerateIdentityLut1D(&data[0], size, channels);
+    for (int c = 0; c < channels; ++c)
+    {
+        OIIO_CHECK_EQUAL(data[0+c], 0.0f);
+        OIIO_CHECK_EQUAL(data[channels+c], 0.33333333f);
+        OIIO_CHECK_EQUAL(data[2*channels+c], 0.66666667f);
+        OIIO_CHECK_EQUAL(data[3*channels+c], 1.0f);
+    }
+
 }
 
 #endif // OCIO_UNIT_TEST

--- a/src/core/MatrixOps.h
+++ b/src/core/MatrixOps.h
@@ -69,6 +69,9 @@ OCIO_NAMESPACE_ENTER
                             float sat,
                             const float * lumaCoef3,
                             TransformDirection direction);
+    // Used by tests
+    void CreateIdentifyOp(OpRcPtrVec & ops,
+                          TransformDirection direction);
 }
 OCIO_NAMESPACE_EXIT
 

--- a/src/pyglue/PyConfig.cpp
+++ b/src/pyglue/PyConfig.cpp
@@ -145,8 +145,8 @@ OCIO_NAMESPACE_ENTER
         
         // disable cast-function-type warning on GCC 8+
         // this is triggered by methods that take kwargs (METH_KEYWORDS)
-        #pragma GCC diagnostic push
         #if __GNUC__ >= 8
+        #pragma GCC diagnostic push
         #pragma GCC diagnostic ignored "-Wcast-function-type"
         #endif
         
@@ -276,7 +276,9 @@ OCIO_NAMESPACE_ENTER
             { NULL, NULL, 0, NULL }
         };
         
+        #if __GNUC__ >= 8
         #pragma GCC diagnostic pop
+        #endif
         
     }
     


### PR DESCRIPTION
Unit tests for operators: review existing tests and add no tests.
Add macro to test the content of an Exception being thrown.
Tests for AllocationOps, ExponentOps, LogOps, Lut1DOps, Lut3DOps, MatrixOps, NoOps.
Fix GPU tests disabling.
Remove an hardcoded dependency.
Fix a gcc 4.4.x build break. The program was only used by gcc 8.x.x build so hide it for lower gcc versions