### PR TITLE
Fix some warnings and add some gpu unit tests

### DIFF
--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -1910,10 +1910,10 @@ OIIO_ADD_TEST(Config, EnvCheck)
     "\n";
     
     
-    std::string test("SHOW=bar");
-    putenv((char *)test.c_str());
-    std::string test2("TASK=lighting");
-    putenv((char *)test2.c_str());
+    const std::string test("SHOW=bar");
+    putenv(const_cast<char *>(test.c_str()));
+    const std::string test2("TASK=lighting");
+    putenv(const_cast<char *>(test2.c_str()));
     
     std::istringstream is;
     is.str(SIMPLE_PROFILE);
@@ -2034,8 +2034,8 @@ OIIO_ADD_TEST(Config, Env_colorspace_name)
     }
 
     {
-        char * env = (char *)"CAMERARAW=lnh";
-        putenv(env);
+        const std::string env("CAMERARAW=lnh");
+        putenv(const_cast<char*>(env.c_str()));
 
         std::istringstream is;
         is.str(MY_OCIO_CONFIG);
@@ -2049,8 +2049,8 @@ OIIO_ADD_TEST(Config, Env_colorspace_name)
     {
         // Test when the env. variable content is wrong
 
-        char * env = (char *)"CAMERARAW=FaultyColorSpaceName";
-        putenv(env);
+        const std::string env("CAMERARAW=FaultyColorSpaceName");
+        putenv(const_cast<char*>(env.c_str()));
 
         std::istringstream is;
         is.str(MY_OCIO_CONFIG);

--- a/src/core/GpuShaderUtils.cpp
+++ b/src/core/GpuShaderUtils.cpp
@@ -40,9 +40,8 @@ OCIO_NAMESPACE_ENTER
     {
         // This method converts a float to a string adding a dot when
         // the float does not have a fractional part. Hence, it ensures
-        // that the shader understand that number as a float and not as an integer.
-        //
-        // Always add the float indicator even if the issue only appears on MAC platform.
+        // that the shader program understand that number as a float 
+        // and not as an integer.
         //
         std::string GetFloatString(float v)
         {

--- a/src/core/GpuShaderUtils.cpp
+++ b/src/core/GpuShaderUtils.cpp
@@ -36,6 +36,26 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 OCIO_NAMESPACE_ENTER
 {
+    namespace
+    {
+        // This method converts a float to a string adding a dot when
+        // the float does not have a fractional part. Hence, it ensures
+        // that the shader understand that number as a float and not as an integer.
+        //
+        // Always add the float indicator even if the issue only appears on MAC platform.
+        //
+        std::string GetFloatString(float v)
+        {
+            float integerpart = 0.0f;
+            const float fracpart = modff(v, &integerpart);
+
+            std::ostringstream oss;
+            oss.precision(8);
+            oss << v << ((fracpart==0.0f) ? "." : "");
+            return oss.str();
+        }
+    }
+
     void Write_half4x4(std::ostream & os, const float * m44, GpuLanguage lang)
     {
         if(lang == GPU_LANGUAGE_CG)
@@ -54,7 +74,7 @@ OCIO_NAMESPACE_ENTER
             for(int i=0; i<16; i++)
             {
                 if(i!=0) os << ", ";
-                os << m44[i]; // Clamping to half is not necessary
+                os << GetFloatString(m44[i]); // Clamping to half is not necessary
             }
             os << ")";
         }
@@ -82,7 +102,7 @@ OCIO_NAMESPACE_ENTER
             for(int i=0; i<4; i++)
             {
                 if(i!=0) os << ", ";
-                os << v4[i]; // Clamping to half is not necessary
+                os << GetFloatString(v4[i]); // Clamping to half is not necessary
             }
             os << ")";
         }
@@ -110,7 +130,7 @@ OCIO_NAMESPACE_ENTER
             for(int i=0; i<3; i++)
             {
                 if(i!=0) os << ", ";
-                os << v3[i]; // Clamping to half is not necessary
+                os << GetFloatString(v3[i]); // Clamping to half is not necessary
             }
             os << ")";
         }

--- a/src/core/MatrixOps.cpp
+++ b/src/core/MatrixOps.cpp
@@ -1427,8 +1427,6 @@ OIIO_ADD_TEST(MatrixOps, isSameType)
 
 OIIO_ADD_TEST(MatrixOps, isInverse)
 {
-    const float error = 1e-8f;
-
     OpRcPtrVec ops;
     const float offset[] = { 1.1f, -1.3f, 0.3f, 0.0f };
     const float offsetInv[] = { -1.1f, 1.3f, -0.3f, 0.0f };

--- a/src/core/Platform.cpp
+++ b/src/core/Platform.cpp
@@ -89,7 +89,8 @@ OIIO_ADD_TEST(Platform, getenv)
 OIIO_ADD_TEST(Platform, putenv)
 {
     {
-        ::putenv("MY_DUMMY_ENV=SomeValue");
+        const std::string value("MY_DUMMY_ENV=SomeValue");
+        ::putenv(const_cast<char*>(value.c_str()));
         std::string env;
         OCIO::Platform::getenv("MY_DUMMY_ENV", env);
         OIIO_CHECK_ASSERT(!env.empty());

--- a/src/core_gpu_tests/ExpOps_test.cpp
+++ b/src/core_gpu_tests/ExpOps_test.cpp
@@ -1,0 +1,60 @@
+/*
+Copyright (c) 2003-2010 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <OpenColorIO/OpenColorIO.h>
+
+
+namespace OCIO = OCIO_NAMESPACE;
+#include "GPUUnitTest.h"
+
+OCIO_NAMESPACE_USING
+
+
+// Helper method to build unit tests
+void AddExpTest(OCIOGPUTest & test, TransformDirection direction,
+    const float * value, float epsilon)
+{
+    OCIO::ExponentTransformRcPtr exp = OCIO::ExponentTransform::Create();
+    exp->setDirection(direction);
+    exp->setValue(value);
+
+    test.setContext(exp->createEditableCopy(), epsilon);
+}
+
+
+OCIO_ADD_GPU_TEST(ExpTransform, ExpValue)
+{
+    const float exp1[4] = { 2.0f, 2.0f, 2.0f, 1.0f };
+    AddExpTest(test, TRANSFORM_DIR_FORWARD, exp1, 1e-6f);
+}
+
+OCIO_ADD_GPU_TEST(ExpTransform, ExpValue_inverse)
+{
+    const float exp1[4] = { 1.0f/2.0f, 1.0f/2.0f, 1.0f/2.0f, 1.0f };
+    AddExpTest(test, TRANSFORM_DIR_INVERSE, exp1, 1e-6f);
+}

--- a/src/core_gpu_tests/GPUHelpers.cpp
+++ b/src/core_gpu_tests/GPUHelpers.cpp
@@ -1,5 +1,29 @@
 /*
-    Made by Autodesk Inc. under the terms of the OpenColorIO BSD 3 Clause License
+Copyright (c) 2003-2010 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <OpenColorIO/OpenColorIO.h>

--- a/src/core_gpu_tests/GPUHelpers.h
+++ b/src/core_gpu_tests/GPUHelpers.h
@@ -1,5 +1,29 @@
 /*
-    Made by Autodesk Inc. under the terms of the OpenColorIO BSD 3 Clause License
+Copyright (c) 2003-2010 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #ifndef OPENCOLORIO_GPU_HELPERS_H

--- a/src/core_gpu_tests/GPUUnitTest.h
+++ b/src/core_gpu_tests/GPUUnitTest.h
@@ -1,5 +1,29 @@
 /*
-    Made by Autodesk Inc. under the terms of the OpenColorIO BSD 3 Clause License
+Copyright (c) 2003-2010 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #ifndef OPENCOLORIO_GPU_UNITTEST_H

--- a/src/core_gpu_tests/LogOps_test.cpp
+++ b/src/core_gpu_tests/LogOps_test.cpp
@@ -1,0 +1,82 @@
+/*
+Copyright (c) 2003-2010 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <OpenColorIO/OpenColorIO.h>
+
+
+namespace OCIO = OCIO_NAMESPACE;
+#include "GPUUnitTest.h"
+
+OCIO_NAMESPACE_USING
+
+
+// Helper method to build unit tests
+void AddLogTest(OCIOGPUTest & test, TransformDirection direction,
+    const float base, float epsilon)
+{
+    OCIO::LogTransformRcPtr log = OCIO::LogTransform::Create();
+    log->setDirection(direction);
+    log->setBase(base);
+
+    test.setContext(log->createEditableCopy(), epsilon);
+}
+
+
+OCIO_ADD_GPU_TEST(LogTransform, LogBase)
+{
+    const float base10 = 10.0f;
+    AddLogTest(test, TRANSFORM_DIR_FORWARD, base10, 1e-5f);
+}
+
+
+OCIO_ADD_GPU_TEST(LogTransform, LogBase_inverse)
+{
+    const float base10 = 10.0f;
+    AddLogTest(test, TRANSFORM_DIR_INVERSE, base10, 1e-4f);
+}
+
+
+OCIO_ADD_GPU_TEST(LogTransform, euler_constant)
+{
+    const float eulerConstant = std::exp(1.0f);
+    AddLogTest(test, TRANSFORM_DIR_FORWARD, eulerConstant, 1e-5f);
+}
+
+
+OCIO_ADD_GPU_TEST(LogTransform, euler_constant_inverse)
+{
+    const float eulerConstant = std::exp(1.0f);
+    AddLogTest(test, TRANSFORM_DIR_INVERSE, eulerConstant, 1e-5f);
+}
+
+
+OCIO_ADD_GPU_TEST(LogTransform, base1_inverse)
+{
+    const float base1 = 1.0f;
+    AddLogTest(test, TRANSFORM_DIR_INVERSE, base1, 1e-5f);
+}

--- a/src/core_gpu_tests/Lut3DOp_test.cpp
+++ b/src/core_gpu_tests/Lut3DOp_test.cpp
@@ -1,7 +1,30 @@
 /*
-    Made by Autodesk Inc. under the terms of the OpenColorIO BSD 3 Clause License
-*/
+Copyright (c) 2003-2010 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 
 #include <OpenColorIO/OpenColorIO.h>
 

--- a/src/core_gpu_tests/MatrixOps_test.cpp
+++ b/src/core_gpu_tests/MatrixOps_test.cpp
@@ -1,7 +1,30 @@
 /*
-    Made by Autodesk Inc. under the terms of the OpenColorIO BSD 3 Clause License
-*/
+Copyright (c) 2003-2010 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
 
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
 
 #include <OpenColorIO/OpenColorIO.h>
 

--- a/src/pyglue/tests/ConfigTest.py
+++ b/src/pyglue/tests/ConfigTest.py
@@ -84,11 +84,11 @@ vec4 pytestocio(in vec4 inPixel,
     const sampler3D lut3d) 
 {
 vec4 out_pixel = inPixel; 
-out_pixel = out_pixel * mat4(1.08749, -0.0794667, -0.00802222, 0, -0.0236222, 1.03164, -0.00802222, 0, -0.0236222, -0.0794667, 1.10309, 0, 0, 0, 0, 1);
-out_pixel = pow(max(out_pixel, vec4(0, 0, 0, 0)), vec4(0.909091, 0.909091, 0.909091, 1));
-out_pixel = out_pixel * mat4(1.11111, -2, -3, -4, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
-out_pixel = vec4(4.68889, -2.3, -0.4, -0) + out_pixel;
-out_pixel = pow(max(out_pixel, vec4(0, 0, 0, 0)), vec4(0.454545, 0.454545, 0.454545, 1));""" \
+out_pixel = out_pixel * mat4(1.0874889, -0.079466686, -0.0080222245, 0., -0.023622228, 1.0316445, -0.0080222245, 0., -0.023622226, -0.079466686, 1.1030889, 0., 0., 0., 0., 1.);
+out_pixel = pow(max(out_pixel, vec4(0., 0., 0., 0.)), vec4(0.90909088, 0.90909088, 0.90909088, 1.));
+out_pixel = out_pixel * mat4(1.1111112, -2., -3., -4., 0., 1., 0., 0., 0., 0., 1., 0., 0., 0., 0., 1.);
+out_pixel = vec4(4.688889, -2.3, -0.40000001, -0.) + out_pixel;
+out_pixel = pow(max(out_pixel, vec4(0., 0., 0., 0.)), vec4(0.45454544, 0.45454544, 0.45454544, 1.));""" \
  + osx_hack + \
 """
 return out_pixel;


### PR DESCRIPTION
The starting point was to fix various Linux warnings to evolve to fix a gpu shader program issue.

Serializing a vector of 4 floats could end up to be a vector of 4 integers for some OpenGL shader program (i.e. depending of the graphic card & driver) causing a fragment shader compilation failure. A fragment shader program could have:
1. **vec4 v(1, 2, 3, 4)** which is a vector of four **integers** (i.e. serialization of floats without fractional part)
2. **vec4 v(1.1, 2.1, 3.1, 4.1)** which is a vector of 4 **floats** (i.e. floats with fractional part)

The solution is to always add a '.' to any float values when there is no fractional part. Please refer to GetFloatString() for details.