### PR TITLE
Add CI build option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ env:
 # Install missing packages
 before_install:
   # Linux ones
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then 
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       sudo apt-get update -qq;
       sudo apt-get install -y -qq texlive-full;
-      sudo apt-get install -y -qq freeglut3-dev libglew-dev libxmu-dev libxi-dev; 
+      sudo apt-get install -y -qq freeglut3-dev libglew-dev libxmu-dev libxi-dev;
     fi
   # OSX ones
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       osx_image: xcode9.1
 
 env:
-  - OPTIONS="-DCMAKE_BUILD_TYPE=Release -DOCIO_BUILD_TESTS=yes -DOCIO_BUILD_DOCS=yes"
+  - OPTIONS="-DCMAKE_BUILD_TYPE=Release -DOCIO_BUILD_TESTS=yes -DOCIO_BUILD_DOCS=yes -DOCIO_WARNING_AS_ERROR=yes"
 
 # Install missing packages
 before_install:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 ### GLOBAL ###
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+option(OCIO_WARNING_AS_ERROR "Set build error level for CI testing" OFF)
 option(OCIO_BUILD_SHARED "Set to OFF to disable building the shared core library" ON)
 option(OCIO_BUILD_STATIC "Set to OFF to disable building the static core library" ON)
 option(OCIO_BUILD_TRUELIGHT "Set to OFF to disable truelight" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,7 +204,7 @@ else(USE_EXTERNAL_TINYXML)
     endif()
     mark_as_advanced(TINYXML_OBJECT_LIB_EMBEDDED) ## two way to build with tinyxml (objects embedded or static transitive link)
     if(TINYXML_OBJECT_LIB_EMBEDDED)
-        set(tinyxml_sources ${TINYXML_SOURCE_DIR}/tinyxml/tinystr.cpp       ${TINYXML_SOURCE_DIR}/tinyxml/tinyxml.cpp 
+        set(tinyxml_sources ${TINYXML_SOURCE_DIR}/tinyxml/tinystr.cpp       ${TINYXML_SOURCE_DIR}/tinyxml/tinyxml.cpp
                             ${TINYXML_SOURCE_DIR}/tinyxml/tinyxmlerror.cpp  ${TINYXML_SOURCE_DIR}/tinyxml/tinyxmlparser.cpp )
         set(tinyxml_headers ${TINYXML_SOURCE_DIR}/tinyxml/tinystr.h         ${TINYXML_SOURCE_DIR}/tinyxml/tinyxml.h )
         add_custom_command(                                 ## will be done at build time
@@ -217,7 +217,7 @@ else(USE_EXTERNAL_TINYXML)
         )
         include_directories(BEFORE ${TINYXML_SOURCE_DIR}/tinyxml) ## needed to build correctly
         add_library(TINYXML_LIB OBJECT ${tinyxml_sources})
-        ## embedded tinyxml objects files (no static link needed anymore) 
+        ## embedded tinyxml objects files (no static link needed anymore)
         ## => great news when build staticaly since we do not want another client project have to link also with tinyxml when he want to use this project
         ## => could be problematic if the client project use another version of tinyxml... In this case build tinyxml as shared lib with all projects could be a solution
         ## => TODO: so maybe provide a simple cmake way to build 3rdParty as shared and auto install with this project ?
@@ -247,7 +247,7 @@ else(USE_EXTERNAL_TINYXML)
     endif()
     set_target_properties(TINYXML_LIB PROPERTIES FOLDER External)
 endif(USE_EXTERNAL_TINYXML)
-    
+
 ###############################################################################
 ### YAML ###
 
@@ -315,8 +315,8 @@ else(USE_EXTERNAL_YAML) ## provide 2 ways to build this dependency
         message("Force disable YAML_CPP_OBJECT_LIB_EMBEDDED feature due to CMake Version less than 2.8.8")
     endif()
     mark_as_advanced(YAML_CPP_OBJECT_LIB_EMBEDDED)
-    if(YAML_CPP_OBJECT_LIB_EMBEDDED)        
-        ## generated at extraction level dir, with (use git bash or cygwin under windows): 
+    if(YAML_CPP_OBJECT_LIB_EMBEDDED)
+        ## generated at extraction level dir, with (use git bash or cygwin under windows):
         ## find yaml-cpp -type f \( -name "*.h" -o -name "*.cpp" \) -not \( -path "*/test/*" -o -path "*/util/*" \) > yaml-cpp-sourcesList.txt
         ## this will exclude test and util paths since we want YAML_CPP_BUILD_TOOLS:BOOL=OFF (see externalProject cmake args)
         file(STRINGS ${YAML_CPP_SRCLISTFILE} YAML_CPP_SRCLISTFILE_CONTENT)
@@ -335,9 +335,9 @@ else(USE_EXTERNAL_YAML) ## provide 2 ways to build this dependency
         add_library(YAML_CPP_LIB OBJECT ${yamlcpp_sources})
         ## embedded yaml-cpp objects files (no static link needed anymore)
         ## => great news when build statically since we do not want another client project have to link also with yaml-cpp when he want to use this project
-        ## => could be problematic if the client project use another version of yaml-cpp... In this case build yaml-cpp as shared lib with all projects could be a solution 
+        ## => could be problematic if the client project use another version of yaml-cpp... In this case build yaml-cpp as shared lib with all projects could be a solution
         ## => TODO: so maybe provide a simple cmake way to build 3rdParty as shared and auto install with this project ?
-        list(APPEND EXTERNAL_OBJECTS $<TARGET_OBJECTS:YAML_CPP_LIB>) 
+        list(APPEND EXTERNAL_OBJECTS $<TARGET_OBJECTS:YAML_CPP_LIB>)
     else()
         find_package(Git REQUIRED) ## in order to apply patch (for crossplateform compatibility)
         ExternalProject_Add(YAML_CPP_LOCAL
@@ -503,14 +503,14 @@ if(OCIO_BUILD_APPS AND (OCIO_BUILD_STATIC OR OCIO_BUILD_SHARED) )
 
     # Try to find OpenImageIO (OIIO) and OpenGL stuff
     OCIOFindOpenImageIO()
-    
+
     if(OIIO_FOUND)
         add_subdirectory(src/apps/ocioconvert)
         add_subdirectory(src/apps/ociolutimage)
     else()
         messageonce("Not building ocioconvert/ociolutimage. Requirement(s) found: OIIO:${OIIO_FOUND}")
     endif()
-    
+
     # ociodisplay, displays color-transformed images (uses OpenImageIO,
     # and OpenGL)
     if(OPENGL_FOUND AND GLUT_FOUND AND GLEW_FOUND AND OIIO_FOUND)
@@ -520,13 +520,13 @@ if(OCIO_BUILD_APPS AND (OCIO_BUILD_STATIC OR OCIO_BUILD_SHARED) )
         ## on windows, if you use STATIC version, do not forget to use : GEW_BUILD=GLEW_STATIC preprocessor definition
         messageonce("Not building ociodisplay. Requirement(s) found, OpenGL:${OPENGL_FOUND}, GLUT:${GLUT_FOUND}, GLEW:${GLEW_FOUND}, OIIO:${OIIO_FOUND}")
     endif()
-    
+
     # ociocheck: verifies an OCIO config
     add_subdirectory(src/apps/ociocheck)
-    
+
     # ociobakelut writes out luts
     add_subdirectory(src/apps/ociobakelut)
-    
+
 else()
     message(STATUS "Disable build of apps. See cmake options : OCIO_BUILD_APPS and OCIO_BUILD_SHARED/OCIO_BUILD_STATIC (required)")
 endif()
@@ -649,12 +649,12 @@ install(EXPORT OpenColorIO DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/OpenColorIO
 file(WRITE "${CMAKE_BINARY_DIR}/OpenColorIOConfig.cmake"
     "
     get_filename_component(OpenColorIO_DIR \"\${CMAKE_CURRENT_LIST_FILE}\" PATH)
-    
+
     ## include
     set(OpenColorIO_INCLUDE_DIR     \"\${OpenColorIO_DIR}/include\")
     set(OpenColorIO_INCLUDE_DIRS    \"\${OpenColorIO_INCLUDE_DIR}\")
     message(STATUS OpenColorIO_INCLUDE_DIRS=\${OpenColorIO_INCLUDE_DIRS})
-    
+
     ## targets libraries + associated definitions
     if(NOT TARGET OpenColorIO)
         include(\"\${OpenColorIO_DIR}/${CMAKE_INSTALL_LIBDIR}/cmake/OpenColorIO/OpenColorIO.cmake\") ## thanks to imported target
@@ -675,7 +675,7 @@ file(WRITE "${CMAKE_BINARY_DIR}/OpenColorIOConfig.cmake"
     endif()
     set(OpenColorIO_LIBRARIES \${OpenColorIO_LIBRARY})
     message(STATUS OpenColorIO_LIBRARIES=\${OpenColorIO_LIBRARIES})
-    
+
     ## display available preprocessor definition to use
     if(OCIO_COMPILE_DEFINITIONS)
         message(STATUS \"OCIO_COMPILE_DEFINITIONS=\")
@@ -683,7 +683,7 @@ file(WRITE "${CMAKE_BINARY_DIR}/OpenColorIOConfig.cmake"
             message(STATUS \"   \${OCIO_DEF}\")
         endforeach()
     endif()
-    
+
     ## found
     if(OpenColorIO_INCLUDE_DIRS AND OpenColorIO_LIBRARIES)
         set(OpenColorIO_FOUND ON)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -17,15 +17,15 @@ configure_file(${CMAKE_SOURCE_DIR}/export/OpenColorIO/OpenColorABI.h.in
     ${CMAKE_BINARY_DIR}/export/OpenColorABI.h @ONLY)
 list(APPEND core_export_headers ${CMAKE_BINARY_DIR}/export/OpenColorABI.h)
 
-# Process all warnings as errors
-
-if(WIN32)
-    # On debug mode there are other kinds of warning...
-    if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
-        set(EXTERNAL_COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS} /WX")
+if(OCIO_WARNING_AS_ERROR)
+    if(WIN32)
+        # On debug mode there are other kinds of warning...
+        if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+            set(EXTERNAL_COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS} /WX")
+        endif()
+    else()
+        set(EXTERNAL_COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS} -Werror")
     endif()
-else()
-    set(EXTERNAL_COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS} -Werror")
 endif()
 
 # SHARED

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -50,7 +50,7 @@ if(OCIO_BUILD_SHARED)
     endif()
 
     if(WIN32)
-        # Mute a design issue where the Exception public class inherits 
+        # Mute a design issue where the Exception public class inherits
         # from a STL Exception. STL classes are never supposed to
         # be exported among different dynamic libraries.
         set(EXTERNAL_COMPILE_FLAGS "${EXTERNAL_COMPILE_FLAGS} /wd4275")
@@ -60,13 +60,13 @@ if(OCIO_BUILD_SHARED)
         OUTPUT_NAME OpenColorIO
         COMPILE_FLAGS   "${EXTERNAL_COMPILE_FLAGS}"
         LINK_FLAGS      "${EXTERNAL_LINK_FLAGS}")
-    
+
     message(STATUS "Setting OCIO SOVERSION to: ${SOVERSION}")
     set_target_properties(OpenColorIO PROPERTIES
         VERSION ${OCIO_VERSION}
         SOVERSION ${SOVERSION})
-    
-    install(TARGETS OpenColorIO EXPORT OpenColorIO 
+
+    install(TARGETS OpenColorIO EXPORT OpenColorIO
         ARCHIVE DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/lib${LIB_SUFFIX}
         LIBRARY DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/lib${LIB_SUFFIX}
         RUNTIME DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/bin
@@ -82,19 +82,19 @@ if(OCIO_BUILD_STATIC)
     if(EXTERNAL_LIBRARIES)
         target_link_libraries(OpenColorIO_STATIC ${EXTERNAL_LIBRARIES})
     endif()
-    
+
 	set_target_properties(OpenColorIO_STATIC PROPERTIES COMPILE_DEFINITIONS "OpenColorIO_STATIC")
     set_target_properties(OpenColorIO_STATIC PROPERTIES
         OUTPUT_NAME                 OpenColorIO
         ARCHIVE_OUTPUT_DIRECTORY    "${CMAKE_CURRENT_BINARY_DIR}/static"
         COMPILE_FLAGS               "${EXTERNAL_COMPILE_FLAGS}"
         LINK_FLAGS                  "${EXTERNAL_LINK_FLAGS}")
-    
+
     message(STATUS "Setting OCIO SOVERSION to: ${SOVERSION}")
     set_target_properties(OpenColorIO_STATIC PROPERTIES
         VERSION ${OCIO_VERSION}
         SOVERSION ${SOVERSION})
-    
+
     install(TARGETS OpenColorIO_STATIC EXPORT OpenColorIO ARCHIVE DESTINATION ${CMAKE_INSTALL_EXEC_PREFIX}/lib/static)
 endif()
 

--- a/src/pyglue/CMakeLists.txt
+++ b/src/pyglue/CMakeLists.txt
@@ -20,10 +20,11 @@ if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4275")
 endif()
 
-# Process all warnings as errors
 # Unfortunately Windows still has a warning
-if(UNIX)
+if(OCIO_WARNING_AS_ERROR)
+  if(UNIX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+  endif()
 endif()
 
 find_package(PythonLibs)

--- a/src/pyglue/CMakeLists.txt
+++ b/src/pyglue/CMakeLists.txt
@@ -7,14 +7,14 @@ if(CMAKE_FIRST_RUN)
     message(STATUS "Python ${PYTHON_VERSION} okay (UCS: ${PYTHON_UCS}), will build the Python bindings against ${PYTHON_INCLUDE}")
     message(STATUS "Python variant path is ${PYTHON_VARIANT_PATH}")
 endif()
-    
+
 if(CMAKE_COMPILER_IS_GNUCXX)
     # Python breaks strict-aliasing rules. Disable the warning here.
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-strict-aliasing -Wno-missing-field-initializers")
 endif()
 
 if(WIN32)
-    # Mute a design issue where the Exception public class inherits 
+    # Mute a design issue where the Exception public class inherits
     # from a STL Exception. STL classes are never supposed to
     # be exported among different dynamic libraries.
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4275")
@@ -75,7 +75,7 @@ if(WIN32)
 endif()
 
 if(OCIO_PYGLUE_LINK OR WIN32)
-    # Windows always need the python library, 
+    # Windows always need the python library,
     #  refer to https://docs.python.org/3/extending/windows.html#a-cookbook-approach
     message(STATUS "Linking python bindings against: ${PYTHON_LIBRARY}")
     message(STATUS "Python library dirs: ${PYTHON_LIBRARY_DIRS}")
@@ -84,9 +84,9 @@ if(OCIO_PYGLUE_LINK OR WIN32)
 endif()
 
 # PyOpenColorIO so serves dual roles:
-# - First, to provide the C API function necessary to act as a cpython module, 
+# - First, to provide the C API function necessary to act as a cpython module,
 #   (extern "C" PyMODINIT_FUNC initPyOpenColorIO(void)
-# - Second, to act as a normal shared library, providing the C++ API functions 
+# - Second, to act as a normal shared library, providing the C++ API functions
 #   to convert between C++ and python representation of the OCIO object.
 #
 # To fulfill this second role, as a shared libary, we must continue to define


### PR DESCRIPTION
Seeing as how we test very few build combinations through CI, I feel its best not to completely halt compilation for someone else that is trying to build OCIO for themselves. Even one minor version up in GCC produces warnings.

So submitting this to limit -Werror purely to contributors.