### PR TITLE
Fix oiio dependent apps compilation

### DIFF
--- a/share/cmake/OCIOMacros.cmake
+++ b/share/cmake/OCIOMacros.cmake
@@ -92,6 +92,25 @@ MACRO(OCIOFindOpenImageIO)
         /opt/local/lib
         DOC "The OIIO library")
 
+    if(OIIO_INCLUDES AND EXISTS "${OIIO_INCLUDES}/OpenImageIO/oiioversion.h")
+        file(STRINGS ${OIIO_INCLUDES}/OpenImageIO/oiioversion.h
+            MAJOR
+            REGEX
+            "#define OIIO_VERSION_MAJOR.*$")
+        file(STRINGS ${OIIO_INCLUDES}/OpenImageIO/oiioversion.h
+            MINOR
+            REGEX
+            "#define OIIO_VERSION_MINOR.*$")
+        file(STRINGS ${OIIO_INCLUDES}/OpenImageIO/oiioversion.h
+            PATCH
+            REGEX
+            "#define OIIO_VERSION_PATCH.*$")
+        string(REGEX MATCHALL "[0-9]+" MAJOR ${MAJOR})
+        string(REGEX MATCHALL "[0-9]+" MINOR ${MINOR})
+        string(REGEX MATCHALL "[0-9]+" PATCH ${PATCH})
+        set(OIIO_VERSION "${MAJOR}.${MINOR}.${PATCH}")
+    endif()
+
     if(OIIO_INCLUDES AND OIIO_LIBRARIES)
         set(OIIO_FOUND TRUE)
         message(STATUS "Found OIIO library ${OIIO_LIBRARIES}")

--- a/src/apps/ocioconvert/CMakeLists.txt
+++ b/src/apps/ocioconvert/CMakeLists.txt
@@ -11,6 +11,10 @@ if (OIIO_FOUND)
     
     add_executable(ocioconvert ${share_src_files} main.cpp)
     
+    if(OIIO_VERSION AND NOT ${OIIO_VERSION} VERSION_LESS 1.8.5)
+        set_property(TARGET ocioconvert PROPERTY CXX_STANDARD 11)
+    endif()
+    
     set_target_properties(ocioconvert PROPERTIES COMPILE_FLAGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
 
     target_link_libraries(ocioconvert ${OIIO_LIBRARIES} ${CMAKE_DL_LIBS})

--- a/src/apps/ociodisplay/CMakeLists.txt
+++ b/src/apps/ociodisplay/CMakeLists.txt
@@ -11,6 +11,10 @@ if (OIIO_FOUND)
     )
 
     add_executable(ociodisplay main.cpp)
+    
+    if(OIIO_VERSION AND NOT ${OIIO_VERSION} VERSION_LESS 1.8.5)
+        set_property(TARGET ociodisplay PROPERTY CXX_STANDARD 11)
+    endif()
 
     # set_target_properties(ociodisplay PROPERTIES INSTALL_RPATH ${OIIO_LIBRARIES} )
     set_target_properties(ociodisplay PROPERTIES COMPILE_FLAGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})

--- a/src/apps/ociolutimage/CMakeLists.txt
+++ b/src/apps/ociolutimage/CMakeLists.txt
@@ -11,6 +11,10 @@ if (OIIO_FOUND)
     
     add_executable(ociolutimage ${share_src_files} main.cpp)
     
+    if(OIIO_VERSION AND NOT ${OIIO_VERSION} VERSION_LESS 1.8.5)
+        set_property(TARGET ociolutimage PROPERTY CXX_STANDARD 11)
+    endif()
+    
     set_target_properties(ociolutimage PROPERTIES COMPILE_FLAGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
 
     target_link_libraries(ociolutimage ${OIIO_LIBRARIES} ${CMAKE_DL_LIBS})


### PR DESCRIPTION
This could be used to fix the compilation errors when building OCIO 1.1 (while waiting for 2.0) application using OIIO >= 1.8.5. This occured to me lately during a fresh Mac install with brew (`brew install opencolorio --with-python` trigger a compilation that fails in the end).

Would be glad to have others thoughts.