### PR TITLE
Adsk Contrib - Comments and spelling consistency

### DIFF
--- a/src/apps/ociobakelut/main.cpp
+++ b/src/apps/ociobakelut/main.cpp
@@ -77,7 +77,7 @@ int main (int argc, const char* argv[])
     
     // What are the allowed baker output formats?
     std::ostringstream formats;
-    formats << "the lut format to bake: ";
+    formats << "the LUT format to bake: ";
     for(int i=0; i<OCIO::Baker::getNumFormats(); ++i)
     {
         if(i!=0) formats << ", ";
@@ -92,7 +92,7 @@ int main (int argc, const char* argv[])
     float dummyf1, dummyf2, dummyf3;
     
     ArgParse ap;
-    ap.options("ociobakelut -- create a new LUT or icc profile from an OCIO config or lut file(s)\n\n"
+    ap.options("ociobakelut -- create a new LUT or ICC profile from an OCIO config or LUT file(s)\n\n"
                "usage:  ociobakelut [options] <OUTPUTFILE.LUT>\n\n"
                "example:  ociobakelut --inputspace lg10 --outputspace srgb8 --format flame lg_to_srgb.3dl\n"
                "example:  ociobakelut --lut filmlut.3dl --lut calibration.3dl --format flame display.3dl\n"
@@ -109,7 +109,7 @@ int main (int argc, const char* argv[])
                "--iconfig %s", &inputconfig, "Input .ocio configuration file (default: $OCIO)\n",
                "<SEPARATOR>", "Config-Free LUT Baking",
                "<SEPARATOR>", "    (all options can be specified multiple times, each is applied in order)",
-               "--cccid %s", &dummystr, "Specify a CCCId for any following luts",
+               "--cccid %s", &dummystr, "Specify a CCCId for any following LUTs",
                "--lut %s", &dummystr, "Specify a LUT (forward direction)",
                "--invlut %s", &dummystr, "Specify a LUT (inverse direction)",
                "--slope %f %f %f", &dummyf1, &dummyf2, &dummyf3, "slope",
@@ -125,9 +125,9 @@ int main (int argc, const char* argv[])
                "--v", &verbose, "Verbose",
                "--help", &help, "Print help message\n",
                "<SEPARATOR>", "ICC Options",
-               //"--cubesize %d", &cubesize, "size of the icc CLUT cube (default: 32)",
+               //"--cubesize %d", &cubesize, "size of the ICC CLUT cube (default: 32)",
                "--whitepoint %d", &whitepointtemp, "whitepoint for the profile (default: 6505)",
-               "--displayicc %s", &displayicc , "an icc profile which matches the OCIO profiles target display",
+               "--displayicc %s", &displayicc , "an ICC profile which matches the OCIO profiles target display",
                "--description %s", &description , "a meaningful description, this will show up in UI like photoshop (defaults to \"filename.icc\")",
                "--copyright %s", &copyright , "a copyright field (default: \"No copyright. Use freely.\"\n",
                // TODO: add --metadata option
@@ -256,7 +256,7 @@ int main (int argc, const char* argv[])
         
         if(format.empty())
         {
-            std::cerr << "\nERROR: You must specify the lut format using --format.\n\n";
+            std::cerr << "\nERROR: You must specify the LUT format using --format.\n\n";
             std::cerr << "See --help for more info." << std::endl;
             return 1;
         }
@@ -275,7 +275,7 @@ int main (int argc, const char* argv[])
         }
         else
         {
-            std::cerr << "ERROR: You must specify an input ocio configuration ";
+            std::cerr << "ERROR: You must specify an input .ocio configuration ";
             std::cerr << "(either with --iconfig or $OCIO).\n\n";
             ap.usage ();
             return 1;
@@ -302,14 +302,14 @@ int main (int argc, const char* argv[])
             
             if(usestdout)
             {
-                std::cerr << "\nERROR: --stdout not supported when writing icc profiles.\n\n";
+                std::cerr << "\nERROR: --stdout not supported when writing ICC profiles.\n\n";
                 std::cerr << "See --help for more info." << std::endl;
                 return 1;
             }
             
             if(outputfile.empty())
             {
-                std::cerr << "ERROR: you need to specify a output icc path\n";
+                std::cerr << "ERROR: you need to specify a output ICC path\n";
                 std::cerr << "See --help for more info." << std::endl;
                 return 1;
             }
@@ -347,7 +347,7 @@ int main (int argc, const char* argv[])
         
             OCIO::BakerRcPtr baker = OCIO::Baker::Create();
             
-            // setup the baker for our lut type
+            // setup the baker for our LUT type
             baker->setConfig(config);
             baker->setFormat(format.c_str());
             baker->setInputSpace(inputspace.c_str());
@@ -357,11 +357,11 @@ int main (int argc, const char* argv[])
             if(shapersize!=-1) baker->setShaperSize(shapersize);
             if(cubesize!=-1) baker->setCubeSize(cubesize);
             
-            // output lut
+            // output LUT
             std::ostringstream output;
             
             if(!usestdout && verbose)
-                std::cout << "[OpenColorIO INFO]: Baking '" << format << "' lut" << std::endl;
+                std::cout << "[OpenColorIO INFO]: Baking '" << format << "' LUT" << std::endl;
             
             if(usestdout)
             {

--- a/src/apps/ociobakelut/main.cpp
+++ b/src/apps/ociobakelut/main.cpp
@@ -275,7 +275,7 @@ int main (int argc, const char* argv[])
         }
         else
         {
-            std::cerr << "ERROR: You must specify an input .ocio configuration ";
+            std::cerr << "ERROR: You must specify an input OCIO configuration ";
             std::cerr << "(either with --iconfig or $OCIO).\n\n";
             ap.usage ();
             return 1;

--- a/src/apps/ociocheck/main.cpp
+++ b/src/apps/ociocheck/main.cpp
@@ -96,7 +96,7 @@ int main(int argc, const char **argv)
         }
         else
         {
-            std::cout << "ERROR: You must specify an input ocio configuration ";
+            std::cout << "ERROR: You must specify an input .ocio configuration ";
             std::cout << "(either with --iconfig or $OCIO).\n";
             ap.usage ();
             std::cout << DESC_STRING;

--- a/src/apps/ociocheck/main.cpp
+++ b/src/apps/ociocheck/main.cpp
@@ -39,7 +39,7 @@ namespace OCIO = OCIO_NAMESPACE;
 
 
 const char * DESC_STRING = "\n\n"
-"ociocheck is useful to validate that the specified .ocio configuration\n"
+"ociocheck is useful to validate that the specified OCIO configuration\n"
 "is valid, and that all the color transforms are defined.\n"
 "For example, it is possible that the configuration may reference\n"
 "lookup tables that do not exist. ociocheck will find these cases.\n\n"
@@ -96,7 +96,7 @@ int main(int argc, const char **argv)
         }
         else
         {
-            std::cout << "ERROR: You must specify an input .ocio configuration ";
+            std::cout << "ERROR: You must specify an input OCIO configuration ";
             std::cout << "(either with --iconfig or $OCIO).\n";
             ap.usage ();
             std::cout << DESC_STRING;

--- a/src/apps/ociolutimage/main.cpp
+++ b/src/apps/ociolutimage/main.cpp
@@ -104,7 +104,7 @@ void Generate(int cubesize, int maxwidth,
         else
         {
             std::ostringstream os;
-            os << "You must specify an ocio configuration ";
+            os << "You must specify an .ocio configuration ";
             os << "(either with --config or $OCIO).";
             throw Exception(os.str().c_str());
         }
@@ -176,7 +176,7 @@ void Extract(int cubesize, int maxwidth,
     
     if(spec.width*spec.height<lut3DNumPixels)
     {
-        throw Exception("Image is not large enough to contain expected 3dlut.");
+        throw Exception("Image is not large enough to contain expected 3D LUT.");
     }
     
     // TODO: confirm no data window?
@@ -202,7 +202,7 @@ void Extract(int cubesize, int maxwidth,
     
     img.resize(lut3DNumPixels*3);
     
-    // Write the output lut
+    // Write the output LUT
     WriteLut3D(outputfile, &img[0], cubesize);
 }
 
@@ -222,13 +222,13 @@ int main (int argc, const char* argv[])
     
     // TODO: Add optional allocation transform instead of colorconvert
     ArgParse ap;
-    ap.options("ociolutimage -- Convert a 3dlut to or from an image\n\n"
+    ap.options("ociolutimage -- Convert a 3D LUT to or from an image\n\n"
                "usage:  ociolutimage [options] <OUTPUTFILE.LUT>\n\n"
                "example:  ociolutimage --generate --output lut.exr\n"
                "example:  ociolutimage --extract --input lut.exr --output output.spi3d\n",
                "<SEPARATOR>", "",
                "--generate", &generate, "Generate a lattice image",
-               "--extract", &extract, "Extract a 3dlut from an input image",
+               "--extract", &extract, "Extract a 3D LUT from an input image",
                "<SEPARATOR>", "",
                "--cubesize %d", &cubesize, "Size of the cube (default: 32)",
                "--maxwidth %d", &maxwidth, "Specify maximum width of the image (default: 2048)",
@@ -282,12 +282,12 @@ int main (int argc, const char* argv[])
         }
         catch(std::exception & e)
         {
-            std::cerr << "Error extracting lut: " << e.what() << std::endl;
+            std::cerr << "Error extracting LUT: " << e.what() << std::endl;
             exit(1);
         }
         catch(...)
         {
-            std::cerr << "Error extracting lut. An unknown error occurred.\n";
+            std::cerr << "Error extracting LUT. An unknown error occurred.\n";
             exit(1);
         }
     }
@@ -317,7 +317,7 @@ void GenerateIdentityLut3D(float* img, int edgeLen, int numChannels,
     if(!img) return;
     if(numChannels < 3)
     {
-        throw Exception("Cannot generate idenitity 3d lut with less than 3 channels.");
+        throw Exception("Cannot generate identity 3D LUT with less than 3 channels.");
     }
     
     float c = 1.0f / ((float)edgeLen - 1.0f);

--- a/src/apps/ociolutimage/main.cpp
+++ b/src/apps/ociolutimage/main.cpp
@@ -104,7 +104,7 @@ void Generate(int cubesize, int maxwidth,
         else
         {
             std::ostringstream os;
-            os << "You must specify an .ocio configuration ";
+            os << "You must specify an OCIO configuration ";
             os << "(either with --config or $OCIO).";
             throw Exception(os.str().c_str());
         }

--- a/src/core/AllocationOp.cpp
+++ b/src/core/AllocationOp.cpp
@@ -26,12 +26,12 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#include <OpenColorIO/OpenColorIO.h>
 #include "AllocationOp.h"
 #include "LogOps.h"
 #include "MatrixOps.h"
 #include "Op.h"
 
-#include <OpenColorIO/OpenColorIO.h>
 #include <string.h>
 
 OCIO_NAMESPACE_ENTER

--- a/src/core/Baker.cpp
+++ b/src/core/Baker.cpp
@@ -251,11 +251,11 @@ OCIO_NAMESPACE_ENTER
         //   at least set
         // - check limits of shaper and target, throw exception if we can't
         //   write that much data in x format
-        // - check that the shaper is 1D transform only, throw excpetion
+        // - check that the shaper is 1D transform only, throw exception
         // - check the file format supports shapers, 1D and 3D
         // - add some checks to make sure we are monotonic
         // - deal with the case of writing out non cube formats (1D only)
-        // - do a compare between ocio transform and output lut transform
+        // - do a compare between OCIO transform and output LUT transform
         //   throw error if we going beyond tolerance
         //
     }

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -873,8 +873,9 @@ OCIO_NAMESPACE_ENTER
         // convert the filename to lowercase.
         std::string fullstr = pystring::lower(std::string(str));
         
-        // See if it matches a lut name.
-        // This is the position of the RIGHT end of the colorspace substring, not the left
+        // See if it matches a LUT name.
+        // This is the position of the RIGHT end of the colorspace substring,
+        // not the left
         int rightMostColorPos=-1;
         std::string rightMostColorspace = "";
         int rightMostColorSpaceIndex = -1;
@@ -889,8 +890,9 @@ OCIO_NAMESPACE_ENTER
             if(colorspacePos < 0)
                 continue;
             
-            // If we have found a match, move the pointer over to the right end of the substring
-            // This will allow us to find the longest name that matches the rightmost colorspace
+            // If we have found a match, move the pointer over to the right end
+            // of the substring.  This will allow us to find the longest name
+            // that matches the rightmost colorspace
             colorspacePos += (int)csname.size();
             
             if ( (colorspacePos > rightMostColorPos) ||
@@ -1366,7 +1368,7 @@ OCIO_NAMESPACE_ENTER
         return getProcessor(context, srcName, dstName);
     }
     
-    //! Names can be colorspace name or role name
+    // Names can be colorspace name or role name
     ConstProcessorRcPtr Config::getProcessor(const ConstContextRcPtr & context,
                                              const char * srcName,
                                              const char * dstName) const

--- a/src/core/Context.cpp
+++ b/src/core/Context.cpp
@@ -335,7 +335,7 @@ namespace
         
         for (unsigned int i = 0; i < searchpaths.size(); ++i)
         {
-            // Make an attempt to find the lut in one of the search paths
+            // Make an attempt to find the LUT in one of the search paths
             std::string fullpath = pystring::os::path::join(searchpaths[i], filename);
             std::string expandedfullpath = EnvExpand(fullpath, getImpl()->envMap_);
             if(FileExists(expandedfullpath))

--- a/src/core/FileFormat3DL.cpp
+++ b/src/core/FileFormat3DL.cpp
@@ -40,17 +40,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdio>
 #include <sstream>
 
-/*
-// Discreet's Flame Lut Format
-// Use a loose interpretation of the format to allow other 3d luts that look
+// Discreet's Flame LUT Format
+// Use a loose interpretation of the format to allow other 3D LUTs that look
 // similar, but dont strictly adhere to the real definition.
 
 // If line starts with text or # skip it
-// If line is a bunch of ints (more than 3) , it's the 1d shaper lut
+// If line is a bunch of ints (more than 3) , it's the 1D shaper LUT
 
 // All remaining lines of size 3 int are data
 // cube size is determined from num entries
-// The bit depth of the shaper lut and the 3d lut need not be the same.
+// The bit depth of the shaper LUT and the 3D LUT need not be the same.
+/*
 
 Example 1, FLAME
 # Comment here
@@ -158,12 +158,12 @@ OCIO_NAMESPACE_ENTER
         
         
         
-        // We use the maximum value found in the lut to infer
+        // We use the maximum value found in the LUT to infer
         // the bit depth.  While this is fugly. We dont believe
         // there is a better way, looking at the file, to
         // determine this.
         //
-        // Note:  We allow for 2x overshoot in the luts.
+        // Note:  We allow for 2x overshoot in the LUTs.
         // As we dont allow for odd bit depths, this isnt a big deal.
         // So sizes from 1/2 max - 2x max are valid 
         //
@@ -229,7 +229,7 @@ OCIO_NAMESPACE_ENTER
             
             int lut3dmax = 0;
 
-            // Parse the file 3d lut data to an int array
+            // Parse the file 3D LUT data to an int array
             {
                 const int MAX_LINE_SIZE = 4096;
                 char lineBuffer[MAX_LINE_SIZE];
@@ -277,7 +277,7 @@ OCIO_NAMESPACE_ENTER
                     }
                     
                     // If we've found more than 3 ints, and dont have
-                    // a shaper lut yet, we've got it!
+                    // a shaper LUT yet, we've got it!
                     if(tmpData.size()>3)
                     {
                         if (rawshaper.empty())
@@ -289,22 +289,22 @@ OCIO_NAMESPACE_ENTER
                         }
                         else
                         {
-                            // format error, more than 1 shaper lut
+                            // format error, more than 1 shaper LUT
                             std::ostringstream os;
                             os << "Error parsing .3dl file. ";
-                            os << "Appears to contain more than 1 shaper lut.";
+                            os << "Appears to contain more than 1 shaper LUT.";
                             os << "Line (" << lineNumber << "): '";
                             os << lineBuffer << "'.";
                             throw Exception(os.str().c_str());
                         }
                     }
-                    // If we've found 3 ints, add it to our 3dlut.
+                    // If we've found 3 ints, add it to our 3D LUT.
                     else if(tmpData.size() == 3)
                     {
                         raw3d.push_back(tmpData[0]);
                         raw3d.push_back(tmpData[1]);
                         raw3d.push_back(tmpData[2]);
-                        // Find the maximum shaper lut value to infer bit-depth
+                        // Find the maximum shaper LUT value to infer bit-depth
                         lut3dmax = std::max(lut3dmax, tmpData[0]);
                         lut3dmax = std::max(lut3dmax, tmpData[1]);
                         lut3dmax = std::max(lut3dmax, tmpData[2]);
@@ -326,7 +326,7 @@ OCIO_NAMESPACE_ENTER
             {
                 std::ostringstream os;
                 os << "Error parsing .3dl file. ";
-                os << "Does not appear to contain a valid shaper lut or a 3D lut.";
+                os << "Does not appear to contain a valid shaper LUT or a 3D LUT.";
                 throw Exception(os.str().c_str());
             }
             
@@ -336,17 +336,17 @@ OCIO_NAMESPACE_ENTER
             // it's possible that other formats will accidentally be able to be read
             // mistakenly as .3dl files.  We can exclude a huge segement of these mis-reads
             // by screening for files that use float represenations.  I.e., if the MAX
-            // value of the lut is a small number (such as <128.0) it's likely not an integer
+            // value of the LUT is a small number (such as <128.0) it's likely not an integer
             // format, and thus not a likely 3DL file.
             
             const int FORMAT3DL_CODEVALUE_LOWEST_PLAUSIBLE_MAXINT = 128;
             
-            // Interpret the shaper lut
+            // Interpret the shaper LUT
             if(!rawshaper.empty())
             {
                 cachedFile->has1D = true;
                 
-                // Find the maximum shaper lut value to infer bit-depth
+                // Find the maximum shaper LUT value to infer bit-depth
                 int shapermax = 0;
                 for(unsigned int i=0; i<rawshaper.size(); ++i)
                 {
@@ -357,8 +357,8 @@ OCIO_NAMESPACE_ENTER
                 {
                     std::ostringstream os;
                     os << "Error parsing .3dl file. ";
-                    os << "The maximum shaper lut value, " << shapermax;
-                    os << ", is unreasonably low. This lut is probably not a .3dl ";
+                    os << "The maximum shaper LUT value, " << shapermax;
+                    os << ", is unreasonably low. This LUT is probably not a .3dl ";
                     os << "file, but instead a related format that shares a similar ";
                     os << "structure.";
                     
@@ -370,7 +370,7 @@ OCIO_NAMESPACE_ENTER
                 {
                     std::ostringstream os;
                     os << "Error parsing .3dl file. ";
-                    os << "The maximum shaper lut value, " << shapermax;
+                    os << "The maximum shaper LUT value, " << shapermax;
                     os << ", does not correspond to any likely bit depth. ";
                     os << "Please confirm source file is valid.";
                     throw Exception(os.str().c_str());
@@ -390,7 +390,7 @@ OCIO_NAMESPACE_ENTER
                 }
                 
                 // The error threshold will be 2 code values. This will allow
-                // shaper luts which use different int conversions (round vs. floor)
+                // shaper LUTs which use different int conversions (round vs. floor)
                 // to both be optimized.
                 // Required: Abs Tolerance
                 
@@ -411,8 +411,8 @@ OCIO_NAMESPACE_ENTER
                 {
                     std::ostringstream os;
                     os << "Error parsing .3dl file.";
-                    os << "The maximum 3d lut value, " << lut3dmax;
-                    os << ", is unreasonably low. This lut is probably not a .3dl ";
+                    os << "The maximum 3D LUT value, " << lut3dmax;
+                    os << ", is unreasonably low. This LUT is probably not a .3dl ";
                     os << "file, but instead a related format that shares a similar ";
                     os << "structure.";
                     
@@ -424,7 +424,7 @@ OCIO_NAMESPACE_ENTER
                 {
                     std::ostringstream os;
                     os << "Error parsing .3dl file.";
-                    os << "The maximum 3d lut value, " << lut3dmax;
+                    os << "The maximum 3D LUT value, " << lut3dmax;
                     os << ", does not correspond to any likely bit depth. ";
                     os << "Please confirm source file is valid.";
                     throw Exception(os.str().c_str());
@@ -433,7 +433,7 @@ OCIO_NAMESPACE_ENTER
                 int bitdepthmax = GetMaxValueFromIntegerBitDepth(lut3dbitdepth);
                 float scale = 1.0f / static_cast<float>(bitdepthmax);
                 
-                // Interpret the int array as a 3dlut
+                // Interpret the int array as a 3D LUT
                 int lutEdgeLen = Get3DLutEdgeLenFromNumPixels((int)raw3d.size()/3);
                 
                 // Reformat 3D data
@@ -449,7 +449,7 @@ OCIO_NAMESPACE_ENTER
                     {
                         for (int rIndex = 0; rIndex<lutEdgeLen; ++rIndex)
                         {
-                            // In file, lut is blue fastest
+                            // In file, LUT is blue fastest
                             int i = GetLut3DIndex_BlueFast(rIndex, gIndex, bIndex,
                                 lutEdgeLen, lutEdgeLen, lutEdgeLen);
 
@@ -837,7 +837,7 @@ OIIO_ADD_TEST(FileFormat3DL, TestLoad)
     OIIO_CHECK_EQUAL(17, lutFile->lut3D->size[1]);
     OIIO_CHECK_EQUAL(17, lutFile->lut3D->size[2]);
     OIIO_CHECK_EQUAL(17*17*17*3, lutFile->lut3D->lut.size());
-    // lut is R fast, file is B fast ([3..5] is [867..869] in file)
+    // LUT is R fast, file is B fast ([3..5] is [867..869] in file)
     OIIO_CHECK_EQUAL(0.00854700897f, lutFile->lut3D->lut[3]);
     OIIO_CHECK_EQUAL(0.00244200253f, lutFile->lut3D->lut[4]);
     OIIO_CHECK_EQUAL(0.00708180759f, lutFile->lut3D->lut[5]);
@@ -848,8 +848,9 @@ OIIO_ADD_TEST(FileFormat3DL, TestLoad)
     const std::string discree3DtLutFail(ocioTestFilesDir
         + std::string("/error_truncated_file.3dl"));
 
-    OIIO_CHECK_THROW(LoadLutFile(discree3DtLutFail),
-        OCIO::Exception);
+    OIIO_CHECK_THROW_WHAT(LoadLutFile(discree3DtLutFail),
+                          OCIO::Exception,
+                          "Cannot infer 3D LUT size");
 
 }
 

--- a/src/core/FileFormatCSP.cpp
+++ b/src/core/FileFormatCSP.cpp
@@ -390,30 +390,30 @@ OCIO_NAMESPACE_ENTER
             // this shouldn't happen
             if (!istream)
             {
-                throw Exception ("file stream empty when trying to read csp lut");
+                throw Exception ("file stream empty when trying to read csp LUT");
             }
             
             Lut1DRcPtr prelut_ptr = Lut1D::Create();
             Lut1DRcPtr lut1d_ptr = Lut1D::Create();
             Lut3DRcPtr lut3d_ptr = Lut3D::Create();
 
-            // try and read the lut header
+            // try and read the LUT header
             std::string line;
             nextline (istream, line);
             if (!startswithU(line, "CSPLUTV100"))
             {
                 std::ostringstream os;
-                os << "Lut doesn't seem to be a csp file, expected 'CSPLUTV100'.";
+                os << "LUT doesn't seem to be a csp file, expected 'CSPLUTV100'.";
                 os << "First line: '" << line << "'.";
                 throw Exception(os.str().c_str());
             }
 
-            // next line tells us if we are reading a 1D or 3D lut
+            // next line tells us if we are reading a 1D or 3D LUT
             nextline (istream, line);
             if (!startswithU(line, "1D") && !startswithU(line, "3D"))
             {
                 std::ostringstream os;
-                os << "Unsupported CSP lut type. Require 1D or 3D. ";
+                os << "Unsupported CSP LUT type. Require 1D or 3D. ";
                 os << "Found, '" << line << "'.";
                 throw Exception(os.str().c_str());
             }
@@ -509,7 +509,7 @@ OCIO_NAMESPACE_ENTER
             if (csptype == "1D")
             {
 
-                // how many 1D lut points do we have
+                // how many 1D LUT points do we have
                 nextline (istream, line);
                 int points1D = atoi (line.c_str());
 
@@ -532,7 +532,7 @@ OCIO_NAMESPACE_ENTER
                     nextline (istream, line);
                     if (sscanf (line.c_str(), "%f %f %f",
                         &lp[0], &lp[1], &lp[2]) != 3) {
-                        throw Exception ("malformed 1D csp lut");
+                        throw Exception ("malformed 1D csp LUT");
                     }
 
                     // store each channel
@@ -551,7 +551,7 @@ OCIO_NAMESPACE_ENTER
                     &lut3d_ptr->size[0],
                     &lut3d_ptr->size[1],
                     &lut3d_ptr->size[2]) != 3 ) {
-                    throw Exception("malformed 3D csp lut, couldn't read cube size");
+                    throw Exception("malformed 3D csp LUT, couldn't read cube size");
                 }
                 
                 
@@ -570,7 +570,7 @@ OCIO_NAMESPACE_ENTER
                        &lut3d_ptr->lut[3*i+2]) != 3 )
                     {
                         std::ostringstream os;
-                        os << "Malformed 3D csp lut, couldn't read cube row (";
+                        os << "Malformed 3D csp LUT, couldn't read cube row (";
                         os << i << "): " << line << " .";
                         throw Exception(os.str().c_str());
                     }
@@ -602,11 +602,11 @@ OCIO_NAMESPACE_ENTER
                         cprelut_raw->values[i] = prelut_out[c][i];
                     }
                     
-                    // Create interpolater, to resample to simple 1D lut
+                    // Create interpolater, to resample to simple 1D LUT
                     rsr_Interpolator1D * interpolater =
                         rsr_Interpolator1D_createFromRaw(cprelut_raw);
                     
-                    // Resample into 1D lut
+                    // Resample into 1D LUT
                     // TODO: Fancy spline analysis to determine required number of samples
                     prelut_ptr->from_min[c] = from_min;
                     prelut_ptr->from_max[c] = from_max;
@@ -655,7 +655,7 @@ OCIO_NAMESPACE_ENTER
             
             ConstConfigRcPtr config = baker.getConfig();
             
-            // TODO: Add 1d/3d lut writing switch, using hasChannelCrosstalk
+            // TODO: Add 1D/3D LUT writing switch, using hasChannelCrosstalk
             int cubeSize = baker.getCubeSize();
             if(cubeSize==-1) cubeSize = DEFAULT_CUBE_SIZE;
             cubeSize = std::max(2, cubeSize); // smallest cube is 2x2x2
@@ -772,7 +772,7 @@ OCIO_NAMESPACE_ENTER
                 shaperToInput->apply(shaperInImg);
                 shaperToInput->apply(cubeImg);
                 
-                // Apply the 3d lut to the remainder (from the input to the output)
+                // Apply the 3D LUT to the remainder (from the input to the output)
                 ConstProcessorRcPtr inputToTarget;
                 if (!looks.empty())
                 {

--- a/src/core/FileFormatDiscreet1DL.cpp
+++ b/src/core/FileFormatDiscreet1DL.cpp
@@ -44,18 +44,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <iostream>
 
-/*
-This format is a 1D LUT format that was used by the Discreet (now Autodesk)
-creative finishing products such as Flame and Smoke.
-This format is now deprecated (but still supported) in those products.
-It has been supplanted by the Academy CLF/CTF format.
-*/
-
+// This format is a 1D LUT format that was used by the Discreet (now Autodesk)
+// creative finishing products such as Flame and Smoke.
+// This format is now deprecated (but still supported) in those products.
+// It has been supplanted by the Academy CLF/CTF format.
 
 OCIO_NAMESPACE_ENTER
 {
-    ////////////////////////////////////////////////////////////////
-    
     namespace
     {
         void ReplaceTabsAndStripSpaces(char * stringToStrip)
@@ -66,27 +61,29 @@ OCIO_NAMESPACE_ENTER
 
             if (*stringToStrip)
             {
-                while (stringToStrip[++source]) /* Find End */
+                // Find end
+                while (stringToStrip[++source])
                 {
                     if (stringToStrip[source] == 9) // TAB
                         stringToStrip[source] = ' ';
                 }
 
-                /* Find Last Non Blank */
+                // Find Last Non Blank
                 while (--source >= 0 && stringToStrip[source] == ' ')
                     /*do nothing*/;
 
+                // Chop end
                 if (stringToStrip[++source] != 0)
-                    stringToStrip[source] = 0; /* Chop End */
+                    stringToStrip[source] = 0;
 
                 source = -1;
 
-                /* Find First Non Blank */
+                // Find First Non Blank 
                 while (stringToStrip[++source] == ' ') {}
 
                 if (destination != source)
                 {
-                    /* Copy */
+                    // Copy 
                     while ((stringToStrip[destination++]
                         = stringToStrip[source++])) {
                     }
@@ -110,7 +107,7 @@ OCIO_NAMESPACE_ENTER
         {
         public:
             //
-            // Defined values of supported lut formats.
+            // Defined values of supported LUT formats.
             // this enumerator is mapped onto the values defined
             // in IM_BitsPerChannel
             //
@@ -124,23 +121,21 @@ OCIO_NAMESPACE_ENTER
                 IM_LUT_FLOATBITS_PERCHANNEL = -32
             } IM_LutBitsPerChannel;
 
-            /* A look-up table descriptor: */
+            // A look-up table descriptor: 
             class IMLutStruct {
             public:
-                int numtables; /* Number of tables. */
-                int length; /* Length of each table. */
+                int numtables; // Number of tables.
+                int length;  // Length of each table.
                 IM_LutBitsPerChannel srcBitDepth;
-                IM_LutBitsPerChannel targetBitDepth;  /* Hint if this is a resizing Lut */
-                unsigned short ** tables; /* Points to an array of "numtables"
-                                          * pointers to tables of length
-                                          * "length".
-                                          */
+                IM_LutBitsPerChannel targetBitDepth;  // Hint if this is a resizing LUT
+                unsigned short ** tables; // Points to an array of "numtables"
+                                          // pointers to tables of length "length".
 
                 IMLutStruct() : numtables(0), tables(0) {}
                 ~IMLutStruct();
             };
 
-            /* Image LUT library return codes: */
+            // Image LUT library return codes: 
             enum {
                 IMLUT_OK = 0,
                 IMLUT_ERR_UNEXPECTED_EOF,
@@ -149,50 +144,36 @@ OCIO_NAMESPACE_ENTER
                 IMLUT_ERR_SYNTAX
             };
 
-            /*-----------------------------------------------------------------------
-            Convert between table size and bit depth
-            */
+            // Convert between table size and bit depth
             static IM_LutBitsPerChannel IMLutTableSizeToBitDepth(int tableSize,
                 bool isFloat = false);
 
-            /*-----------------------------------------------------------------------
-            Supply appropriate message string given IMLUT_ERR code.
-            */
+            // Supply appropriate message string given IMLUT_ERR code.
             static const char * IMLutErrorStr(int errnum);
 
-            /*-----------------------------------------------------------------------
-            Free an image look-up table descriptor.
-            */
+            // Free an image look-up table descriptor.
             static void IMLutFree(IMLutStruct **lut);
 
-            /*-----------------------------------------------------------------------
-            Allocate memory for an image look-up table descriptor.
-            */
+            // Allocate memory for an image look-up table descriptor.
             static bool IMLutAlloc(IMLutStruct **plut, int num, int length);
 
-            /*-----------------------------------------------------------------------
-            Attempt to open and read a file as an image look-up table.
-            If successful, allocate and return a "lut", a look-up table
-            descriptor, otherwise return appropriate error status and line
-            of input file at which error occurred.
-            */
+            // Attempt to open and read a file as an image look-up table.
+            // If successful, allocate and return a "LUT", a look-up table
+            // descriptor, otherwise return appropriate error status and line
+            // of input file at which error occurred.
             static int IMLutGet(
                 std::istream & istream,
                 const std::string & fileName,
                 IMLutStruct **lut, int & line, std::string & errorLine);
 
-            /*-----------------------------------------------------------------------
-            Determines the bitdepth of a Lut given it's filename Searches for
-            the first occurence of the "to" sequence of characters in the
-            LutFileName string and then parses the numeric characters.
-            This function is usefull for figuring out the target bitdepth
-            of resizing lut if the filename is an indicator of this
-            */
+            // Determines the bitdepth of a LUT given it's filename Searches for
+            // the first occurence of the "to" sequence of characters in the
+            // LutFileName string and then parses the numeric characters.
+            // This function is usefull for figuring out the target bitdepth
+            // of resizing LUT if the filename is an indicator of this
             static IM_LutBitsPerChannel IMLutGetBitDepthFromFileName(const std::string & fileName);
 
-            /*-----------------------------------------------------------------------
-            Get maximum value in the table based on the bit depth
-            */
+            // Get maximum value in the table based on the bit depth
             static float GetMax(IM_LutBitsPerChannel lutBitDepth);
 
         };
@@ -223,19 +204,30 @@ OCIO_NAMESPACE_ENTER
             return IM_LUT_UNKNOWN_BITS_PERCHANNEL;
         }
 
-        /*-----------------------------------------------------------------------
-        Free an image look-up table descriptor.
-        */
+        // Free an image look-up table descriptor.
         Lut1dUtils::IMLutStruct::~IMLutStruct()
         {
-            if (tables) {
-                for (int i = 0; i < numtables; i++) {
-                    if (tables[i]) {
+            if (tables)
+            {
+                for (int i = 0; i < numtables; i++)
+                {
+                    if (tables[i])
+                    {
+                        // in case there was only 1 table in the file
+                        // the pointer might have been copied.
                         int j;
-                        for (j = 0; j < i; j++) {
-                            if (tables[j] == tables[i]) { break; }
+                        for (j = 0; j < i; j++)
+                        {
+                            if (tables[j] == tables[i])
+                            {
+                                break;
+                            }
                         }
-                        if (j == i) { free(tables[i]); }
+                        if (j == i)
+                        {
+                            free(tables[i]);
+                            // do not NULL the value (loop above needs it).
+                        }
                     }
                 }
                 free(tables);
@@ -251,12 +243,10 @@ OCIO_NAMESPACE_ENTER
             }
         }
 
-        /*-----------------------------------------------------------------------
-        Allocate and initialize a look-up table descriptor.
-        If successful, return TRUE.
-        NOTE:
-        *plut must be NULL when this routine is called!
-        */
+        // Allocate and initialize a look-up table descriptor.
+        // If successful, return TRUE.
+        // NOTE:
+        // *plut must be NULL when this routine is called!
         bool Lut1dUtils::IMLutAlloc(IMLutStruct **plut, int num, int length)
         {
             int i;
@@ -282,16 +272,19 @@ OCIO_NAMESPACE_ENTER
             lut->targetBitDepth = IMLutTableSizeToBitDepth(length);
 
             lut->tables = (unsigned short **)malloc(4 * sizeof(unsigned short *));
-            if (lut->tables == NULL) {
+            if (lut->tables == NULL)
+            {
                 delete lut;
                 lut = 0;
                 return false;
             }
             for (i = 0; i < num; i++)
                 lut->tables[i] = NULL;
-            for (i = 0; i < num; i++) {
+            for (i = 0; i < num; i++)
+            {
                 lut->tables[i] = (unsigned short *)malloc(length * sizeof(unsigned short));
-                if (lut->tables[i] == NULL) {
+                if (lut->tables[i] == NULL)
+                {
                     delete lut;
                     lut = 0;
                     return false;
@@ -301,17 +294,15 @@ OCIO_NAMESPACE_ENTER
             return true;
         }
 
-        /*-----------------------------------------------------------------------
-        Load values from stream into table "ptable".
-        Return an error status.
-        */
+        // Load values from stream into table "ptable".
+        // Return an error status.
         static int tableLoad(
             std::istream & istream,
-            unsigned short *ptable, /* Destination table. */
-            int length, /* Length of ptable. */
-            int ptablestart, /* Start at ptable[ptablestart]. */
-            int & line, /* Last line successfully read. */
-            std::string & errorLine /* Line content in case of syntax err */
+            unsigned short *ptable, // Destination table.
+            int length,             // Length of ptable.
+            int ptablestart,        // Start at ptable[ptablestart].
+            int & line,             // Last line successfully read.
+            std::string & errorLine // Line content in case of syntax err
         )
         {
             char InString[200];
@@ -342,14 +333,12 @@ OCIO_NAMESPACE_ENTER
             return Lut1dUtils::IMLUT_OK;
         }
 
-        /*-----------------------------------------------------------------------
-        Find first line that is not blank or a comment:
-        */
+        // Find first line that is not blank or a comment:
         static bool FindNonComment(
             std::istream & istream,
             int & line,
             char InString[],
-            int length /* Length of InString. */
+            int length // Length of InString.
         )
         {
             bool readOn = true;
@@ -367,12 +356,10 @@ OCIO_NAMESPACE_ENTER
             return istream.good();
         }
 
-        /*-----------------------------------------------------------------------
-        Attempt to open and read a file as an image look-up table.
-        If successful, allocate and return "plut", a look-up table
-        descriptor, otherwise return appropriate error status and line
-        of input file at which error occurred.
-        */
+        // Attempt to open and read a file as an image look-up table.
+        // If successful, allocate and return "plut", a look-up table
+        // descriptor, otherwise return appropriate error status and line
+        // of input file at which error occurred.
         int Lut1dUtils::IMLutGet(
             std::istream & istream,
             const std::string & fileName,
@@ -391,31 +378,33 @@ OCIO_NAMESPACE_ENTER
 
             line = 0;
 
-            /* Find first line that is not blank or a comment:
-            */
-            if (!FindNonComment(istream, line, InString, 200)) {
+            // Find first line that is not blank or a comment:
+            if (!FindNonComment(istream, line, InString, 200))
+            {
                 status = IMLUT_ERR_UNEXPECTED_EOF;
                 *plut = 0;
                 goto load_abort;
             }
 
-            if (isdigit(*InString)) {
-                /* Old format LUT file:  1 table of 256 entries. */
+            if (isdigit(*InString))
+            {
+                // Old format LUT file:  1 table of 256 entries.
                 numtables = 1;
                 length = 256;
 
-                if (!IMLutAlloc(&lut, numtables, length)) {
+                if (!IMLutAlloc(&lut, numtables, length))
+                {
                     status = IMLUT_ERR_CANNOT_MALLOC;
                     *plut = 0;
                     goto load_abort;
                 }
 
-                /* Load first table value.
-                */
+                // Load first table value.
                 (lut->tables[0])[0] = (unsigned short)atoi(InString);
                 tablestart = 1;
             }
-            else {
+            else
+            {
                 char dstDepthS[16] = "";
 #ifdef WINDOWS
                 const int nummatched = sscanf(InString, "%*s %d %d %s", &numtables, &length, dstDepthS, 16);
@@ -434,14 +423,11 @@ OCIO_NAMESPACE_ENTER
                     goto load_abort;
                 }
 
-                /* New format LUT file:  "numtables" tables, each of
-                 * "length" entries. Optional dstDepth.
-                 */
-
+                // New format LUT file:  "numtables" tables, each of
+                // "length" entries. Optional dstDepth.
                 if (nummatched > 2)
                 {
                     // Optional dstDepth was specified. Validate it.
-                    //
                     int dstDepth = 0;
                     char floatC = ' ';
 #ifdef WINDOWS
@@ -458,7 +444,8 @@ OCIO_NAMESPACE_ENTER
 
                     depthScaled = IMLutTableSizeToBitDepth(dstDepth,
                         floatC == 'f' || floatC == 'F');
-                    if (depthScaled == IM_LUT_UNKNOWN_BITS_PERCHANNEL) {
+                    if (depthScaled == IM_LUT_UNKNOWN_BITS_PERCHANNEL)
+                    {
                         errorLine = InString;
                         status = IMLUT_ERR_SYNTAX;
                         *plut = 0;
@@ -466,7 +453,8 @@ OCIO_NAMESPACE_ENTER
                     }
                 }
 
-                if (!IMLutAlloc(&lut, numtables, length)) {
+                if (!IMLutAlloc(&lut, numtables, length))
+                {
                     status = IMLUT_ERR_CANNOT_MALLOC;
                     *plut = 0;
                     goto load_abort;
@@ -474,37 +462,42 @@ OCIO_NAMESPACE_ENTER
                 tablestart = 0;
             }
 
-            for (i = 0; i < numtables; i++) {
+            for (i = 0; i < numtables; i++)
+            {
                 status = tableLoad(
                     istream,
                     lut->tables[i],
                     length,
                     tablestart, 
                     line, errorLine);
-                if (status != IMLUT_OK) {
+                if (status != IMLUT_OK)
+                {
                     IMLutFree(&lut);
                     *plut = 0;
                     goto load_abort;
                 }
             }
 
-            if (numtables == 1) {
+            if (numtables == 1)
+            {
                 lut->numtables = 3;
                 lut->tables[2] = lut->tables[1] = lut->tables[0];
             }
 
-            if (depthScaled == IM_LUT_UNKNOWN_BITS_PERCHANNEL) {
+            if (depthScaled == IM_LUT_UNKNOWN_BITS_PERCHANNEL)
+            {
                 depthScaled = IMLutGetBitDepthFromFileName(fileName.c_str());
             }
 
-            if (IM_LUT_UNKNOWN_BITS_PERCHANNEL != depthScaled) {
+            if (IM_LUT_UNKNOWN_BITS_PERCHANNEL != depthScaled)
+            {
                 lut->targetBitDepth = depthScaled;
             }
 
-            /* If there are any more lines in the file that are not blank
-             * or comments, it's a syntax error:
-             */
-            if (FindNonComment(istream, line, InString, 200)) {
+            // If there are any more lines in the file that are not blank
+            // or comments, it's a syntax error:
+            if (FindNonComment(istream, line, InString, 200))
+            {
                 errorLine = InString;
                 status = IMLUT_ERR_SYNTAX;
                 IMLutFree(&lut);
@@ -518,59 +511,68 @@ OCIO_NAMESPACE_ENTER
             return status;
         }
 
-        /*-----------------------------------------------------------------------
-        Parses the filename and attempts to determine the bitdepth
-        of the LUT
-        */
+        // Parses the filename and attempts to determine the bitdepth
+        // of the LUT
         Lut1dUtils::IM_LutBitsPerChannel Lut1dUtils::IMLutGetBitDepthFromFileName(const std::string & fileName)
         {
-            if (fileName.empty()) {
+            if (fileName.empty())
+            {
                 return IM_LUT_UNKNOWN_BITS_PERCHANNEL;
             }
 
             std::string lowerFileName(pystring::lower(fileName));
 
-            //Get the export depth from the lut name.  Look for a bit depth
-            //after the "to" string. (ex: 12to10log).
+            // Get the export depth from the LUT name.  Look for a bit depth
+            // after the "to" string. (ex: 12to10log).
             const char* tokenStr;
             if ((tokenStr = strstr(lowerFileName.c_str(), "to")))
             {
-                //Skip the "to";
+                // Skip the "to";
                 tokenStr += 2;
                 char firstChar = *tokenStr;
-                if (firstChar == '8') {
+                if (firstChar == '8')
+                {
                     return IM_LUT_8BITS_PERCHANNEL;
                 }
-                else if (firstChar == '1') {
-                    //Advance one character.
+                else if (firstChar == '1')
+                {
+                    // Advance one character.
                     tokenStr++;
                     char secondChar = *tokenStr;
-                    if (secondChar == '0') {
+                    if (secondChar == '0')
+                    {
                         return IM_LUT_10BITS_PERCHANNEL;
                     }
-                    else if (secondChar == '2') {
+                    else if (secondChar == '2')
+                    {
                         return IM_LUT_12BITS_PERCHANNEL;
                     }
-                    else if (secondChar == '6') {
-                        //check for 16fp
+                    else if (secondChar == '6')
+                    {
+                        // check for 16fp
                         tokenStr++;
                         char thirdChar = *tokenStr;
-                        if (thirdChar == 'f' || thirdChar == 'F') {
+                        if (thirdChar == 'f' || thirdChar == 'F')
+                        {
                             return IM_LUT_HALFBITS_PERCHANNEL;
                         }
-                        else {
+                        else
+                        {
                             return IM_LUT_16BITS_PERCHANNEL;
                         }
                     }
                 }
-                else if (firstChar == '3') {
+                else if (firstChar == '3')
+                {
                     tokenStr++;
                     char secondChar = *tokenStr;
 
-                    if (secondChar == '2') {
+                    if (secondChar == '2')
+                    {
                         tokenStr++;
                         char thirdChar = *tokenStr;
-                        if (thirdChar == 'f' || thirdChar == 'F') {
+                        if (thirdChar == 'f' || thirdChar == 'F')
+                        {
                             return IM_LUT_FLOATBITS_PERCHANNEL;
                         }
                     }
@@ -580,12 +582,11 @@ OCIO_NAMESPACE_ENTER
             return IM_LUT_UNKNOWN_BITS_PERCHANNEL;
         }
 
-        /*-----------------------------------------------------------------------
-        Supply appropriate message string given IMLUT_ERR status code.
-        */
+        // Supply appropriate message string given IMLUT_ERR status code.
         const char * Lut1dUtils::IMLutErrorStr(int errnum)
         {
-            switch (errnum) {
+            switch (errnum) 
+            {
             case IMLUT_OK:
                 return "";
             case IMLUT_ERR_UNEXPECTED_EOF:

--- a/src/core/FileFormatHDL.cpp
+++ b/src/core/FileFormatHDL.cpp
@@ -32,9 +32,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     http://www.sidefx.com/docs/hdk11.0/hdk_io_lut.html
     
     Types:
-      - 1D Lut (partial support)
-      - 3D Lut
-      - 3D Lut with 1D Prelut
+      - 1D LUT (partial support)
+      - 3D LUT
+      - 3D LUT with 1D Prelut
     
     TODO:
         - Add support for other 1D types (R, G, B, A, RGB, RGBA, All)
@@ -180,7 +180,7 @@ OCIO_NAMESPACE_ENTER
                     }
                     else
                     {
-                        // Named lut, e.g "Pre {"
+                        // Named LUT, e.g "Pre {"
                         inlut = true;
                         lutname = pystring::lower(word);
 
@@ -309,7 +309,7 @@ OCIO_NAMESPACE_ENTER
             
             // this shouldn't happen
             if (!istream)
-                throw Exception ("file stream empty when trying to read Houdini lut");
+                throw Exception ("file stream empty when trying to read Houdini LUT");
 
             //
             CachedFileHDLRcPtr cachedFile = CachedFileHDLRcPtr (new CachedFileHDL ());

--- a/src/core/FileFormatICC.cpp
+++ b/src/core/FileFormatICC.cpp
@@ -63,7 +63,7 @@ OCIO_NAMESPACE_ENTER
         // Gamma
         float mGammaRGB[4];
 
-        // Lut 1d
+        // 1D LUT
         Lut1DRcPtr lut;
     };
 
@@ -611,7 +611,7 @@ OIIO_ADD_TEST(FileFormatICC, TestFile)
         OIIO_CHECK_EQUAL(0.0f, tmp[2]);
         OIIO_CHECK_EQUAL(1.0f, tmp[3]);
 
-        // Knowing the lut has 1024 elements
+        // Knowing the LUT has 1024 elements
         // and is inverted, verify values for a given index
         // are converted to index * step
         const float error = 1e-6f;
@@ -625,7 +625,8 @@ OIIO_ADD_TEST(FileFormatICC, TestFile)
         OIIO_CHECK_CLOSE(200.0f / 1023.0f, tmp[1], error);
         OIIO_CHECK_CLOSE(200.0f / 1023.0f, tmp[2], error);
 
-        // Get cached file to access lut size
+
+        // Get cached file to access LUT size
         OIIO_CHECK_NO_THROW(iccFile = LoadICCFile(iccFileName));
 
         OIIO_CHECK_ASSERT((bool)iccFile);
@@ -637,6 +638,10 @@ OIIO_ADD_TEST(FileFormatICC, TestFile)
         OIIO_CHECK_EQUAL(1024, iccFile->lut->luts[0].size());
         OIIO_CHECK_EQUAL(1024, iccFile->lut->luts[1].size());
         OIIO_CHECK_EQUAL(1024, iccFile->lut->luts[2].size());
+
+        OIIO_CHECK_EQUAL(0.0317235067f, iccFile->lut->luts[0][200]);
+        OIIO_CHECK_EQUAL(0.0317235067f, iccFile->lut->luts[1][200]);
+        OIIO_CHECK_EQUAL(0.0317235067f, iccFile->lut->luts[2][200]);
     }
 
     {

--- a/src/core/FileFormatIridasCube.cpp
+++ b/src/core/FileFormatIridasCube.cpp
@@ -177,7 +177,7 @@ OCIO_NAMESPACE_ENTER
             // this shouldn't happen
             if(!istream)
             {
-                throw Exception ("File stream empty when trying to read Iridas .cube lut");
+                throw Exception ("File stream empty when trying to read Iridas .cube LUT");
             }
             
             // Parse the file
@@ -304,7 +304,7 @@ OCIO_NAMESPACE_ENTER
                 }
             }
             
-            // Interpret the parsed data, validate lut sizes
+            // Interpret the parsed data, validate LUT sizes
             
             LocalCachedFileRcPtr cachedFile = LocalCachedFileRcPtr(new LocalCachedFile());
             
@@ -341,7 +341,7 @@ OCIO_NAMESPACE_ENTER
                     // are written out with 6 decimal places of precision.  This is
                     // a bit aggressive, I.e., changes in the 6th decimal place will
                     // be considered roundoff error, but changes in the 5th decimal
-                    // will be considered lut 'intent'.
+                    // will be considered LUT 'intent'.
                     // 1.0
                     // 1.000005 equal to 1.0
                     // 1.000007 equal to 1.0
@@ -361,7 +361,7 @@ OCIO_NAMESPACE_ENTER
                     != static_cast<int>(raw.size()/3))
                 {
                     std::ostringstream os;
-                    os << "Incorrect number of lut3d entries. ";
+                    os << "Incorrect number of 3D LUT entries. ";
                     os << "Found " << raw.size() / 3 << ", expected ";
                     os << size3d[0] * size3d[1] * size3d[2] << ".";
                     ThrowErrorMessage(
@@ -380,7 +380,7 @@ OCIO_NAMESPACE_ENTER
             else
             {
                 ThrowErrorMessage(
-                    "Lut type (1D/3D) unspecified.",
+                    "LUT type (1D/3D) unspecified.",
                     fileName, -1, "");
             }
             
@@ -570,7 +570,7 @@ OIIO_ADD_TEST(FileFormatIridasCube, ReadFailure)
     {
         // Validate stream can be read with no error.
         // Then stream will be altered to introduce errors.
-        const std::string SAMPLE_ERROR =
+        const std::string SAMPLE_NO_ERROR =
             "LUT_3D_SIZE 2\n"
             "DOMAIN_MIN 0.0 0.0 0.0\n"
             "DOMAIN_MAX 1.0 1.0 1.0\n"
@@ -584,7 +584,7 @@ OIIO_ADD_TEST(FileFormatIridasCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_NO_THROW(ReadIridasCube(SAMPLE_ERROR));
+        OIIO_CHECK_NO_THROW(ReadIridasCube(SAMPLE_NO_ERROR));
     }
     {
         // Wrong LUT_3D_SIZE tag
@@ -602,7 +602,9 @@ OIIO_ADD_TEST(FileFormatIridasCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW(ReadIridasCube(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadIridasCube(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Malformed LUT_3D_SIZE tag");
     }
     {
         // Wrong DOMAIN_MIN tag
@@ -620,7 +622,9 @@ OIIO_ADD_TEST(FileFormatIridasCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW(ReadIridasCube(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadIridasCube(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Malformed DOMAIN_MIN tag");
     }
     {
         // Wrong DOMAIN_MAX tag
@@ -638,7 +642,9 @@ OIIO_ADD_TEST(FileFormatIridasCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW(ReadIridasCube(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadIridasCube(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Malformed DOMAIN_MAX tag");
     }
     {
         // Unexpected tag
@@ -656,7 +662,9 @@ OIIO_ADD_TEST(FileFormatIridasCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW(ReadIridasCube(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadIridasCube(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Malformed color triples specified");
     }
     {
         // Wrong number of entries
@@ -676,7 +684,9 @@ OIIO_ADD_TEST(FileFormatIridasCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW(ReadIridasCube(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadIridasCube(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Incorrect number of 3D LUT entries");
     }
 }
 

--- a/src/core/FileFormatIridasItx.cpp
+++ b/src/core/FileFormatIridasItx.cpp
@@ -151,7 +151,7 @@ OCIO_NAMESPACE_ENTER
             // this shouldn't happen
             if(!istream)
             {
-                throw Exception ("File stream empty when trying to read Iridas .itx lut");
+                throw Exception ("File stream empty when trying to read Iridas .itx LUT");
             }
             
             // Parse the file
@@ -218,7 +218,7 @@ OCIO_NAMESPACE_ENTER
                 }
             }
             
-            // Interpret the parsed data, validate lut sizes
+            // Interpret the parsed data, validate LUT sizes
             LocalCachedFileRcPtr cachedFile 
                 = LocalCachedFileRcPtr(new LocalCachedFile());
             
@@ -228,7 +228,7 @@ OCIO_NAMESPACE_ENTER
                     != static_cast<int>(raw.size()/3))
                 {
                     std::ostringstream os;
-                    os << "Incorrect number of lut3d entries. ";
+                    os << "Incorrect number of 3D LUT entries. ";
                     os << "Found " << raw.size() / 3 << ", expected ";
                     os << size3d[0] * size3d[1] * size3d[2] << ".";
                     ThrowErrorMessage(
@@ -245,7 +245,7 @@ OCIO_NAMESPACE_ENTER
             else
             {
                 ThrowErrorMessage(
-                    "No 3D lut found.",
+                    "No 3D LUT found.",
                     fileName, -1, "");
             }
             
@@ -395,7 +395,7 @@ OIIO_ADD_TEST(FileFormatIridasItx, ReadFailure)
     {
         // Validate stream can be read with no error.
         // Then stream will be altered to introduce errors.
-        const std::string SAMPLE_ERROR =
+        const std::string SAMPLE_NO_ERROR =
             "LUT_3D_SIZE 2\n"
 
             "0.0 0.0 0.0\n"
@@ -407,7 +407,7 @@ OIIO_ADD_TEST(FileFormatIridasItx, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_NO_THROW(ReadIridasItx(SAMPLE_ERROR));
+        OIIO_CHECK_NO_THROW(ReadIridasItx(SAMPLE_NO_ERROR));
     }
     {
         // Wrong LUT_3D_SIZE tag
@@ -423,7 +423,9 @@ OIIO_ADD_TEST(FileFormatIridasItx, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW(ReadIridasItx(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadIridasItx(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Malformed LUT_3D_SIZE tag");
     }
     {
         // Unexpected tag
@@ -440,7 +442,9 @@ OIIO_ADD_TEST(FileFormatIridasItx, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW(ReadIridasItx(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadIridasItx(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Malformed color triples specified");
     }
     {
         // Wrong number of entries
@@ -458,7 +462,9 @@ OIIO_ADD_TEST(FileFormatIridasItx, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW(ReadIridasItx(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadIridasItx(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Incorrect number of 3D LUT entries");
     }
 }
 

--- a/src/core/FileFormatIridasLook.cpp
+++ b/src/core/FileFormatIridasLook.cpp
@@ -356,8 +356,8 @@ OCIO_NAMESPACE_ENTER
             if((size_3d*size_3d*size_3d)*3 != static_cast<int>(raw.size()))
             {
                 std::ostringstream os;
-                os << "Parse error in Iridas .look lut. ";
-                os << "Incorrect number of lut3d entries. ";
+                os << "Parse error in Iridas .look LUT. ";
+                os << "Incorrect number of 3D LUT entries. ";
                 os << "Found " << raw.size() << " values, expected " << (size_3d*size_3d*size_3d)*3 << ".";
                 throw Exception(os.str().c_str());
             }

--- a/src/core/FileFormatPandora.cpp
+++ b/src/core/FileFormatPandora.cpp
@@ -90,7 +90,7 @@ OCIO_NAMESPACE_ENTER
             const std::string & lineContent)
         {
             std::ostringstream os;
-            os << "Error parsing Pandora lut file (";
+            os << "Error parsing Pandora LUT file (";
             os << fileName;
             os << ").  ";
             if (-1 != line)
@@ -126,7 +126,8 @@ OCIO_NAMESPACE_ENTER
             // this shouldn't happen
             if(!istream)
             {
-                throw Exception ("File stream empty when trying to read Pandora lut");
+                throw Exception ("File stream empty when trying "
+                                 "to read Pandora LUT");
             }
             
             // Validate the file type
@@ -149,7 +150,8 @@ OCIO_NAMESPACE_ENTER
                     ++lineNumber;
 
                     // Strip, lowercase, and split the line
-                    pystring::split(pystring::lower(pystring::strip(line)), parts);
+                    pystring::split(pystring::lower(pystring::strip(line)),
+                                    parts);
                     if(parts.empty()) continue;
                     
                     // Skip all lines starting with '#'
@@ -157,10 +159,11 @@ OCIO_NAMESPACE_ENTER
                     
                     if(parts[0] == "channel")
                     {
-                        if(parts.size() != 2 || pystring::lower(parts[1]) != "3d")
+                        if(parts.size() != 2 
+                            || pystring::lower(parts[1]) != "3d")
                         {
                             ThrowErrorMessage(
-                                "Only 3d luts are currently supported "
+                                "Only 3D LUTs are currently supported "
                                 "(channel: 3d).",
                                 fileName,
                                 lineNumber,
@@ -184,7 +187,9 @@ OCIO_NAMESPACE_ENTER
                     }
                     else if(parts[0] == "out")
                     {
-                        if(parts.size() != 2 || !StringToInt( &outputBitDepthMaxValue, parts[1].c_str()))
+                        if(parts.size() != 2 
+                            || !StringToInt(&outputBitDepthMaxValue,
+                                            parts[1].c_str()))
                         {
                             ThrowErrorMessage(
                                 "Malformed 'out' tag.",
@@ -195,10 +200,11 @@ OCIO_NAMESPACE_ENTER
                     }
                     else if(parts[0] == "format")
                     {
-                        if(parts.size() != 2 || pystring::lower(parts[1]) != "lut")
+                        if(parts.size() != 2 
+                            || pystring::lower(parts[1]) != "lut")
                         {
                             ThrowErrorMessage(
-                                "Only luts are currently supported "
+                                "Only LUTs are currently supported "
                                 "(format: lut).",
                                 fileName,
                                 lineNumber,
@@ -213,7 +219,7 @@ OCIO_NAMESPACE_ENTER
                            pystring::lower(parts[3]) != "blue")
                         {
                             ThrowErrorMessage(
-                                "Only rgb luts are currently supported "
+                                "Only rgb LUTs are currently supported "
                                 "(values: red green blue).",
                                 fileName,
                                 lineNumber,
@@ -240,12 +246,13 @@ OCIO_NAMESPACE_ENTER
                 }
             }
             
-            // Interpret the parsed data, validate lut sizes
+            // Interpret the parsed data, validate LUT sizes
             if(lutEdgeLen*lutEdgeLen*lutEdgeLen != static_cast<int>(raw3d.size()/3))
             {
                 std::ostringstream os;
-                os << "Incorrect number of lut3d entries. ";
-                os << "Found " << raw3d.size() / 3 << ", expected " << lutEdgeLen*lutEdgeLen*lutEdgeLen << ".";
+                os << "Incorrect number of 3D LUT entries. ";
+                os << "Found " << raw3d.size() / 3 << ", expected ";
+                os << lutEdgeLen*lutEdgeLen*lutEdgeLen << ".";
                 ThrowErrorMessage(
                     os.str().c_str(),
                     fileName, -1, "");
@@ -254,7 +261,7 @@ OCIO_NAMESPACE_ENTER
             if(lutEdgeLen*lutEdgeLen*lutEdgeLen == 0)
             {
                 ThrowErrorMessage(
-                    "No 3D Lut entries found.",
+                    "No 3D LUT entries found.",
                     fileName, -1, "");
             }
             
@@ -282,7 +289,7 @@ OCIO_NAMESPACE_ENTER
                 {
                     for (int rIndex = 0; rIndex<lutEdgeLen; ++rIndex)
                     {
-                        // In file, lut is blue fastest
+                        // In file, LUT is blue fastest
                         int i = GetLut3DIndex_BlueFast(rIndex, gIndex, bIndex,
                                                       lutEdgeLen, lutEdgeLen, lutEdgeLen);
                         cachedFile->lut3D->lut.push_back(static_cast<float>(raw3d[i+0]) * scale);
@@ -309,7 +316,7 @@ OCIO_NAMESPACE_ENTER
             if(!cachedFile)
             {
                 std::ostringstream os;
-                os << "Cannot build Truelight .cub Op. Invalid cache type.";
+                os << "Cannot build Pandora LUT. Invalid cache type.";
                 throw Exception(os.str().c_str());
             }
             
@@ -382,7 +389,7 @@ OIIO_ADD_TEST(FileFormatPandora, ReadFailure)
     {
         // Validate stream can be read with no error.
         // Then stream will be altered to introduce errors.
-        const std::string SAMPLE_ERROR =
+        const std::string SAMPLE_NO_ERROR =
             "channel 3d\n"
             "in 8\n"
             "out 256\n"
@@ -397,7 +404,7 @@ OIIO_ADD_TEST(FileFormatPandora, ReadFailure)
             "6 255 255   0\n"
             "7 255 255 255\n";
 
-        OIIO_CHECK_NO_THROW(ReadPandora(SAMPLE_ERROR));
+        OIIO_CHECK_NO_THROW(ReadPandora(SAMPLE_NO_ERROR));
     }
     {
         // Wrong channel tag
@@ -416,10 +423,12 @@ OIIO_ADD_TEST(FileFormatPandora, ReadFailure)
             "6 255 255   0\n"
             "7 255 255 255\n";
 
-        OIIO_CHECK_THROW(ReadPandora(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadPandora(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Only 3D LUTs are currently supported");
     }
     {
-        // No value spec
+        // No value spec (LUT will not be read)
         const std::string SAMPLE_ERROR =
             "channel 3d\n"
             "in 8\n"
@@ -434,12 +443,14 @@ OIIO_ADD_TEST(FileFormatPandora, ReadFailure)
             "6 255 255   0\n"
             "7 255 255 255\n";
 
-        OIIO_CHECK_THROW(ReadPandora(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadPandora(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Incorrect number of 3D LUT entries");
     }
     {
         // Wrong entry
         const std::string SAMPLE_ERROR =
-            "channel 2d\n"
+            "channel 3d\n"
             "in 8\n"
             "out 256\n"
             "format lut\n"
@@ -453,12 +464,14 @@ OIIO_ADD_TEST(FileFormatPandora, ReadFailure)
             "6 255 255   0\n"
             "7 255 255 255\n";
 
-        OIIO_CHECK_THROW(ReadPandora(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadPandora(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Expected to find 4 integers");
     }
     {
         // Wrong number of entries
         const std::string SAMPLE_ERROR =
-            "channel 2d\n"
+            "channel 3d\n"
             "in 8\n"
             "out 256\n"
             "format lut\n"
@@ -473,7 +486,9 @@ OIIO_ADD_TEST(FileFormatPandora, ReadFailure)
             "7 255 255   0\n"
             "8 255 255 255\n";
 
-        OIIO_CHECK_THROW(ReadPandora(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadPandora(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Incorrect number of 3D LUT entries");
     }
 }
 

--- a/src/core/FileFormatSpi1D.cpp
+++ b/src/core/FileFormatSpi1D.cpp
@@ -255,7 +255,7 @@ OCIO_NAMESPACE_ENTER
             // are written out with 6 decimal places of precision.  This is
             // a bit aggressive, I.e., changes in the 6th decimal place will
             // be considered roundoff error, but changes in the 5th decimal
-            // will be considered lut 'intent'.
+            // will be considered LUT 'intent'.
             // 1.0
             // 1.000005 equal to 1.0
             // 1.000007 equal to 1.0
@@ -412,7 +412,7 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
     {
         // Validate stream can be read with no error.
         // Then stream will be altered to introduce errors.
-        const std::string SAMPLE_ERROR =
+        const std::string SAMPLE_NO_ERROR =
             "Version 1\n"
             "From 0.0 1.0\n"
             "Length 2\n"
@@ -422,7 +422,7 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_NO_THROW(ReadSpi1d(SAMPLE_ERROR));
+        OIIO_CHECK_NO_THROW(ReadSpi1d(SAMPLE_NO_ERROR));
     }
     {
         // Version missing
@@ -435,7 +435,9 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW(ReadSpi1d(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Could not find 'Version' Tag");
     }
     {
         // Version is not 1
@@ -449,7 +451,9 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW(ReadSpi1d(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Only format version 1 supported");
     }
     {
         // Version can't be scanned
@@ -463,7 +467,9 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW(ReadSpi1d(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Invalid 'Version' Tag");
     }
     {
         // Version case is wrong
@@ -477,7 +483,9 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW(ReadSpi1d(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Could not find 'Version' Tag");
     }
     {
         // From does not specify 2 floats
@@ -491,7 +499,9 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW(ReadSpi1d(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Invalid 'From' Tag");
     }
     {
         // Length is missing
@@ -504,7 +514,9 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW(ReadSpi1d(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Could not find 'Length' Tag");
     }
     {
         // Length can't be read
@@ -518,7 +530,9 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW(ReadSpi1d(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Invalid 'Length' Tag");
     }
     {
         // Component is missing
@@ -531,7 +545,9 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW(ReadSpi1d(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Could not find 'Components' Tag");
     }
     {
         // Component can't be read
@@ -545,7 +561,9 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW(ReadSpi1d(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Invalid 'Components' Tag");
     }
     {
         // Component not 1 or 2 or 3
@@ -559,10 +577,12 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW(ReadSpi1d(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Components must be [1,2,3]");
     }
     {
-        // Lut too short
+        // LUT too short
         const std::string SAMPLE_ERROR =
             "Version 1\n"
             "From 0.0 1.0\n"
@@ -572,7 +592,9 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "0.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW(ReadSpi1d(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Not enough entries found");
     }
 }
 

--- a/src/core/FileFormatSpi3D.cpp
+++ b/src/core/FileFormatSpi3D.cpp
@@ -119,7 +119,7 @@ OCIO_NAMESPACE_ENTER
                 os << "Error parsing .spi3d file (";
                 os << fileName;
                 os << ").  ";
-                os << "Lut does not appear to be valid spilut format. ";
+                os << "LUT does not appear to be valid spilut format. ";
                 os << "Expected 'SPILUT'.  Found: '" << lineBuffer << "'.";
                 throw Exception(os.str().c_str());
             }
@@ -136,7 +136,7 @@ OCIO_NAMESPACE_ENTER
                 os << "Error parsing .spi3d file (";
                 os << fileName;
                 os << "). ";
-                os << "Error while reading lut size. Found: '";
+                os << "Error while reading LUT size. Found: '";
                 os << lineBuffer << "'.";
                 throw Exception(os.str().c_str());
             }
@@ -186,9 +186,9 @@ OCIO_NAMESPACE_ENTER
                         os << fileName;
                         os << "). ";
                         os << "Data is invalid. ";
-                        os << "A lut entry is specified (";
+                        os << "A LUT entry is specified (";
                         os << rIndex << " " << gIndex << " " << bIndex;
-                        os << " that falls outside of the cube.";
+                        os << ") that falls outside of the cube.";
                         throw Exception(os.str().c_str());
                     }
 
@@ -334,7 +334,7 @@ OIIO_ADD_TEST(FileFormatSpi3D, ReadFailure)
     {
         // Validate stream can be read with no error.
         // Then stream will be altered to introduce errors.
-        const std::string SAMPLE_ERROR =
+        const std::string SAMPLE_NO_ERROR =
             "SPILUT 1.0\n"
             "3 3\n"
             "2 2 2\n"
@@ -347,7 +347,7 @@ OIIO_ADD_TEST(FileFormatSpi3D, ReadFailure)
             "1 1 0 0.6 0.7 0.1\n"
             "1 1 1 0.6 0.7 0.7\n";
 
-        OIIO_CHECK_NO_THROW(ReadSpi3d(SAMPLE_ERROR));
+        OIIO_CHECK_NO_THROW(ReadSpi3d(SAMPLE_NO_ERROR));
     }
     {
         // Wrong first line
@@ -364,7 +364,9 @@ OIIO_ADD_TEST(FileFormatSpi3D, ReadFailure)
             "1 1 0 0.6 0.7 0.1\n"
             "1 1 1 0.6 0.7 0.7\n";
 
-        OIIO_CHECK_THROW(ReadSpi3d(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpi3d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Expected 'SPILUT'");
     }
     {
         // 3 line is not 3 ints
@@ -381,7 +383,9 @@ OIIO_ADD_TEST(FileFormatSpi3D, ReadFailure)
             "1 1 0 0.6 0.7 0.1\n"
             "1 1 1 0.6 0.7 0.7\n";
 
-        OIIO_CHECK_THROW(ReadSpi3d(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpi3d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Error while reading LUT size");
     }
     {
         // index out of range
@@ -398,7 +402,9 @@ OIIO_ADD_TEST(FileFormatSpi3D, ReadFailure)
             "1 1 0 0.6 0.7 0.1\n"
             "1 1 1 0.6 0.7 0.7\n";
 
-        OIIO_CHECK_THROW(ReadSpi3d(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpi3d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "that falls outside of the cube");
     }
     {
         // Not enough entries
@@ -414,7 +420,9 @@ OIIO_ADD_TEST(FileFormatSpi3D, ReadFailure)
             "1 1 0 0.6 0.7 0.1\n"
             "1 1 1 0.6 0.7 0.7\n";
 
-        OIIO_CHECK_THROW(ReadSpi3d(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpi3d(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Not enough entries found");
     }
 }
 

--- a/src/core/FileFormatSpiMtx.cpp
+++ b/src/core/FileFormatSpiMtx.cpp
@@ -317,12 +317,12 @@ OIIO_ADD_TEST(FileFormatSpiMtx, ReadFailure)
     {
         // Validate stream can be read with no error.
         // Then stream will be altered to introduce errors.
-        const std::string SAMPLE_ERROR =
+        const std::string SAMPLE_NO_ERROR =
             "1.0 0.0 0.0 0.0\n"
             "0.0 1.0 0.0 0.0\n"
             "0.0 0.0 1.0 0.0\n";
 
-        OIIO_CHECK_NO_THROW(ReadSpiMtx(SAMPLE_ERROR));
+        OIIO_CHECK_NO_THROW(ReadSpiMtx(SAMPLE_NO_ERROR));
     }
     {
         // Wrong number of elements
@@ -331,7 +331,9 @@ OIIO_ADD_TEST(FileFormatSpiMtx, ReadFailure)
             "0.0 1.0 0.0\n"
             "0.0 0.0 1.0\n";
 
-        OIIO_CHECK_THROW(ReadSpiMtx(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpiMtx(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "File must contain 12 float entries");
     }
     {
         // Some elements can' t be read as float
@@ -340,7 +342,9 @@ OIIO_ADD_TEST(FileFormatSpiMtx, ReadFailure)
             "0.0 error 0.0 0.0\n"
             "0.0 0.0 1.0 0.0\n";
 
-        OIIO_CHECK_THROW(ReadSpiMtx(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadSpiMtx(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "File must contain all float entries");
     }
 }
 

--- a/src/core/FileFormatTruelight.cpp
+++ b/src/core/FileFormatTruelight.cpp
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // FL-TL-TN-0388-TLCubeFormat2.0.pdf
 //
 // Known deficiency in implementation:
-// 1D shaper luts (InputLUT) using integer encodings (vs float) are not supported.
+// 1D shaper LUTs (InputLUT) using integer encodings (vs float) are not supported.
 // How to we determine if the input is integer? MaxVal?  Or do we look for a decimal-point?
 // How about scientific notation? (which is explicitly allowed?)
 
@@ -123,7 +123,7 @@ OCIO_NAMESPACE_ENTER
             // this shouldn't happen
             if(!istream)
             {
-                throw Exception ("File stream empty when trying to read Truelight .cub lut");
+                throw Exception ("File stream empty when trying to read Truelight .cub LUT");
             }
             
             // Validate the file type
@@ -131,7 +131,7 @@ OCIO_NAMESPACE_ENTER
             if(!nextline(istream, line) || 
                !pystring::startswith(pystring::lower(line), "# truelight cube"))
             {
-                throw Exception("Lut doesn't seem to be a Truelight .cub lut.");
+                throw Exception("LUT doesn't seem to be a Truelight .cub LUT.");
             }
             
             // Parse the file
@@ -165,7 +165,7 @@ OCIO_NAMESPACE_ENTER
                                !StringToInt( &size3d[1], parts[3].c_str()) ||
                                !StringToInt( &size3d[2], parts[4].c_str()))
                             {
-                                throw Exception("Malformed width tag in Truelight .cub lut.");
+                                throw Exception("Malformed width tag in Truelight .cub LUT.");
                             }
                             
                             raw3d.reserve(3*size3d[0]*size3d[1]*size3d[2]);
@@ -175,7 +175,7 @@ OCIO_NAMESPACE_ENTER
                             if(parts.size() != 3 || 
                                !StringToInt( &size1d, parts[2].c_str()))
                             {
-                                throw Exception("Malformed lutlength tag in Truelight .cub lut.");
+                                throw Exception("Malformed lutlength tag in Truelight .cub LUT.");
                             }
                             raw1d.reserve(3*size1d);
                         }
@@ -221,12 +221,12 @@ OCIO_NAMESPACE_ENTER
                 }
             }
             
-            // Interpret the parsed data, validate lut sizes
+            // Interpret the parsed data, validate LUT sizes
             
             if(size1d != static_cast<int>(raw1d.size()/3))
             {
                 std::ostringstream os;
-                os << "Parse error in Truelight .cub lut. ";
+                os << "Parse error in Truelight .cub LUT. ";
                 os << "Incorrect number of lut1d entries. ";
                 os << "Found " << raw1d.size()/3 << ", expected " << size1d << ".";
                 throw Exception(os.str().c_str());
@@ -235,8 +235,8 @@ OCIO_NAMESPACE_ENTER
             if(size3d[0]*size3d[1]*size3d[2] != static_cast<int>(raw3d.size()/3))
             {
                 std::ostringstream os;
-                os << "Parse error in Truelight .cub lut. ";
-                os << "Incorrect number of lut3d entries. ";
+                os << "Parse error in Truelight .cub LUT. ";
+                os << "Incorrect number of 3D LUT entries. ";
                 os << "Found " << raw3d.size()/3 << ", expected " << size3d[0]*size3d[1]*size3d[2] << ".";
                 throw Exception(os.str().c_str());
             }
@@ -252,8 +252,8 @@ OCIO_NAMESPACE_ENTER
             {
                 for(int channel=0; channel<3; ++channel)
                 {
-                    // Determine the scale factor for the 1d lut. Example:
-                    // The inputlut feeding a 6x6x6 3dlut should be scaled from 0.0-5.0.
+                    // Determine the scale factor for the 1D LUT. Example:
+                    // The inputlut feeding a 6x6x6 3D LUT should be scaled from 0.0-5.0.
                     // Beware: Nuke Truelight Writer (at least 6.3 and before) is busted
                     // and does this scaling incorrectly.
                     
@@ -274,7 +274,7 @@ OCIO_NAMESPACE_ENTER
                 // are written out with 6 decimal places of precision.  This is
                 // a bit aggressive, I.e., changes in the 6th decimal place will
                 // be considered roundoff error, but changes in the 5th decimal
-                // will be considered lut 'intent'.
+                // will be considered LUT 'intent'.
                 // 1.0
                 // 1.000005 equal to 1.0
                 // 1.000007 equal to 1.0
@@ -318,7 +318,7 @@ OCIO_NAMESPACE_ENTER
             GenerateIdentityLut3D(&cubeData[0], cubeSize, 3, LUT3DORDER_FAST_RED);
             PackedImageDesc cubeImg(&cubeData[0], cubeSize*cubeSize*cubeSize, 1, 3);
             
-            // Apply processor to lut data
+            // Apply processor to LUT data
             ConstProcessorRcPtr inputToTarget;
             inputToTarget = config->getProcessor(baker.getInputSpace(), baker.getTargetSpace());
             inputToTarget->apply(cubeImg);
@@ -337,8 +337,8 @@ OCIO_NAMESPACE_ENTER
             ostream << "\n";
 
 
-            // Write the shaper lut
-            // (We are just going to use a unity lut)
+            // Write the shaper LUT
+            // (We are just going to use a unity LUT)
             ostream << "# InputLUT\n";
             ostream << std::setprecision(6) << std::fixed;
             float v = 0.0f;

--- a/src/core/FileFormatVF.cpp
+++ b/src/core/FileFormatVF.cpp
@@ -125,7 +125,7 @@ OCIO_NAMESPACE_ENTER
             // this shouldn't happen
             if(!istream)
             {
-                throw Exception ("File stream empty when trying to read .vf lut");
+                throw Exception ("File stream empty when trying to read .vf LUT");
             }
             
             // Validate the file type
@@ -214,11 +214,11 @@ OCIO_NAMESPACE_ENTER
                 }
             }
             
-            // Interpret the parsed data, validate lut sizes
+            // Interpret the parsed data, validate LUT sizes
             if(size3d[0]*size3d[1]*size3d[2] != static_cast<int>(raw3d.size()/3))
             {
                 std::ostringstream os;
-                os << "Incorrect number of lut3d entries. ";
+                os << "Incorrect number of 3D LUT entries. ";
                 os << "Found " << raw3d.size()/3 << ", expected " << size3d[0]*size3d[1]*size3d[2] << ".";
                 ThrowErrorMessage(
                     os.str().c_str(),
@@ -228,14 +228,14 @@ OCIO_NAMESPACE_ENTER
             if(size3d[0]*size3d[1]*size3d[2] == 0)
             {
                 ThrowErrorMessage(
-                    "No 3D Lut entries found.",
+                    "No 3D LUT entries found.",
                     fileName, -1, "");
             }
             
             LocalCachedFileRcPtr cachedFile = LocalCachedFileRcPtr(new LocalCachedFile());
             
             // Setup the global matrix.
-            // (Nuke pre-scales this by the 3dlut size, so we must undo that here)
+            // (Nuke pre-scales this by the 3D LUT size, so we must undo that here)
             if(global_transform.size() == 16)
             {
                 for(int i=0; i<4; ++i)
@@ -262,7 +262,7 @@ OCIO_NAMESPACE_ENTER
                 {
                     for (int rIndex = 0; rIndex<size3d[0]; ++rIndex)
                     {
-                        // In file, lut is blue fastest
+                        // In file, LUT is blue fastest
                         int i = GetLut3DIndex_BlueFast(rIndex, gIndex, bIndex,
                             size3d[0], size3d[1], size3d[2]);
                         
@@ -372,7 +372,7 @@ OIIO_ADD_TEST(FileFormatVF, ReadFailure)
     {
         // Validate stream can be read with no error.
         // Then stream will be altered to introduce errors.
-        const std::string SAMPLE_ERROR =
+        const std::string SAMPLE_NO_ERROR =
             "#Inventor V2.1 ascii\n"
             "grid_size 2 2 2\n"
             "global_transform 1 0 0 0  0 1 0 0  0 0 1 0  0 0 0 1 \n"
@@ -386,7 +386,7 @@ OIIO_ADD_TEST(FileFormatVF, ReadFailure)
             "1 1 0\n"
             "1 1 1\n";
 
-        OIIO_CHECK_NO_THROW(ReadVF(SAMPLE_ERROR));
+        OIIO_CHECK_NO_THROW(ReadVF(SAMPLE_NO_ERROR));
     }
     {
         // Too much data
@@ -405,7 +405,9 @@ OIIO_ADD_TEST(FileFormatVF, ReadFailure)
             "1 1 0\n"
             "1 1 1\n";
 
-        OIIO_CHECK_THROW(ReadVF(SAMPLE_ERROR), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(ReadVF(SAMPLE_ERROR),
+                              OCIO::Exception,
+                              "Incorrect number of 3D LUT entries");
     }
 }
 

--- a/src/core/FileTransform.cpp
+++ b/src/core/FileTransform.cpp
@@ -768,7 +768,7 @@ static const std::string ocioTestFilesDir(STR(OCIO_UNIT_TEST_FILES_DIR));
 
 OIIO_ADD_TEST(FileTransform, LoadFileOK)
 {
-    // Discreet 1D Lut
+    // Discreet 1D LUT
     const std::string discreetLut(ocioTestFilesDir
         + std::string("/logtolin_8to8.lut"));
     OIIO_CHECK_NO_THROW(LoadTransformFile(discreetLut));

--- a/src/core/GpuShader.cpp
+++ b/src/core/GpuShader.cpp
@@ -113,7 +113,7 @@ namespace
             if(width > get1dLutMaxWidth())
             {
                 std::stringstream ss;
-                ss  << "1d Lut size exceeds the maximum: "
+                ss  << "1D LUT size exceeds the maximum: "
                     << width << " > " << get1dLutMaxWidth();
                 throw OCIO_NAMESPACE::Exception(ss.str().c_str());
             }
@@ -131,7 +131,7 @@ namespace
             if(index >= textures.size())
             {
                 std::ostringstream ss;
-                ss << "1D Lut access error: index = " << index
+                ss << "1D LUT access error: index = " << index
                    << " where size = " << textures.size();
                 throw OCIO_NAMESPACE::Exception(ss.str().c_str());
             }
@@ -150,7 +150,7 @@ namespace
             if(index >= textures.size())
             {
                 std::ostringstream ss;
-                ss << "1D Lut access error: index = " << index
+                ss << "1D LUT access error: index = " << index
                    << " where size = " << textures.size();
                 throw OCIO_NAMESPACE::Exception(ss.str().c_str());
             }
@@ -165,7 +165,7 @@ namespace
             if(dimension > get3dLutMaxDimension())
             {
                 std::stringstream ss;
-                ss  << "3d Lut dimension exceeds the maximum: "
+                ss  << "3D LUT dimension exceeds the maximum: "
                     << dimension << " > " << get3dLutMaxDimension();
                 throw OCIO_NAMESPACE::Exception(ss.str().c_str());
             }
@@ -184,7 +184,7 @@ namespace
             if(index >= textures3D.size())
             {
                 std::ostringstream ss;
-                ss << "3D Lut access error: index = " << index
+                ss << "3D LUT access error: index = " << index
                    << " where size = " << textures3D.size();
                 throw OCIO_NAMESPACE::Exception(ss.str().c_str());
             }
@@ -201,7 +201,7 @@ namespace
             if(index >= textures3D.size())
             {
                 std::ostringstream ss;
-                ss << "3D Lut access error: index = " << index
+                ss << "3D LUT access error: index = " << index
                    << " where size = " << textures3D.size();
                 throw OCIO_NAMESPACE::Exception(ss.str().c_str());
             }
@@ -333,13 +333,13 @@ OCIO_NAMESPACE_ENTER
 
     unsigned LegacyGpuShaderDesc::getTextureMaxWidth() const 
     {
-        throw Exception("1D luts are not supported");
+        throw Exception("1D LUTs are not supported");
         return 0;
     }
 
     void LegacyGpuShaderDesc::setTextureMaxWidth(unsigned)
     {
-        throw Exception("1D luts are not supported");
+        throw Exception("1D LUTs are not supported");
     }
 
     unsigned LegacyGpuShaderDesc::getNumTextures() const
@@ -351,19 +351,19 @@ OCIO_NAMESPACE_ENTER
         const char *, const char *, unsigned, unsigned,
         TextureType, Interpolation, float *)
     {
-        throw Exception("1D luts are not supported");
+        throw Exception("1D LUTs are not supported");
     }
 
     void LegacyGpuShaderDesc::getTexture(
         unsigned, const char *&, const char *&, 
         unsigned &, unsigned &, TextureType &, Interpolation &) const
     {
-        throw Exception("1D luts are not supported");
+        throw Exception("1D LUTs are not supported");
     }
 
     void LegacyGpuShaderDesc::getTextureValues(unsigned, const float *&) const
     {
-        throw Exception("1D luts are not supported");
+        throw Exception("1D LUTs are not supported");
     }
 
     unsigned LegacyGpuShaderDesc::getNum3DTextures() const
@@ -703,7 +703,9 @@ OIIO_ADD_TEST(GpuShader, generic_shader)
         OIIO_CHECK_EQUAL(OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL, t);
         OIIO_CHECK_EQUAL(OCIO::INTERP_TETRAHEDRAL, i);
 
-        OIIO_CHECK_THROW(shaderDesc->getTexture(1, name, id, w, h, t, i), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(shaderDesc->getTexture(1, name, id, w, h, t, i),
+                              OCIO::Exception,
+                              "1D LUT access error");
 
         const float * vals = 0x0;
         OIIO_CHECK_NO_THROW(shaderDesc->getTextureValues(0, vals));
@@ -713,9 +715,11 @@ OIIO_ADD_TEST(GpuShader, generic_shader)
             OIIO_CHECK_EQUAL(values[idx], vals[idx]);
         }
 
-        OIIO_CHECK_THROW(shaderDesc->getTextureValues(1, vals), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(shaderDesc->getTextureValues(1, vals),
+                              OCIO::Exception,
+                              "1D LUT access error");
 
-        // Support several 1D Luts
+        // Support several 1D LUTs
 
         OIIO_CHECK_NO_THROW(shaderDesc->addTexture("lut2", "1234", width, height, 
                                                    OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL, 
@@ -726,7 +730,9 @@ OIIO_ADD_TEST(GpuShader, generic_shader)
 
         OIIO_CHECK_NO_THROW(shaderDesc->getTextureValues(0, vals));
         OIIO_CHECK_NO_THROW(shaderDesc->getTextureValues(1, vals));
-        OIIO_CHECK_THROW(shaderDesc->getTextureValues(2, vals), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(shaderDesc->getTextureValues(2, vals),
+                              OCIO::Exception,
+                              "1D LUT access error");
     }
 
     {
@@ -755,7 +761,9 @@ OIIO_ADD_TEST(GpuShader, generic_shader)
         OIIO_CHECK_EQUAL(edgelen, e);
         OIIO_CHECK_EQUAL(OCIO::INTERP_TETRAHEDRAL, i);
 
-        OIIO_CHECK_THROW(shaderDesc->get3DTexture(1, name, id, e, i), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(shaderDesc->get3DTexture(1, name, id, e, i),
+                              OCIO::Exception,
+                              "3D LUT access error");
 
         const float * vals = 0x0;
         OIIO_CHECK_NO_THROW(shaderDesc->get3DTextureValues(0, vals));
@@ -765,9 +773,11 @@ OIIO_ADD_TEST(GpuShader, generic_shader)
             OIIO_CHECK_EQUAL(values[idx], vals[idx]);
         }
 
-        OIIO_CHECK_THROW(shaderDesc->get3DTextureValues(1, vals), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(shaderDesc->get3DTextureValues(1, vals),
+                              OCIO::Exception,
+                              "3D LUT access error");
 
-        // Supports several 3D Luts
+        // Supports several 3D LUTs
 
         OIIO_CHECK_NO_THROW(shaderDesc->add3DTexture("lut1", "1234", edgelen, 
                                                      OCIO::INTERP_TETRAHEDRAL,
@@ -815,11 +825,12 @@ OIIO_ADD_TEST(GpuShader, legacy_shader)
         float values[size];
 
         OIIO_CHECK_EQUAL(shaderDesc->getNumTextures(), 0U);
-        OIIO_CHECK_THROW(shaderDesc->addTexture("lut1", "1234", width, height, 
+        OIIO_CHECK_THROW_WHAT(shaderDesc->addTexture("lut1", "1234", width, height, 
                                                 OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL, 
                                                 OCIO::INTERP_TETRAHEDRAL,
                                                 &values[0]), 
-                         OCIO::Exception);
+                              OCIO::Exception,
+                              "1D LUTs are not supported");
 
         const char * name = 0x0;
         const char * id = 0x0;
@@ -828,7 +839,9 @@ OIIO_ADD_TEST(GpuShader, legacy_shader)
         OCIO::GpuShaderDesc::TextureType t = OCIO::GpuShaderDesc::TEXTURE_RED_CHANNEL;
         OCIO::Interpolation i = OCIO::INTERP_UNKNOWN;
 
-        OIIO_CHECK_THROW(shaderDesc->getTexture(0, name, id, w, h, t, i), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(shaderDesc->getTexture(0, name, id, w, h, t, i),
+                              OCIO::Exception,
+                              "1D LUTs are not supported");
     }
 
     {
@@ -856,7 +869,9 @@ OIIO_ADD_TEST(GpuShader, legacy_shader)
         OIIO_CHECK_EQUAL(edgelen, e);
         OIIO_CHECK_EQUAL(OCIO::INTERP_TETRAHEDRAL, i);
 
-        OIIO_CHECK_THROW(shaderDesc->get3DTexture(1, name, id, e, i), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(shaderDesc->get3DTexture(1, name, id, e, i),
+                              OCIO::Exception,
+                              "3D LUT access error");
 
         const float * vals = 0x0;
         OIIO_CHECK_NO_THROW(shaderDesc->get3DTextureValues(0, vals));
@@ -866,14 +881,17 @@ OIIO_ADD_TEST(GpuShader, legacy_shader)
             OIIO_CHECK_EQUAL(values[idx], vals[idx]);
         }
 
-        OIIO_CHECK_THROW(shaderDesc->get3DTextureValues(1, vals), OCIO::Exception);
+        OIIO_CHECK_THROW_WHAT(shaderDesc->get3DTextureValues(1, vals),
+                              OCIO::Exception,
+                              "3D LUT access error");
 
-        // Only one 3D Lut
+        // Only one 3D LUT
 
-        OIIO_CHECK_THROW(shaderDesc->add3DTexture("lut1", "1234", edgelen, 
+        OIIO_CHECK_THROW_WHAT(shaderDesc->add3DTexture("lut1", "1234", edgelen, 
                                                   OCIO::INTERP_TETRAHEDRAL,
                                                   &values[0]),
-                         OCIO::Exception);
+                              OCIO::Exception,
+                              "only one 3D texture allowed");
 
     }
 }

--- a/src/core/GpuShader.h
+++ b/src/core/GpuShader.h
@@ -51,7 +51,7 @@ OCIO_NAMESPACE_ENTER
 
         unsigned getEdgelen() const;
 
-        // Accessors to the 3D textures built from 3D Luts
+        // Accessors to the 3D textures built from 3D LUT
         //
         unsigned getNum3DTextures() const;
         void add3DTexture(const char * name, const char * id, unsigned edgelen, 
@@ -132,7 +132,7 @@ OCIO_NAMESPACE_ENTER
     // 
     // The class holds all the information to build a shader program without baking
     // the color transform. It mainly means that the processor could contain 
-    // several 1D or 3D luts.
+    // several 1D or 3D LUTs.
     // 
 
     class GenericGpuShaderDesc : public GpuShaderDesc
@@ -151,7 +151,7 @@ OCIO_NAMESPACE_ENTER
         void addUniform(
             unsigned index, const char * name, UniformType type, void * value);
 
-        // Accessors to the 1D & 2D textures built from 1D Luts
+        // Accessors to the 1D & 2D textures built from 1D LUT
         //
         unsigned getNumTextures() const;
         void addTexture(const char * name, const char * id, unsigned width, unsigned height,
@@ -161,7 +161,7 @@ OCIO_NAMESPACE_ENTER
                         TextureType & channel, Interpolation & interpolation) const;
         void getTextureValues(unsigned index, const float *& values) const;
 
-        // Accessors to the 3D textures built from 3D Luts
+        // Accessors to the 3D textures built from 3D LUT
         //
         unsigned getNum3DTextures() const;
         void add3DTexture(const char * name, const char * id, unsigned edgelen, 

--- a/src/core/Lut1DOp.cpp
+++ b/src/core/Lut1DOp.cpp
@@ -554,9 +554,9 @@ OCIO_NAMESPACE_ENTER
 
             // TODO: To enhance when adding bit depth
 
-            // TODO: To enhance when adding half domain luts
+            // TODO: To enhance when adding half domain LUTs
 
-            // TODO: To enhance to support not monotonic luts
+            // TODO: To enhance to support non-monotonic LUTs
 
             // The input bit depth describes the scaling of the LUT entries.
             const float normalMin = 0.0f;
@@ -761,7 +761,7 @@ OCIO_NAMESPACE_ENTER
                 depth = BIT_DEPTH_F16;
             }
 
-            // Make a domain for the composed Lut1D.
+            // Make a domain for the composed 1D LUT.
             Lut1DRcPtr newDomainLut = MakeLookupDomain(depth);
 
             // Regardless of what depth is used to build the domain, set the in & out 
@@ -778,7 +778,7 @@ OCIO_NAMESPACE_ENTER
         {
             if(m_direction == TRANSFORM_DIR_UNKNOWN)
             {
-                throw Exception("Cannot apply lut1d op, unspecified transform direction.");
+                throw Exception("Cannot apply Lut1DOp, unspecified transform direction.");
             }
             
             // Validate the requested interpolation type
@@ -796,7 +796,7 @@ OCIO_NAMESPACE_ENTER
                     break;
                 case INTERP_TETRAHEDRAL:
                     throw Exception(
-                        "Cannot apply Lut1DOp, tetrahedral interpolation is not allowed for 1d luts.");
+                        "Cannot apply Lut1DOp, tetrahedral interpolation is not allowed for 1D LUTs.");
                     break;
                 default:
                     throw Exception("Cannot apply Lut1DOp, invalid interpolation specified.");
@@ -804,14 +804,14 @@ OCIO_NAMESPACE_ENTER
             
             if(m_lut->luts[0].empty() || m_lut->luts[1].empty() || m_lut->luts[2].empty())
             {
-                throw Exception("Cannot apply lut1d op, no lut data provided.");
+                throw Exception("Cannot apply Lut1DOp, no LUT data provided.");
             }
 
             if(m_lut->luts[0].size()!=m_lut->luts[1].size()
                 || m_lut->luts[0].size()!=m_lut->luts[2].size())
             {
                 throw Exception(
-                    "Cannot apply lut1d op, the LUT for each channel must have the same dimensions.");
+                    "Cannot apply Lut1DOp, the LUT for each channel must have the same dimensions.");
             }
 
             // Create the cacheID
@@ -827,7 +827,7 @@ OCIO_NAMESPACE_ENTER
 
             if(m_direction == TRANSFORM_DIR_INVERSE)
             {
-                // Compute a fast forward Lut 1D from an inverse Lut 1D
+                // Compute a fast forward LUT 1D from an inverse LUT 1D
                 m_lut_gpu_apply = makeFastLut1D(true);
             }
         }
@@ -898,7 +898,7 @@ OCIO_NAMESPACE_ENTER
                 rgb[3*idx+2] = blu[idx];
             }
 
-            // Register the RGB lut
+            // Register the RGB LUT
 
             std::ostringstream resName;
             resName << shaderDesc->getResourcePrefix()
@@ -931,11 +931,11 @@ OCIO_NAMESPACE_ENTER
                 somethingToDo |= (scale[i] != 1.f || offset[i] != 0.f);
             }
 
-            // Add the lut code to the OCIO shader program
+            // Add the LUT code to the OCIO shader program
 
             if(height>1)
             {
-                // In case the 1D lut length exceeds the 1D texture maximum length
+                // In case the 1D LUT length exceeds the 1D texture maximum length
                 // a 2D texture is used.
 
                 {
@@ -1071,7 +1071,7 @@ OCIO_NAMESPACE_ENTER
     {
         if(lut->isNoOp()) return;
         
-        // TODO: Detect if lut1d can be exactly approximated as y = mx + b
+        // TODO: Detect if 1D LUT can be exactly approximated as y = mx + b
         // If so, return a mtx instead.
         
         ops.push_back( OpRcPtr(new Lut1DOp(lut, interpolation, direction)) );
@@ -1107,7 +1107,7 @@ namespace OCIO = OCIO_NAMESPACE;
 
 OIIO_ADD_TEST(Lut1DOp, NoOp)
 {
-    // Make an identity lut
+    // Make an identity LUT
     OCIO::Lut1DRcPtr lut = OCIO::Lut1D::Create();
     lut->from_min[0] = 0.0f;
     lut->from_min[1] = 0.0f;
@@ -1144,7 +1144,7 @@ OIIO_ADD_TEST(Lut1DOp, NoOp)
         OCIO::INTERP_NEAREST, OCIO::TRANSFORM_DIR_FORWARD));
     OIIO_CHECK_EQUAL(ops.size(), 0);
     
-    // Edit the lut
+    // Edit the LUT
     // These should NOT be identity
     lut->unfinalize();
     lut->luts[0][125] += 1e-3f;
@@ -1163,7 +1163,7 @@ OIIO_ADD_TEST(Lut1DOp, NoOp)
 
 OIIO_ADD_TEST(Lut1DOp, FiniteValue)
 {
-    // Make a lut that squares the input
+    // Make a LUT that squares the input
     OCIO::Lut1DRcPtr lut = OCIO::Lut1D::Create();
     lut->from_min[0] = 0.0f;
     lut->from_min[1] = 0.0f;
@@ -1325,7 +1325,7 @@ OIIO_ADD_TEST(Lut1DOp, ExtrapolationErrors)
 
 OIIO_ADD_TEST(Lut1DOp, Inverse)
 {
-    // Make a lut that squares the input
+    // Make a LUT that squares the input
     OCIO::Lut1DRcPtr lut_a = OCIO::Lut1D::Create();
     {
     lut_a->from_min[0] = 0.0f;
@@ -1349,7 +1349,7 @@ OIIO_ADD_TEST(Lut1DOp, Inverse)
     lut_a->errortype = OCIO::ERROR_RELATIVE;
     }
     
-    // Make another lut
+    // Make another LUT
     OCIO::Lut1DRcPtr lut_b = OCIO::Lut1D::Create();
     {
     lut_b->from_min[0] = 0.5f;
@@ -1417,7 +1417,7 @@ OIIO_ADD_TEST(Lut1DOp, Inverse)
 #ifdef USE_SSE
 OIIO_ADD_TEST(Lut1DOp, SSE)
 {
-    // Make a lut that squares the input
+    // Make a LUT that squares the input
     OCIO::Lut1DRcPtr lut = OCIO::Lut1D::Create();
     lut->from_min[0] = 0.0f;
     lut->from_min[1] = 0.0f;
@@ -1508,7 +1508,7 @@ OIIO_ADD_TEST(Lut1DOp, SSE)
 
 OIIO_ADD_TEST(Lut1DOp, NanInf)
 {
-    // Make a lut that squares the input
+    // Make a LUT that squares the input
     OCIO::Lut1DRcPtr lut = OCIO::Lut1D::Create();
     lut->from_min[0] = 0.0f;
     lut->from_min[1] = 0.0f;
@@ -1611,7 +1611,7 @@ OIIO_ADD_TEST(Lut1DOp, NanInf)
 
 OIIO_ADD_TEST(Lut1DOp, ThrowNoOp)
 {
-    // Make an identity lut
+    // Make an identity LUT
     OCIO::Lut1DRcPtr lut = OCIO::Lut1D::Create();
     lut->from_min[0] = 0.0f;
     lut->from_min[1] = 0.0f;
@@ -1689,7 +1689,7 @@ OIIO_ADD_TEST(Lut1DOp, ThrowOp)
         OCIO::Exception, "unspecified interpolation");
     ops.clear();
 
-    // INTERP_TETRAHEDRAL not allowed for 1d lut.
+    // INTERP_TETRAHEDRAL not allowed for 1D LUT.
     OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut,
         OCIO::INTERP_TETRAHEDRAL, OCIO::TRANSFORM_DIR_FORWARD));
     OIIO_CHECK_EQUAL(ops.size(), 1);
@@ -1702,7 +1702,7 @@ OIIO_ADD_TEST(Lut1DOp, ThrowOp)
     OIIO_CHECK_EQUAL(ops.size(), 1);
     lut->luts[0].clear();
     OIIO_CHECK_THROW_WHAT(ops[0]->finalize(),
-        OCIO::Exception, "no lut data provided");
+        OCIO::Exception, "no LUT data provided");
 }
 
 OIIO_ADD_TEST(Lut1DOp, GPU)

--- a/src/core/Lut1DOp.h
+++ b/src/core/Lut1DOp.h
@@ -57,10 +57,10 @@ OCIO_NAMESPACE_ENTER
         static Lut1DRcPtr CreateIdentity(BitDepth inputBitDepth, BitDepth outBitDepth);
         
         // This will compute the cacheid, and also
-        // determine if the lut is a no-op.
-        // If this lut is being read in from float ASCII text
+        // determine if the LUT is a no-op.
+        // If this LUT is being read in from float ASCII text
         // a value of 1e-5 is preferable.
-        // If this lut is being read in from integer ASCII
+        // If this LUT is being read in from integer ASCII
         // representation, the value will depend on the LSB
         // at the specified integer precision.
         // Example: reading 10-bit ints? Use 2/1023.0
@@ -99,7 +99,7 @@ OCIO_NAMESPACE_ENTER
         void finalize() const;
     };
     
-    // This generates an identity 1d lut, from 0.0 to 1.0
+    // This generates an identity 1D LUT, from 0.0 to 1.0
     void GenerateIdentityLut1D(float* img, int numElements, int numChannels);
     
     void CreateLut1DOp(OpRcPtrVec & ops,

--- a/src/core/Lut3DOp.cpp
+++ b/src/core/Lut3DOp.cpp
@@ -517,7 +517,7 @@ OCIO_NAMESPACE_ENTER
         if(!img) return;
         if(numChannels < 3)
         {
-            throw Exception("Cannot generate idenitity 3d lut with less than 3 channels.");
+            throw Exception("Cannot generate idenitity 3D LUT with less than 3 channels.");
         }
         
         float c = 1.0f / ((float)edgeLen - 1.0f);
@@ -554,7 +554,7 @@ OCIO_NAMESPACE_ENTER
         if(dim*dim*dim != numPixels)
         {
             std::ostringstream os;
-            os << "Cannot infer 3D Lut size. ";
+            os << "Cannot infer 3D LUT size. ";
             os << numPixels << " element(s) does not correspond to a ";
             os << "unform cube edge length. (nearest edge length is ";
             os << dim << ").";
@@ -665,7 +665,7 @@ OCIO_NAMESPACE_ENTER
             if(m_direction != TRANSFORM_DIR_FORWARD)
             {
                 std::ostringstream os;
-                os << "3D Luts can only be applied in the forward direction. ";
+                os << "3D LUTs can only be applied in the forward direction. ";
                 os << "(" << TransformDirectionToString(m_direction) << ")";
                 os << " specified.";
                 throw Exception(os.str().c_str());
@@ -693,7 +693,7 @@ OCIO_NAMESPACE_ENTER
             {
                 if(m_lut->size[i] == 0)
                 {
-                    throw Exception("Cannot apply Lut3DOp, lut object is empty.");
+                    throw Exception("Cannot apply Lut3DOp, LUT object is empty.");
                 }
                 // TODO if from_min[i] == from_max[i]
             }
@@ -946,7 +946,7 @@ OIIO_ADD_TEST(Lut3DOp, InverseComparisonCheck)
     OCIO::OpRcPtrVec ops;
     OIIO_CHECK_NO_THROW(CreateLut3DOp(ops,
         lut_a, OCIO::INTERP_NEAREST, OCIO::TRANSFORM_DIR_FORWARD));
-    // inverse Lut3D can't be finalized;
+    // inverse 3D LUT can't be finalized;
     OIIO_CHECK_NO_THROW(CreateLut3DOp(ops,
         lut_a, OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_INVERSE));
     OIIO_CHECK_NO_THROW(CreateLut3DOp(ops,
@@ -1045,7 +1045,7 @@ OIIO_ADD_TEST(Lut3DOp, PerformanceCheck)
 
 OIIO_ADD_TEST(Lut3DOp, ThrowLut)
 {
-    // std::string Lut3D::getCacheID() const when lut is empty
+    // std::string Lut3D::getCacheID() const when LUT is empty
     OCIO::Lut3DRcPtr lut = OCIO::Lut3D::Create();
     OIIO_CHECK_THROW_WHAT(lut->getCacheID(), OCIO::Exception, "invalid Lut3D");
 
@@ -1067,7 +1067,7 @@ OIIO_ADD_TEST(Lut3DOp, ThrowLut)
 
     // Get3DLutEdgeLenFromNumPixels with not cubic size
     OIIO_CHECK_THROW_WHAT(OCIO::Get3DLutEdgeLenFromNumPixels(10),
-        OCIO::Exception, "Cannot infer 3D Lut size");
+        OCIO::Exception, "Cannot infer 3D LUT size");
 }
 
 OIIO_ADD_TEST(Lut3DOp, ThrowLutOp)
@@ -1106,11 +1106,11 @@ OIIO_ADD_TEST(Lut3DOp, ThrowLutOp)
     for (int i = 0; i < 3; ++i)
     {
         lut->size[i] = 0;
-        OIIO_CHECK_THROW_WHAT(ops[0]->finalize(), OCIO::Exception, "lut object is empty");
+        OIIO_CHECK_THROW_WHAT(ops[0]->finalize(), OCIO::Exception, "LUT object is empty");
         lut->size[i] = 3;
     }
 
-    // missmatch lut size
+    // Mismatched LUT size
     lut->lut.resize(lut->lut.size() + 1);
     OIIO_CHECK_THROW_WHAT(ops[0]->finalize(), OCIO::Exception, "specified size does not match data");
 }
@@ -1139,14 +1139,14 @@ OIIO_ADD_TEST(Lut3DOp, cacheID)
 
     const std::string cacheID = ops[0]->getCacheID();
     OIIO_CHECK_EQUAL(cacheID.empty(), false);
-    // same lut have the same cacheID
+    // Identical LUTs have the same cacheID
     OIIO_CHECK_EQUAL(cacheID, ops[1]->getCacheID());
 }
 
 OIIO_ADD_TEST(Lut3DOp, EdgeLenFromNumPixels)
 {
     OIIO_CHECK_THROW_WHAT(OCIO::Get3DLutEdgeLenFromNumPixels(10),
-        OCIO::Exception, "Cannot infer 3D Lut size");
+        OCIO::Exception, "Cannot infer 3D LUT size");
     int expectedRes = 33;
     int res = 0;
     OIIO_CHECK_NO_THROW(res = OCIO::Get3DLutEdgeLenFromNumPixels(

--- a/src/core/Lut3DOp.h
+++ b/src/core/Lut3DOp.h
@@ -84,7 +84,7 @@ OCIO_NAMESPACE_ENTER
         return 3 * (indexB + sizeB * (indexG + sizeG * indexR));
     }
     
-    // What is the preferred order for the lut3d?
+    // What is the preferred order for the 3D LUT?
     // I.e., are the first two entries change along
     // the blue direction, or the red direction?
     // OpenGL expects 'red'

--- a/src/core/NoOps.cpp
+++ b/src/core/NoOps.cpp
@@ -199,7 +199,7 @@ OCIO_NAMESPACE_ENTER
                                     &gpuLut3DOpEndIndex,
                                     ops);
         
-        // Write the entire shader using only shader text (3d lut is unused)
+        // Write the entire shader using only shader text (3D LUT is unused)
         if(gpuLut3DOpStartIndex == -1 && gpuLut3DOpEndIndex == -1)
         {
             for(unsigned int i=0; i<ops.size(); ++i)
@@ -207,7 +207,7 @@ OCIO_NAMESPACE_ENTER
                 gpuPreOps.push_back( ops[i]->clone() );
             }
         }
-        // Analytical -> 3dlut -> analytical
+        // Analytical -> 3D LUT -> analytical
         else
         {
             // Handle analytical shader block before start index.
@@ -463,7 +463,7 @@ void CreateGenericScaleOp(OpRcPtrVec & ops)
 
 void CreateGenericLutOp(OpRcPtrVec & ops)
 {
-    // Make a lut that squares the input
+    // Make a LUT that squares the input
     Lut1DRcPtr lut = Lut1D::Create();
     {
         lut->from_min[0] = 0.0f;

--- a/src/core/Op.h
+++ b/src/core/Op.h
@@ -69,18 +69,18 @@ OCIO_NAMESPACE_ENTER
             
             virtual OpRcPtr clone() const = 0;
             
-            //! Something short, and printable.
-            //  The type of stuff you'd want to see in debugging.
+            // Something short, and printable.
+            // The type of stuff you'd want to see in debugging.
             virtual std::string getInfo() const = 0;
             
-            //! This should yield a string of not unreasonable length.
-            //! It can only be called after finalize()
+            // This should yield a string of not unreasonable length.
+            // It can only be called after finalize()
             virtual std::string getCacheID() const = 0;
             
-            //! Is the processing a noop? I.e, does apply do nothing.
-            //! (Even no-ops may define Allocation though.)
-            //! This must be implmented in a manner where its valid to call
-            //! *prior* to finalize. (Optimizers may make use of it)
+            // Is the processing a noop? I.e, does apply do nothing.
+            // (Even no-ops may define Allocation though.)
+            // This must be implemented in a manner where its valid to
+            // call *prior* to finalize. (Optimizers may make use of it)
             virtual bool isNoOp() const = 0;
             
             virtual bool isSameType(const OpRcPtr & op) const = 0;

--- a/src/core/OpTools.cpp
+++ b/src/core/OpTools.cpp
@@ -97,7 +97,7 @@ OCIO_NAMESPACE_ENTER
     {
         if (A->outputBitDepth != B[0]->getInputBitDepth())
         {
-            throw Exception("A bit depth mismatch forbids the composition of luts");
+            throw Exception("A bit depth mismatch forbids the composition of LUTs");
         }
 
         OpRcPtrVec ops;
@@ -173,7 +173,7 @@ OCIO_NAMESPACE_ENTER
     {
         if (A->outputBitDepth != B->getInputBitDepth())
         {
-            throw Exception("A bit depth mismatch forbids the composition of luts");
+            throw Exception("A bit depth mismatch forbids the composition of LUTs");
         }
 
         OpRcPtrVec ops;

--- a/src/core/OpTools.h
+++ b/src/core/OpTools.h
@@ -37,10 +37,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 OCIO_NAMESPACE_ENTER
 {
-    // Returns the ideal lut size based on a specific bit depth
+    // Returns the ideal LUT size based on a specific bit depth
     unsigned GetLutIdealSize(BitDepth incomingBitDepth);
 
-    // Control behavior of Lut1D composition.
+    // Control behavior of 1D LUT composition.
     enum ComposeMethod
     {
         COMPOSE_RESAMPLE_NO      = 0, // Preserve original domain

--- a/src/core/Platform.cpp
+++ b/src/core/Platform.cpp
@@ -1,7 +1,31 @@
-//
-// made by Autodesk Inc. under the terms of the OpenColorIO BSD 3 Clause License
-//
-//
+/*
+Copyright (c) 2003-2010 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
 
 #include <OpenColorIO/OpenColorIO.h>
 

--- a/src/core/Processor.cpp
+++ b/src/core/Processor.cpp
@@ -260,7 +260,7 @@ OCIO_NAMESPACE_ENTER
 
             lut->lut.resize(lut3DNumPixels*3);
             
-            // Allocate 3dlut image, RGBA
+            // Allocate 3D LUT image, RGBA
             std::vector<float> lut3D(lut3DNumPixels*4);
             GenerateIdentityLut3D(&lut3D[0], lut3DEdgeLen, 4, LUT3DORDER_FAST_RED);
             

--- a/src/core/Processor.h
+++ b/src/core/Processor.h
@@ -48,7 +48,7 @@ OCIO_NAMESPACE_ENTER
         
         // These 3 op vecs represent the 3 stages in our gpu pipe.
         // 1) preprocess shader text
-        // 2) 3d lut process lookup
+        // 2) 3D LUT process lookup
         // 3) postprocess shader text
         
         OpRcPtrVec m_gpuOpsHwPreProcess;

--- a/src/core_gpu_tests/Lut1DOp_test.cpp
+++ b/src/core_gpu_tests/Lut1DOp_test.cpp
@@ -277,7 +277,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, scale_lut1d_4_generic_shader)
 }
 
 /*
-    TODO: Uncomment when the Lut1D inverse is fully working.
+    TODO: Uncomment when the 1D LUT inverse is fully working.
 
 OCIO_ADD_GPU_TEST(Lut1DOp, scale_lut1d_4_inverse_generic_shader)
 {
@@ -303,7 +303,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, not_linear_lut1d_5_generic_shader)
 }
 
 /*
-    TODO: Uncomment when the Lut1D inverse is fully working.
+    TODO: Uncomment when the 1D LUT inverse is fully working.
 
 OCIO_ADD_GPU_TEST(Lut1DOp, not_linear_lut1d_5_inverse_generic_shader)
 {

--- a/src/core_gpu_tests/Lut3DOp_test.cpp
+++ b/src/core_gpu_tests/Lut3DOp_test.cpp
@@ -48,8 +48,7 @@ const float g_epsilon = 1e-4f;
 
 OCIO_ADD_GPU_TEST(Lut3DOp, red_only_using_CSP_file_legacy_shader)
 {
-    // Used a format I know to create a 3D lut file.
-    //  Any other file format would have been good also.
+    // Any other 3D LUT file format would have been good also.
 
     std::ostringstream content;
     content << "CSPLUTV100"                                  << "\n";
@@ -93,8 +92,7 @@ OCIO_ADD_GPU_TEST(Lut3DOp, red_only_using_CSP_file_legacy_shader)
 
 OCIO_ADD_GPU_TEST(Lut3DOp, green_only_using_CSP_file_legacy_shader)
 {
-    // Used a format I know to create a 3D lut file.
-    //  Any other file format would have been good also.
+    // Any other 3D LUT file format would have been good also.
 
     std::ostringstream content;
     content << "CSPLUTV100"                                  << "\n";
@@ -138,8 +136,7 @@ OCIO_ADD_GPU_TEST(Lut3DOp, green_only_using_CSP_file_legacy_shader)
 
 OCIO_ADD_GPU_TEST(Lut3DOp, blue_only_using_CSP_file_legacy_shader)
 {
-    // Used a format I know to create a 3D lut file.
-    //  Any other file format would have been good also.
+    // Any other 3D LUT file format would have been good also.
 
     std::ostringstream content;
     content << "CSPLUTV100"                                  << "\n";
@@ -184,8 +181,7 @@ OCIO_ADD_GPU_TEST(Lut3DOp, blue_only_using_CSP_file_legacy_shader)
 
 OCIO_ADD_GPU_TEST(Lut3DOp, arbitrary_using_CSP_file_legacy_shader)
 {
-    // Used a format I know to create a 3D lut file.
-    //  Any other file format would have been good also.
+    // Any other 3D LUT file format would have been good also.
 
     std::ostringstream content;
     content << "CSPLUTV100"                                  << "\n";
@@ -268,10 +264,10 @@ OCIO_ADD_GPU_TEST(Lut3DOp, arbitrary_using_CSP_file)
 
     test.setContext(file->createEditableCopy(), shaderDesc);
 
-    // TODO: Small luts not being resampled for now, such error threshold is expected
+    // TODO: Small LUTs not being resampled for now, such error threshold is expected
     //       The legacy shader has a better error threashold because 
-    //       it converts all luts in one 3d lut of dimension LUT3D_EDGE_SIZE
-    //       which performs a resampling of small luts.
+    //       it converts all LUTs in one 3D LUT of dimension LUT3D_EDGE_SIZE
+    //       which performs a resampling of small LUTs.
     test.setErrorThreshold(1e-2f);
 }
 

--- a/src/jniglue/tests/org/OpenColorIO/ConfigTest.java
+++ b/src/jniglue/tests/org/OpenColorIO/ConfigTest.java
@@ -75,7 +75,7 @@ public class ConfigTest extends TestCase {
     + "out_pixel = pow(max(out_pixel, vec4(0, 0, 0, 0)), vec4(0.909091, 0.909091, 0.909091, 1));\n"
     + "out_pixel = vec4(-0.1, -0.3, -0.4, -0) + out_pixel;\n"
     + "out_pixel = pow(max(out_pixel, vec4(0, 0, 0, 0)), vec4(0.454545, 0.454545, 0.454545, 1));\n"
-    + "// OSX segfault work-around: Force a no-op sampling of the 3d lut.\n"
+    + "// OSX segfault work-around: Force a no-op sampling of the 3D LUT.\n"
     + "texture3D(lut3d, 0.96875 * out_pixel.rgb + 0.015625).rgb;\n"
     + "return out_pixel;\n"
     + "}\n"

--- a/src/lang-glsl/glsl.cpp
+++ b/src/lang-glsl/glsl.cpp
@@ -236,12 +236,12 @@ void OpenGLBuilder::allocateAllTextures(unsigned startIndex)
     m_startIndex = startIndex;
     unsigned currIndex = m_startIndex;
 
-    // Process the 3D Luts first
+    // Process the 3D LUT first
 
     const unsigned maxTexture3D = m_shaderDesc->getNum3DTextures();
     for(unsigned idx=0; idx<maxTexture3D; ++idx)
     {
-        // 1. Get the information of the 3D lut
+        // 1. Get the information of the 3D LUT
 
         const char* name = 0x0;
         const char* uid  = 0x0;
@@ -261,7 +261,7 @@ void OpenGLBuilder::allocateAllTextures(unsigned startIndex)
             throw OCIO::Exception("The texture values are missing");
         }
 
-        // 2. Allocate the 3D lut
+        // 2. Allocate the 3D LUT
 
         unsigned texId = 0;
         AllocateTexture3D(currIndex, texId, interpolation, edgelen, values);
@@ -273,12 +273,12 @@ void OpenGLBuilder::allocateAllTextures(unsigned startIndex)
         currIndex++;
     }
 
-    // Process the 1D luts
+    // Process the 1D LUTs
 
     const unsigned maxTexture2D = m_shaderDesc->getNumTextures();
     for(unsigned idx=0; idx<maxTexture2D; ++idx)
     {
-        // 1. Get the information of the 1D lut
+        // 1. Get the information of the 1D LUT
 
         const char* name = 0x0;
         const char* uid  = 0x0;
@@ -300,7 +300,7 @@ void OpenGLBuilder::allocateAllTextures(unsigned startIndex)
             throw OCIO::Exception("The texture values are missing");
         }
 
-        // 2. Allocate the 1D lut (a 2D texture is needed to hold large luts)
+        // 2. Allocate the 1D LUT (a 2D texture is needed to hold large LUTs)
 
         unsigned texId = 0;
         AllocateTexture2D(currIndex, texId, width, height, interpolation, values);

--- a/src/pyglue/DocStrings/Baker.py
+++ b/src/pyglue/DocStrings/Baker.py
@@ -2,10 +2,10 @@
 class Baker:
     """
     In certain situations it is necessary to serialize transforms into
-    a variety of application specific lut formats. The Baker can be
-    used to create lut formats that ocio supports for writing.
+    a variety of application specific LUT formats. The Baker can be
+    used to create lut formats that OCIO supports for writing.
 
-    **Usage Example:** *Bake a houdini sRGB viewer lut*
+    **Usage Example:** *Bake a houdini sRGB viewer LUT*
 
     .. code-block:: python
 
@@ -14,7 +14,7 @@ class Baker:
         baker = OCIO.Baker()
         baker.setConfig(config)
         baker.setFormat('houdini')  # set the houdini type
-        baker.setType('3D')  # we want a 3D lut
+        baker.setType('3D')  # we want a 3D LUT
         baker.setInputSpace('lnf')
         baker.setShaperSpace('log')
         baker.setTargetSpace('sRGB')
@@ -23,8 +23,8 @@ class Baker:
             lutFile.write(out)
 
     .. note::
-        Except for icc profiles, this interface can be used in place of
-        *ociobakelut* for lut file creation.
+        Except for ICC profiles, this interface can be used in place of
+        *ociobakelut* for LUT file creation.
 
     """
     def __init__(self):
@@ -80,7 +80,7 @@ class Baker:
         """
         setFormat(formatName)
 
-        Set the lut output format.
+        Set the LUT output format.
 
         Any registered file format *with write capability* is supported
         by Baker. Available formats can be queried programmatically via
@@ -102,7 +102,7 @@ class Baker:
         """
         getFormat()
 
-        Get the lut output format.
+        Get the LUT output format.
 
         :return: format name
         :rtype: string
@@ -113,7 +113,7 @@ class Baker:
         """
         setType(type)
 
-        Set the lut output type (1D or 3D).
+        Set the LUT output type (1D or 3D).
 
         :param type: type name (e.g. '3D')
         :type type: string
@@ -124,7 +124,7 @@ class Baker:
         """
         getType()
 
-        Get the lut output type.
+        Get the LUT output type.
 
         :return: type name
         :rtype: string
@@ -135,7 +135,7 @@ class Baker:
         """
         setMetadata(metadata)
 
-        Set *optional* meta data for luts that support it.
+        Set *optional* meta data for LUTs that support it.
 
         :param metadata: meta data text
         :type metadata: string
@@ -157,7 +157,7 @@ class Baker:
         """
         setInputSpace(inputSpace)
 
-        Set the input :py:class:`PyOpenColorIO.ColorSpace` that the lut
+        Set the input :py:class:`PyOpenColorIO.ColorSpace` that the LUT
         will be applied to.
 
         :param inputSpace: input ColorSpace name
@@ -256,7 +256,7 @@ class Baker:
         setTargetSpace(targetSpace)
 
         Set the target :py:class:`PyOpenColorIO.ColorSpace` for the
-        lut.
+        LUT.
 
         :param targetSpace: target ColorSpace name
         :type targetSpace: string
@@ -323,9 +323,9 @@ class Baker:
         """
         bake()
 
-        Bake the lut into a string and return it.
+        Bake the LUT into a string and return it.
 
-        :return: formatted lut data
+        :return: formatted LUT data
         :rtype: string
         """
         pass
@@ -334,7 +334,7 @@ class Baker:
         """
         getNumFormats()
 
-        Get the number of lut writers.
+        Get the number of LUT writers.
 
         :return: format count
         :rtype: int
@@ -345,7 +345,7 @@ class Baker:
         """
         getFormatNameByIndex(index)
 
-        Get the lut writer name at index. Return an empty string if an
+        Get the LUT writer name at index. Return an empty string if an
         invalid index is specified.
 
         :param index: format index
@@ -359,7 +359,7 @@ class Baker:
         """
         getFormatExtensionByIndex(index)
 
-        Get the lut writer file extension at index. Return an empty
+        Get the LUT writer file extension at index. Return an empty
         string if an invalid index is specified.
 
         :param index: format index

--- a/src/pyglue/DocStrings/Config.py
+++ b/src/pyglue/DocStrings/Config.py
@@ -117,7 +117,7 @@ class Config:
         will be incorporated into the cacheID. While the contents of the files
         are not read, the file system is queried for relavent information
         (mtime, inode) so that the :py:class:`PyOpenColorIO.Config`'s cacheID
-        will change when the underlying luts are updated.
+        will change when the underlying LUTs are updated.
         
         If a context is not provided, the current Context will be used. If a
         null context is provided, file references will not be taken into

--- a/src/pyglue/tests/ConfigTest.py
+++ b/src/pyglue/tests/ConfigTest.py
@@ -74,7 +74,7 @@ colorspaces:
         osx_hack = ''
         if osname=="Darwin":
             osx_hack = """
-// OSX segfault work-around: Force a no-op sampling of the 3d lut.
+// OSX segfault work-around: Force a no-op sampling of the 3D LUT.
 texture3D(lut3d, 0.96875 * out_pixel.rgb + 0.015625).rgb;"""
 
         self.GLSLResult = """


### PR DESCRIPTION
Fix some spelling and format issues with comments.
Add consistency to how LUT is spelled.
Improving consistency could be breaking the first rule of coding guidelines, but it can also be seen as fixing the lack of complying to that rule.