### PR TITLE
Adsk Contrib - Add gpu capability to ocioconvert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ option(OCIO_STATIC_JNIGLUE "Specify whether to statically link ocio to the java 
 option(OCIO_USE_SSE "Specify whether to enable SSE CPU performance optimizations" ON)
 option(OCIO_INLINES_HIDDEN "Specify whether to build with -fvisibility-inlines-hidden" UNIX)
 
+# Building ocioconvert with GPU also requires OPENGL_FOUND, GLUT_FOUND and GLEW_FOUND
+# If they are missing, ocioconvert will be built without the GPU option
+option(OCIO_BUILD_CONVERT_WITH_GPU "Specify whether to build ocioconvert with gpu option" OFF)
+
 # Use boost's shared_ptr by default on Windows (as <VS2010 doesn't have it),
 # Use std::tr1::shared_ptr by default on other platforms
 option(OCIO_USE_BOOST_PTR "Set to ON to enable boost shared_ptr (necessary when tr1 is not available)" WIN32)

--- a/src/apps/ocioconvert/CMakeLists.txt
+++ b/src/apps/ocioconvert/CMakeLists.txt
@@ -1,4 +1,10 @@
 if (OIIO_FOUND)
+
+    # If dependencies are missing turn off GPU
+    if(NOT (OPENGL_FOUND AND GLUT_FOUND AND GLEW_FOUND))
+        set(OCIO_BUILD_CONVERT_WITH_GPU OFF)
+    endif()
+
     include_directories(
         ${CMAKE_SOURCE_DIR}/export/
         ${CMAKE_BINARY_DIR}/export/
@@ -6,6 +12,15 @@ if (OIIO_FOUND)
         ${OIIO_INCLUDES}
         ${ILMBASE_INCLUDES}
     )
+
+    if(OCIO_BUILD_CONVERT_WITH_GPU)
+        include_directories(
+            ${CMAKE_SOURCE_DIR}/src/lang-glsl/
+            ${OPENGL_INCLUDE_DIR}
+            ${GLUT_INCLUDE_DIR}
+            ${GLEW_INCLUDES}
+        )
+    endif()
     
     file(GLOB_RECURSE share_src_files "${CMAKE_SOURCE_DIR}/src/apps/share/*.cpp")
     
@@ -14,6 +29,11 @@ if (OIIO_FOUND)
     set_target_properties(ocioconvert PROPERTIES COMPILE_FLAGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
 
     target_link_libraries(ocioconvert ${OIIO_LIBRARIES} ${CMAKE_DL_LIBS})
+
+    if(OCIO_BUILD_CONVERT_WITH_GPU)
+        add_definitions("-DBUILD_WITH_GPU")
+        target_link_libraries(ocioconvert OCIOOpenGL ${GLEW_LIBRARIES} ${GLUT_LIBRARY} ${OPENGL_LIBRARY})
+    endif()
     
     target_link_OCIO(ocioconvert)
     

--- a/src/apps/ocioconvert/main.cpp
+++ b/src/apps/ocioconvert/main.cpp
@@ -39,6 +39,22 @@ namespace OCIO = OCIO_NAMESPACE;
 namespace OIIO = OIIO_NAMESPACE;
 #endif
 
+#ifdef BUILD_WITH_GPU
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#include <OpenGL/glext.h>
+#include <GLUT/glut.h>
+#elif _WIN32
+#include <GL/glew.h>
+#include <GL/glut.h>
+#else
+#include <GL/glew.h>
+#include <GL/gl.h>
+#include <GL/glext.h>
+#include <GL/glut.h>
+#endif
+#include "glsl.h"
+#endif // BUILD_WITH_GPU
 
 #include "argparse.h"
 
@@ -60,6 +76,270 @@ parse_end_args(int argc, const char *argv[])
   return 0;
 }
 
+#ifdef BUILD_WITH_GPU
+
+class GPUManagement
+{
+private:
+    GPUManagement()
+        : m_glwin(0)
+        , m_initState(STATE_CREATED)
+        , m_imageTexID(0)
+        , m_format(0)
+        , m_width(0)
+        , m_height(0)
+    {
+    }
+
+    ~GPUManagement()
+    {
+        if (m_initState != STATE_CREATED)
+        {
+            cleanUp();
+        }
+    }
+
+public:
+
+    static GPUManagement & Instance()
+    {
+        static GPUManagement inst;
+        return inst;
+    }
+
+    void init()
+    {
+        if (m_initState != STATE_CREATED) return;
+            
+        int argcgl = 2;
+        const char* argvgl[] = { "main", "-glDebug" };
+        glutInit(&argcgl, const_cast<char**>(&argvgl[0]));
+
+        glutInitDisplayMode(GLUT_RGB | GLUT_DOUBLE | GLUT_DEPTH);
+        glutInitWindowSize(10, 10);
+        glutInitWindowPosition(0, 0);
+
+        m_glwin = glutCreateWindow(argvgl[0]);
+
+#ifndef __APPLE__
+        glewInit();
+        if (!glewIsSupported("GL_VERSION_2_0"))
+        {
+            std::cout << "OpenGL 2.0 not supported" << std::endl;
+            exit(1);
+        }
+#endif
+
+        // Initilize the OpenGL engine
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 4);           // 4-byte pixel alignment
+#ifndef __APPLE__
+        glClampColor(GL_CLAMP_READ_COLOR, GL_FALSE);     //
+        glClampColor(GL_CLAMP_VERTEX_COLOR, GL_FALSE);   // avoid any kind of clamping
+        glClampColor(GL_CLAMP_FRAGMENT_COLOR, GL_FALSE); //
+#endif
+
+        glEnable(GL_TEXTURE_2D);
+        glClearColor(0, 0, 0, 0);                        // background color
+        glClearStencil(0);                               // clear stencil buffer
+
+        m_initState = STATE_INITIALIZED;
+    }
+
+    void prepareImage(float * data, long width, long height, long numChannels)
+    {
+        if (m_initState != STATE_INITIALIZED)
+        {
+            std::cerr << "The GPU engine is not initialized." << std::endl;
+            exit(1);
+        }
+
+        m_width = width;
+        m_height = height;
+
+        if (numChannels == 4) m_format = GL_RGBA;
+        else if (numChannels == 3) m_format = GL_RGB;
+        else
+        {
+            std::cerr << "Cannot process with GPU image with "
+                << numChannels << " components." << std::endl;
+            exit(1);
+        }
+
+        glGenTextures(1, &m_imageTexID);
+
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_2D, m_imageTexID);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F_ARB, width, height, 0,
+            m_format, GL_FLOAT, &data[0]);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
+
+        // Create the frame buffer and render buffer
+        GLuint fboId;
+
+        // create a framebuffer object, you need to delete them when program exits.
+        glGenFramebuffers(1, &fboId);
+        glBindFramebuffer(GL_FRAMEBUFFER, fboId);
+
+        GLuint rboId;
+        // create a renderbuffer object to store depth info
+        glGenRenderbuffers(1, &rboId);
+        glBindRenderbuffer(GL_RENDERBUFFER, rboId);
+        glRenderbufferStorage(GL_RENDERBUFFER, GL_RGBA32F_ARB, m_width, m_height);
+        glBindRenderbuffer(GL_RENDERBUFFER, 0);
+
+        // attach a texture to FBO color attachement point
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D, m_imageTexID, 0);
+
+        // attach a renderbuffer to depth attachment point
+        glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rboId);
+
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+        // Set the rendering destination to FBO
+        glBindFramebuffer(GL_FRAMEBUFFER, fboId);
+
+        // Clear buffer
+        glClearColor(0.1f, 0.1f, 0.1f, 0.1f);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+        m_initState = STATE_IMAGE_PREPARED;
+    }
+
+    void updateGPUShader(
+        const OCIO::ConstProcessorRcPtr & processor, bool legacyShader, bool gpuinfo)
+    {
+        if (m_initState != STATE_IMAGE_PREPARED)
+        {
+            std::cerr << "GPU image not prepared." << std::endl;
+            exit(1);
+        }
+
+        OCIO::GpuShaderDescRcPtr shaderDesc
+            = legacyShader ? OCIO::GpuShaderDesc::CreateLegacyShaderDesc(32)
+                           : OCIO::GpuShaderDesc::CreateShaderDesc();
+
+        // Create the GPU shader description
+        shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_3);
+
+        // Collect the shader program information for a specific processor    
+        processor->extractGpuShaderInfo(shaderDesc);
+
+        // Use the helper OpenGL builder
+        m_oglBuilder = OpenGLBuilder::Create(shaderDesc);
+        m_oglBuilder->setVerbose(gpuinfo);
+
+        // Allocate & upload all the LUTs
+        m_oglBuilder->allocateAllTextures(1);
+
+        std::ostringstream main;
+        main << std::endl
+            << "uniform sampler2D img;" << std::endl
+            << std::endl
+            << "void main()" << std::endl
+            << "{" << std::endl
+            << "    vec4 col = texture2D(img, gl_TexCoord[0].st);" << std::endl
+            << "    gl_FragColor = " << shaderDesc->getFunctionName() << "(col);" << std::endl
+            << "}" << std::endl;
+
+        // Build the fragment shader program
+        m_oglBuilder->buildProgram(main.str().c_str());
+
+        // Enable the fragment shader program, and all needed textures
+        m_oglBuilder->useProgram();
+        glUniform1i(glGetUniformLocation(m_oglBuilder->getProgramHandle(), "img"), 0);
+        m_oglBuilder->useAllTextures();
+
+        m_initState = STATE_SHADER_UPDATED;
+    }
+
+    void processImage()
+    {
+        if (m_initState != STATE_SHADER_UPDATED)
+        {
+            std::cerr << "GPU shader has not been updated." << std::endl;
+            exit(1);
+        }
+
+        glViewport(0, 0, m_width, m_height);
+        glMatrixMode(GL_PROJECTION);
+        glLoadIdentity();
+        glOrtho(0.0, m_width, 0.0, m_height, -100.0, 100.0);
+        glMatrixMode(GL_MODELVIEW);
+        glLoadIdentity();
+
+        glEnable(GL_TEXTURE_2D);
+        glClearColor(0.1f, 0.1f, 0.1f, 0.0f);
+        glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        glColor3f(1, 1, 1);
+        glPushMatrix();
+            glBegin(GL_QUADS);
+                glTexCoord2f(0.0f, 1.0f);
+                glVertex2f(0.0f, (float)m_height);
+
+                glTexCoord2f(0.0f, 0.0f);
+                glVertex2f(0.0f, 0.0f);
+
+                glTexCoord2f(1.0f, 0.0f);
+                glVertex2f((float)m_width, 0.0f);
+
+                glTexCoord2f(1.0f, 1.0f);
+                glVertex2f((float)m_width, (float)m_height);
+            glEnd();
+        glPopMatrix();
+        glDisable(GL_TEXTURE_2D);
+
+        glutSwapBuffers();
+
+        m_initState = STATE_IMAGE_PROCESSED;
+    }
+
+    void readImage(std::vector<float>& image)
+    {
+        if (m_initState != STATE_IMAGE_PROCESSED)
+        {
+            std::cerr << "Image has not been processed by GPU shader." << std::endl;
+            exit(1);
+        }
+
+        glReadBuffer(GL_COLOR_ATTACHMENT0);
+        glReadPixels(0, 0, m_width, m_height, m_format, GL_FLOAT, (GLvoid*)&image[0]);
+
+        // Current implementation only has to process 1 image.
+        // To handle more images we could go back to STATE_INITIALIZED
+        m_initState = STATE_IMAGE_READ;
+    }
+
+private:
+    void cleanUp()
+    {
+        m_oglBuilder.reset();
+        glutDestroyWindow(m_glwin);
+        m_initState = STATE_CREATED;
+    }
+
+    enum State
+    {
+        STATE_CREATED,
+        STATE_INITIALIZED,
+        STATE_IMAGE_PREPARED,
+        STATE_SHADER_UPDATED,
+        STATE_IMAGE_PROCESSED,
+        STATE_IMAGE_READ
+    };
+    State m_initState;
+    GLint m_glwin;
+    OpenGLBuilderRcPtr m_oglBuilder;
+    GLuint m_imageTexID;
+    GLenum m_format;
+    long m_width;
+    long m_height;
+};
+
+#endif // BUILD_WITH_GPU
+
 
 bool ParseNameValuePair(std::string& name, std::string& value,
                         const std::string& input);
