### PR TITLE
Adsk Contrib - Improve unit test framework

### DIFF
--- a/src/core/MatrixOps.cpp
+++ b/src/core/MatrixOps.cpp
@@ -671,18 +671,18 @@ OIIO_ADD_TEST(MatrixOps, Scale)
     OpRcPtrVec ops;
     const float scale[] = { 1.1f, 1.3f, 0.3f, 1.0f };
     OIIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OIIO_REQUIRE_EQUAL(ops.size(), 1);
 
     std::string cacheID = ops[0]->getCacheID();
-    OIIO_CHECK_EQUAL(cacheID.empty(), true);
+    OIIO_REQUIRE_ASSERT(cacheID.empty());
 
     OIIO_CHECK_NO_THROW(ops[0]->finalize());
 
     cacheID = ops[0]->getCacheID();
-    OIIO_CHECK_EQUAL(cacheID.empty(), false);
+    OIIO_REQUIRE_ASSERT(!cacheID.empty());
 
     OIIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_EQUAL(ops.size(), 2);
+    OIIO_REQUIRE_EQUAL(ops.size(), 2);
     OIIO_CHECK_NO_THROW(ops[1]->finalize());
 
     const unsigned NB_PIXELS = 3;

--- a/src/core_gpu_tests/GPUUnitTest.cpp
+++ b/src/core_gpu_tests/GPUUnitTest.cpp
@@ -79,26 +79,32 @@ namespace Shader
     // In some occasions, MAX_FLOAT will be "rounded" to infinity on some GPU renderers.
     // In order to avoid this issue, consider all number over/under a given threshold as
     // equal for testing purposes.
-    #define LARGE_THRESHOLD    std::numeric_limits<float>::max()
+    const float largeThreshold = std::numeric_limits<float>::max();
 
-    // Check if difference between floats f1 and f2 does not exceed eps
-    bool AbsoluteFloatComparison(float f1, float f2, float eps)
+    // Code copied from core/MathUtils.h
+    inline bool EqualWithAbsError(float x1, float x2, float e)
     {
-      return ((f1 > f2)? f1 - f2: f2 - f1) <= eps;
+        return ((x1 > x2) ? x1 - x2 : x2 - x1) <= e;
     }
 
     // Relative comparison: check if the difference between value and expected
     // relative to (divided by) expected does not exceed the eps.  A minimum
     // expected value is used to limit the scaling of the difference and
     // avoid large relative differences for small numbers.
-    bool RelativeFloatComparison(float value, float expected, float eps, float minExpected)
+    inline bool EqualWithSafeRelError(float value,
+                                      float expected,
+                                      float eps,
+                                      float minExpected)
     {
-        const float div = ( expected > 0 ) ?
-            ( (  expected < minExpected ) ? minExpected :  expected ) :
-            ( ( -expected < minExpected ) ? minExpected : -expected );
+        const float div = (expected > 0.0f) ?
+            ((expected < minExpected) ? minExpected : expected) :
+            ((-expected < minExpected) ? minExpected : -expected);
 
-        return ( ((value > expected) ? value - expected : expected - value) / div ) <= eps;
+        return (
+            ((value > expected) ? value - expected : expected - value)
+            / div) <= eps;
     }
+    // end of copy from core/MathUtils.h
 
     // Compute the absolute equality of two floats
     // a is the first float to compare