@@ -79,16 +359,27 @@ int main(int argc, const char **argv)
     std::vector<std::string> stringAttrs;
     std::string keepChannels;
     bool croptofull = false;
-     
+#ifdef BUILD_WITH_GPU
+    bool usegpu = false;
+    bool usegpuLegacy = false;
+    bool outputgpuInfo = false;
+#endif
+
     ap.options("ocioconvert -- apply colorspace transform to an image \n\n"
                "usage: ocioconvert [options]  inputimage inputcolorspace outputimage outputcolorspace\n\n",
                "%*", parse_end_args, "",
                "<SEPARATOR>", "OpenImageIO options",
-               "--float-attribute %L", &floatAttrs, "name=float pair defining OIIO float attribute",
-               "--int-attribute %L", &intAttrs, "name=int pair defining OIIO int attribute",
-               "--string-attribute %L", &stringAttrs, "name=string pair defining OIIO string attribute",
-               "--croptofull", &croptofull, "name=Crop or pad to make pixel data region match the \"full\" region",
-               "--ch %s", &keepChannels, "name=Select channels (e.g., \"2,3,4\")",
+               "--float-attribute %L", &floatAttrs, "float pair defining OIIO float attribute",
+               "--int-attribute %L", &intAttrs, "int pair defining OIIO int attribute",
+               "--string-attribute %L", &stringAttrs, "string pair defining OIIO string attribute",
+               "--croptofull", &croptofull, "Crop or pad to make pixel data region match the \"full\" region",
+               "--ch %s", &keepChannels, "Select channels (e.g., \"2,3,4\")",
+#ifdef BUILD_WITH_GPU
+               "--gpu", &usegpu, "Use GPU color processing instead of CPU (CPU is the default)",
+               "--gpulegacy", &usegpuLegacy, "Use the legacy (i.e. baked) GPU color processing "
+                                             "instead of the CPU one (--gpu is ignored)",
+               "--gpuinfo", &outputgpuInfo, "Output the OCIO shader program",
+#endif
                NULL
                );
     if (ap.parse (argc, argv) < 0) {
@@ -102,7 +393,18 @@ int main(int argc, const char **argv)
       ap.usage();
       exit(1);
     }
-    
+
+#ifdef BUILD_WITH_GPU
+    if (usegpuLegacy)
+    {
+        std::cerr << "Using legacy OCIO v1 GPU color processing." << std::endl;
+    }
+    else if (usegpu)
+    {
+        std::cerr << "Using GPU color processing." << std::endl;
+    }
+#endif
+
     const char * inputimage = args[0].c_str();
     const char * inputcolorspace = args[1].c_str();
     const char * outputimage = args[2].c_str();
@@ -113,8 +415,8 @@ int main(int argc, const char **argv)
     int imgwidth = 0;
     int imgheight = 0;
     int components = 0;
-    
 
+    
     // Load the image
     std::cerr << "Loading " << inputimage << std::endl;
     try
@@ -221,6 +523,16 @@ int main(int argc, const char **argv)
         exit(1);
     }
     
+#ifdef BUILD_WITH_GPU
+    // Initialize GPU
+    if (usegpu || usegpuLegacy)
+    {
+        GPUManagement & gpuMgmt = GPUManagement::Instance();
+        gpuMgmt.init();
+        gpuMgmt.prepareImage(&img[0], imgwidth, imgheight, components);
+    }
+#endif
+
     // Process the image
     try
     {
@@ -230,11 +542,28 @@ int main(int argc, const char **argv)
         // Get the processor
         OCIO::ConstProcessorRcPtr processor = config->getProcessor(inputcolorspace, outputcolorspace);
         
-        // Wrap the image in a light-weight ImageDescription
-        OCIO::PackedImageDesc imageDesc(&img[0], imgwidth, imgheight, components);
-        
-        // Apply the color transformation (in place)
-        processor->apply(imageDesc);
+#ifdef BUILD_WITH_GPU
+        if (usegpu || usegpuLegacy)
+        {
+            GPUManagement & gpuMgmt = GPUManagement::Instance();
+            // Get the GPU shader program from the processor and set GPU to use it
+            gpuMgmt.updateGPUShader(processor, usegpuLegacy, outputgpuInfo);
+
+            // Run the GPU shader on the image
+            gpuMgmt.processImage();
+
+            // Read the result
+            gpuMgmt.readImage(img);
+        }
+        else
+#endif
+        {
+            // Wrap the image in a light-weight ImageDescription
+            OCIO::PackedImageDesc imageDesc(&img[0], imgwidth, imgheight, components);
+
+            // Apply the color transformation (in place)
+            processor->apply(imageDesc);
+        }
     }
     catch(OCIO::Exception & exception)
     {
@@ -246,9 +575,9 @@ int main(int argc, const char **argv)
         std::cerr << "Unknown OCIO error encountered." << std::endl;
         exit(1);
     }