@@ -106,14 +112,14 @@ namespace Shader
     // epsilon is the maximum expected epsilon
     bool AbsoluteCompare(float a, float b, float epsilon)
     {
-        if ( ( (a >=  LARGE_THRESHOLD) && (b >=  LARGE_THRESHOLD) ) ||
-             ( (a <= -LARGE_THRESHOLD) && (b <= -LARGE_THRESHOLD) ) ||
+        if ( ( (a >=  largeThreshold) && (b >=  largeThreshold) ) ||
+             ( (a <= -largeThreshold) && (b <= -largeThreshold) ) ||
              ( F_ISNAN(a) && F_ISNAN(b) ) )
         {
             return true;
         }
 
-        return AbsoluteFloatComparison(a, b, epsilon);
+        return EqualWithAbsError(a, b, epsilon);
     }
 
     // Compute the relative equality of two floats
@@ -123,14 +129,14 @@ namespace Shader
     // expectedMinValue is the minimum expected value
     bool RelativeCompare(float a, float b, float epsilon, float expectedMinValue)
     {
-        if ( ( (a >=  LARGE_THRESHOLD) && (b >=  LARGE_THRESHOLD) ) ||
-             ( (a <= -LARGE_THRESHOLD) && (b <= -LARGE_THRESHOLD) ) ||
+        if ( ( (a >=  largeThreshold) && (b >=  largeThreshold) ) ||
+             ( (a <= -largeThreshold) && (b <= -largeThreshold) ) ||
              ( F_ISNAN(a) && F_ISNAN(b) ) )
         {
           return true;
         }
 
-        return RelativeFloatComparison(a, b, epsilon, expectedMinValue);
+        return EqualWithSafeRelError(a, b, epsilon, expectedMinValue);
     }
 }
 
@@ -345,7 +351,7 @@ namespace
         for(size_t idx=0; idx<(g_winWidth * g_winHeight); ++idx)
         {
             const bool isFaulty 
-                = test->performRelativeComparison() 
+                = test->getRelativeComparison()
                     ? (!Shader::RelativeCompare(cppImage[4*idx+0], gpuImage[4*idx+0], epsilon, expectMinValue) ||
                        !Shader::RelativeCompare(cppImage[4*idx+1], gpuImage[4*idx+1], epsilon, expectMinValue) ||
                        !Shader::RelativeCompare(cppImage[4*idx+2], gpuImage[4*idx+2], epsilon, expectMinValue) ||
@@ -443,6 +449,8 @@ int main(int, char **)
 
     unsigned failures = 0;
 
+    std::cerr << "\n OpenColorIO_Core_GPU_Unit_Tests\n\n";
+
     const UnitTests & tests = GetUnitTests();
     const size_t numTests = tests.size();
     for(size_t idx=0; idx<numTests; ++idx)
@@ -453,9 +461,16 @@ int main(int, char **)
 
         try
         {
-            std::cerr << "Test [" << test->group() << "] [" << test->name() << "] - ";
-
             test->setup();
+
+            std::string name(test->group());
+            name += " / " + test->name();
+
+            std::cerr << "[" 
+                      << std::right << std::setw(3)
+                      << (idx+1) << "/" << numTests << "] ["
+                      << std::left << std::setw(50)
+                      << name << "] - ";
 
             if(test->isValid())
             {
@@ -467,7 +482,7 @@ int main(int, char **)
                 glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
                 // Update the image texture
-                UpdateImageTexture(test->useWideRange());
+                UpdateImageTexture(test->getWideRange());
 
                 // Update the GPU shader program
                 UpdateOCIOGLState(test);

--- a/src/core_gpu_tests/GPUUnitTest.h
+++ b/src/core_gpu_tests/GPUUnitTest.h
@@ -57,13 +57,13 @@ class OCIOGPUTest
         inline OCIO_NAMESPACE::GpuShaderDescRcPtr & getShaderDesc() { return m_shaderDesc; }
 
         // Use or not a wide range image
-        inline bool useWideRange() const { return m_useWideRange; }
+        inline bool getWideRange() const { return m_useWideRange; }
         inline void setWideRange(bool use) { m_useWideRange = use; }
 
         inline float getErrorThreshold() const { return m_errorThreshold; }
         inline void setErrorThreshold(float error) { m_errorThreshold = error; }
 
-        inline bool performRelativeComparison() const { return m_performRelativeComparison; }
+        inline bool getRelativeComparison() const { return m_performRelativeComparison; }
         inline void setRelativeComparison(bool relCompare) { m_performRelativeComparison = relCompare; }
 
         // This is the lower bound for the value that is divided into the absolute error 

--- a/src/pyglue/DocStrings/CDLTransform.py
+++ b/src/pyglue/DocStrings/CDLTransform.py
@@ -9,7 +9,7 @@ class CDLTransform:
     def CreateFromFile(self, src, cccid):
         pass
     
-    def equals(self):
+    def equals(self, cdl):
         pass
         
     def getXML(self):

--- a/src/pyglue/PyCDLTransform.cpp
+++ b/src/pyglue/PyCDLTransform.cpp
@@ -224,7 +224,7 @@ OCIO_NAMESPACE_ENTER
             if(sat >= 0.0f) ptr->setSat(sat);
             if(direction) ptr->setDirection(TransformDirectionFromString(direction));
             if(id) ptr->setID(id);
-            if(id) ptr->setDescription(description);
+            if(description) ptr->setDescription(description);
             return ret;
             OCIO_PYTRY_EXIT(-1)
         }

--- a/src/pyglue/PyUtil.cpp
+++ b/src/pyglue/PyUtil.cpp
@@ -402,7 +402,7 @@ OCIO_NAMESPACE_ENTER
         Even though it's not immediately apparent, almost every function
         in the Abstract Objects Layer,
         http://www.python.org/doc/2.5/api/abstract.html
-        can set a global excpetion under certain circumstances.
+        can set a global exception under certain circumstances.
         
         For example, calling the equivalent of int( obj ) will set
         an exception if the object cannot be casted (such as None),

--- a/src/pyglue/tests/OpenColorIOTestSuite.py
+++ b/src/pyglue/tests/OpenColorIOTestSuite.py
@@ -37,7 +37,7 @@ def suite():
     return suite
 
 if __name__ == '__main__':
-    runner = unittest.TextTestRunner()
+    runner = unittest.TextTestRunner(verbosity=2)
     test_suite = suite()
     result = runner.run(test_suite)
     if result.wasSuccessful() == False:


### PR DESCRIPTION
The pull request adds new macros and improves the unit test outputs.

The new macros stop the unit test if there is an error because it invalidates the following validations. Please refer the first unit test of src/core/MatrixOps.cpp to see the usage.

Note: After several changes in the src/oiio/src/include/unittest.h, the file is more and more specific to the OCIO project, and so it could be moved/renamed to src/core_tests or another existing framework could be used (with much more capabilities).