+
+
     
-    
-        
     //
     // set the provided OpenImageIO attributes
     //
@@ -301,9 +630,9 @@ int main(int argc, const char **argv)
     {
         exit(1);
     }
-    
-    
-    
+
+
+
     
     // Write out the result
     try
@@ -322,7 +651,7 @@ int main(int argc, const char **argv)
     }
     catch(...)
     {
-        std::cerr << "Error loading file.";
+        std::cerr << "Error writing file.";
         exit(1);
     }
     

--- a/src/apps/ociodisplay/main.cpp
+++ b/src/apps/ociodisplay/main.cpp
@@ -61,9 +61,10 @@ namespace OIIO = OIIO_NAMESPACE;
 
 #include "glsl.h"
 
-bool g_verbose = false;
-bool g_gpu = false;
-bool g_ociov2 = false;
+bool g_verbose   = false;
+bool g_gpulegacy = false;
+bool g_gpuinfo   = false;
+
 std::string g_filename;
 
 
@@ -182,7 +183,7 @@ static void InitImageTexture(const char * filename)
     
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(GL_TEXTURE_2D, g_imageTexID);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F_ARB, texWidth, texHeight, 0,
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F_ARB, texWidth, texHeight, 0,
         format, GL_FLOAT, &img[0]);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -485,8 +486,8 @@ void UpdateOCIOGLState()
     
     // Step 1: Create the appropriate GPU shader description
     OCIO::GpuShaderDescRcPtr shaderDesc 
-        = g_ociov2 ? OCIO::GpuShaderDesc::CreateShaderDesc()
-                   : OCIO::GpuShaderDesc::CreateLegacyShaderDesc(LUT3D_EDGE_SIZE);
+        = g_gpulegacy ? OCIO::GpuShaderDesc::CreateLegacyShaderDesc(LUT3D_EDGE_SIZE)
+                      : OCIO::GpuShaderDesc::CreateShaderDesc();
     shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_0);
     shaderDesc->setFunctionName("OCIODisplay");
     shaderDesc->setResourcePrefix("ocio_");
@@ -496,7 +497,7 @@ void UpdateOCIOGLState()
 
     // Step 3: Use the helper OpenGL builder
     g_oglBuilder = OpenGLBuilder::Create(shaderDesc);
-    g_oglBuilder->setVerbose(g_gpu);
+    g_oglBuilder->setVerbose(g_gpuinfo);
 
     // Step 4: Allocate & upload all the LUTs
     // 
@@ -679,13 +680,13 @@ void parseArguments(int argc, char **argv)
         {
             g_verbose = true;
         }
-        else if(0==strcmp(argv[i], "-gpu"))
+        else if(0==strcmp(argv[i], "-gpulegacy"))
         {
-            g_gpu = true;
+            g_gpulegacy = true;
         }
-        else if(0==strcmp(argv[i], "-ociov2"))
+        else if(0==strcmp(argv[i], "-gpuinfo"))
         {
-            g_ociov2 = true;
+            g_gpuinfo = true;
         }
         else if(0==strcmp(argv[i], "-h"))
         {
@@ -694,10 +695,10 @@ void parseArguments(int argc, char **argv)
             std::cout << "  ociodisplay [OPTIONS] [image]  where" << std::endl;
             std::cout << std::endl;
             std::cout << "  OPTIONS:" << std::endl;
-            std::cout << "     -h      :  displays the help and exit" << std::endl;
-            std::cout << "     -v      :  displays the color space information" << std::endl;
-            std::cout << "     -gpu    :  displays the color space gpu information" << std::endl;
-            std::cout << "     -ociov2 :  use the generic gpu shader engine" << std::endl;
+            std::cout << "     -h         :  displays the help and exit" << std::endl;
+            std::cout << "     -v         :  displays the color space information" << std::endl;
+            std::cout << "     -gpulegacy :  use the legacy (i.e. baked) GPU color processing" << std::endl;
+            std::cout << "     -gpuinfo   :  output the OCIO shader program" << std::endl;
             std::cout << std::endl;
             exit(0);
         }


### PR DESCRIPTION
The pull request adds the gpu capability to the ocioconvert app, rename the ociodisplay command line arguments to the ocioconvert ones, and finally switches by default ociodisplay to use the new GPU API.

The goal is to use the ocioconvert application for testing any color tranformations using the CPU, baked GPU, or new GPU color processings.