### PR TITLE
Adsk Contrib - Add transform validations

### DIFF
--- a/export/OpenColorIO/OpenColorTransforms.h
+++ b/export/OpenColorIO/OpenColorTransforms.h
@@ -48,7 +48,7 @@ OCIO_NAMESPACE_ENTER
 
     //!rst:: //////////////////////////////////////////////////////////////////
     
-    //!cpp:class:: 
+    //!cpp:class:: Base class for all the transform classes
     class OCIOEXPORT Transform
     {
     public:
@@ -57,7 +57,10 @@ OCIO_NAMESPACE_ENTER
         
         virtual TransformDirection getDirection() const = 0;
         virtual void setDirection(TransformDirection dir) = 0;
-        
+
+        //!cpp:function:: Will throw if data is not valid.
+        virtual void validate() const;
+
     private:
         Transform& operator= (const Transform &);
     };
@@ -83,7 +86,10 @@ OCIO_NAMESPACE_ENTER
         virtual TransformDirection getDirection() const;
         //!cpp:function::
         virtual void setDirection(TransformDirection dir);
-        
+
+        //!cpp:function:: Will throw if data is not valid.
+        virtual void validate() const;
+
         //!cpp:function::
         Allocation getAllocation() const;
         //!cpp:function::
@@ -144,7 +150,10 @@ OCIO_NAMESPACE_ENTER
         virtual TransformDirection getDirection() const;
         //!cpp:function::
         virtual void setDirection(TransformDirection dir);
-        
+
+        //!cpp:function:: Will throw if data is not valid.
+        virtual void validate() const;
+       
         //!cpp:function::
         bool equals(const ConstCDLTransformRcPtr & other) const;
         
@@ -242,7 +251,10 @@ OCIO_NAMESPACE_ENTER
         virtual TransformDirection getDirection() const;
         //!cpp:function::
         virtual void setDirection(TransformDirection dir);
-        
+
+        //!cpp:function:: Will throw if data is not valid.
+        virtual void validate() const;
+
         //!cpp:function::
         const char * getSrc() const;
         //!cpp:function::
@@ -289,10 +301,10 @@ OCIO_NAMESPACE_ENTER
         virtual TransformDirection getDirection() const;
         //!cpp:function::
         virtual void setDirection(TransformDirection dir);
-        
-        
-        
-        
+
+        //!cpp:function:: Will throw if data is not valid.
+        virtual void validate() const;
+       
         //!cpp:function:: Step 0. Specify the incoming color space
         void setInputColorSpaceName(const char * name);
         //!cpp:function::
@@ -395,7 +407,10 @@ OCIO_NAMESPACE_ENTER
         virtual TransformDirection getDirection() const;
         //!cpp:function::
         virtual void setDirection(TransformDirection dir);
-        
+
+        //!cpp:function:: Will throw if data is not valid.
+        virtual void validate() const;
+
         //!cpp:function::
         void setValue(const float * vec4);
         //!cpp:function::
@@ -437,7 +452,10 @@ OCIO_NAMESPACE_ENTER
         virtual TransformDirection getDirection() const;
         //!cpp:function::
         virtual void setDirection(TransformDirection dir);
-        
+
+        //!cpp:function:: Will throw if data is not valid.
+        virtual void validate() const;
+
         //!cpp:function::
         const char * getSrc() const;
         //!cpp:function::
@@ -499,7 +517,10 @@ OCIO_NAMESPACE_ENTER
         virtual TransformDirection getDirection() const;
         //!cpp:function::
         virtual void setDirection(TransformDirection dir);
-        
+
+        //!cpp:function:: Will throw if data is not valid.
+        virtual void validate() const;
+
         //!cpp:function::
         ConstTransformRcPtr getTransform(int index) const;
         
@@ -552,7 +573,10 @@ OCIO_NAMESPACE_ENTER
         virtual TransformDirection getDirection() const;
         //!cpp:function::
         virtual void setDirection(TransformDirection dir);
-        
+
+        //!cpp:function:: Will throw if data is not valid.
+        virtual void validate() const;
+
         //!cpp:function::
         void setBase(float val);
         //!cpp:function::
@@ -596,7 +620,10 @@ OCIO_NAMESPACE_ENTER
         virtual TransformDirection getDirection() const;
         //!cpp:function::
         virtual void setDirection(TransformDirection dir);
-        
+
+        //!cpp:function:: Will throw if data is not valid.
+        virtual void validate() const;
+
         //!cpp:function::
         const char * getSrc() const;
         //!cpp:function::
@@ -653,7 +680,10 @@ OCIO_NAMESPACE_ENTER
         virtual TransformDirection getDirection() const;
         //!cpp:function::
         virtual void setDirection(TransformDirection dir);
-        
+
+        //!cpp:function:: Will throw if data is not valid.
+        virtual void validate() const;
+
         //!cpp:function::
         bool equals(const MatrixTransform & other) const;
         
@@ -736,7 +766,10 @@ OCIO_NAMESPACE_ENTER
         virtual TransformDirection getDirection() const;
         //!cpp:function::
         virtual void setDirection(TransformDirection dir);
-        
+
+        //!cpp:function:: Will throw if data is not valid.
+        virtual void validate() const;
+
         //!cpp:function::
         void setConfigRoot(const char * configroot);
         //!cpp:function::

--- a/src/core/AllocationTransform.cpp
+++ b/src/core/AllocationTransform.cpp
@@ -108,8 +108,31 @@ OCIO_NAMESPACE_ENTER
     {
         getImpl()->dir_ = dir;
     }
-    
-    
+
+    void AllocationTransform::validate() const
+    {
+        Transform::validate();
+
+        if (getImpl()->allocation_ == ALLOCATION_UNIFORM)
+        {
+            if(getImpl()->vars_.size()!=2 && getImpl()->vars_.size()!=0)
+            {
+                throw Exception("AllocationTransform: wrong number of values for the uniform allocation");
+            }
+        }
+        else if (getImpl()->allocation_ == ALLOCATION_LG2)
+        {
+            if(getImpl()->vars_.size()!=3 && getImpl()->vars_.size()!=2 && getImpl()->vars_.size()!=0)
+            {
+                throw Exception("AllocationTransform: wrong number of values for the logarithmic allocation");
+            }
+        }
+        else
+        {
+            throw Exception("AllocationTransform: invalid allocation type");
+        }
+    }
+
     Allocation AllocationTransform::getAllocation() const
     {
         return getImpl()->allocation_;
@@ -194,3 +217,37 @@ OCIO_NAMESPACE_ENTER
     }
 }
 OCIO_NAMESPACE_EXIT
+
+
+#ifdef OCIO_UNIT_TEST
+
+namespace OCIO = OCIO_NAMESPACE;
+#include "UnitTest.h"
+
+OIIO_ADD_TEST(AllocationTransform, allocation)
+{
+    OCIO::AllocationTransformRcPtr al = OCIO::AllocationTransform::Create();
+
+    al->setAllocation(OCIO::ALLOCATION_UNIFORM);
+    OIIO_CHECK_NO_THROW(al->validate());
+
+    std::vector<float> envs(2, 0.0f);
+    al->setVars(static_cast<int>(envs.size()), &envs[0]);
+    OIIO_CHECK_NO_THROW(al->validate());
+
+    envs.push_back(0.01f);
+    al->setVars(static_cast<int>(envs.size()), &envs[0]);
+    OIIO_CHECK_THROW(al->validate(), OCIO::Exception);
+
+    al->setAllocation(OCIO::ALLOCATION_LG2);
+    OIIO_CHECK_NO_THROW(al->validate());
+
+    envs.push_back(0.1f);
+    al->setVars(static_cast<int>(envs.size()), &envs[0]);
+    OIIO_CHECK_THROW(al->validate(), OCIO::Exception);
+
+    al->setVars(0, 0x0);
+    OIIO_CHECK_NO_THROW(al->validate());
+}
+
+#endif

--- a/src/core/CDLTransform.cpp
+++ b/src/core/CDLTransform.cpp
@@ -636,6 +636,18 @@ OCIO_NAMESPACE_ENTER
         getImpl()->dir_ = dir;
     }
     
+    void CDLTransform::validate() const
+    {
+        Transform::validate();
+
+        // TODO: Uncomment in upcoming PR that contains the OpData validate.
+        //       getImpl()->data_->validate()
+        //       
+        //       OpData classes are the enhancement of some existing 
+        //       structures (like Lut1D and Lut3D) by encapsulating
+        //       all the data and adding high-level behaviors.
+    }
+
     const char * CDLTransform::getXML() const
     {
         getImpl()->xml_ = BuildXML(*this);

--- a/src/core/ColorSpaceTransform.cpp
+++ b/src/core/ColorSpaceTransform.cpp
@@ -106,6 +106,21 @@ OCIO_NAMESPACE_ENTER
         getImpl()->dir_ = dir;
     }
     
+    void ColorSpaceTransform::validate() const
+    {
+        Transform::validate();
+
+        if (getImpl()->src_.empty())
+        {
+            throw Exception("ColorSpaceTransform: empty source color space name");
+        }
+
+        if (getImpl()->dst_.empty())
+        {
+            throw Exception("ColorSpaceTransform: empty destination color space name");
+        }
+    }
+
     const char * ColorSpaceTransform::getSrc() const
     {
         return getImpl()->src_.c_str();

--- a/src/core/DisplayTransform.cpp
+++ b/src/core/DisplayTransform.cpp
@@ -135,6 +135,13 @@ OCIO_NAMESPACE_ENTER
         getImpl()->dir_ = dir;
     }
     
+    void DisplayTransform::validate() const
+    {
+        Transform::validate();
+
+        // TODO: Improve DisplayTransform::validate()
+    }
+
     void DisplayTransform::setInputColorSpaceName(const char * name)
     {
         getImpl()->inputColorSpaceName_ = name;

--- a/src/core/ExponentTransform.cpp
+++ b/src/core/ExponentTransform.cpp
@@ -111,6 +111,18 @@ OCIO_NAMESPACE_ENTER
         getImpl()->dir_ = dir;
     }
     
+    void ExponentTransform::validate() const
+    {
+        Transform::validate();
+
+        // TODO: Uncomment in upcoming PR that contains the OpData validate.
+        //       getImpl()->data_->validate()
+        //       
+        //       OpData classes are the enhancement of some existing 
+        //       structures (like Lut1D and Lut3D) by encapsulating
+        //       all the data and adding high-level behaviors.
+    }
+
     void ExponentTransform::setValue(const float * vec4)
     {
         if(vec4) memcpy(getImpl()->value_, vec4, 4*sizeof(float));

--- a/src/core/FileTransform.cpp
+++ b/src/core/FileTransform.cpp
@@ -115,7 +115,17 @@ OCIO_NAMESPACE_ENTER
     {
         getImpl()->dir_ = dir;
     }
-    
+
+    void FileTransform::validate() const
+    {
+        Transform::validate();
+
+        if (getImpl()->src_.empty())
+        {
+            throw Exception("FileTransform: empty file path");
+        }
+    }
+
     const char * FileTransform::getSrc() const
     {
         return getImpl()->src_.c_str();
@@ -918,6 +928,17 @@ OIIO_ADD_TEST(FileTransform, AllFormats)
     OIIO_CHECK_ASSERT(FormatExtensionFoundByName("spimtx", "spimtx"));
     OIIO_CHECK_ASSERT(FormatExtensionFoundByName("vf", "nukevf"));
 
+}
+
+OIIO_ADD_TEST(FileTransform, validate)
+{
+    OCIO::FileTransformRcPtr tr = OCIO::FileTransform::Create();
+
+    tr->setSrc("example-3d-lut.ctf");
+    OIIO_CHECK_NO_THROW(tr->validate());
+
+    tr->setSrc("");
+    OIIO_CHECK_THROW(tr->validate(), OCIO::Exception);
 }
 
 

--- a/src/core/GroupTransform.cpp
+++ b/src/core/GroupTransform.cpp
@@ -121,6 +121,16 @@ OCIO_NAMESPACE_ENTER
         getImpl()->dir_ = dir;
     }
     
+    void GroupTransform::validate() const
+    {
+        Transform::validate();
+
+        for (int i = 0; i<size(); ++i)
+        {
+            getTransform(i)->validate();
+        }
+    }
+
     int GroupTransform::size() const
     {
         return static_cast<int>(getImpl()->vec_.size());

--- a/src/core/LogTransform.cpp
+++ b/src/core/LogTransform.cpp
@@ -107,7 +107,18 @@ OCIO_NAMESPACE_ENTER
         getImpl()->dir_ = dir;
     }
     
-    
+    void LogTransform::validate() const
+    {
+        Transform::validate();
+
+        // TODO: Uncomment in upcoming PR that contains the OpData validate.
+        //       getImpl()->data_->validate()
+        //       
+        //       OpData classes are the enhancement of some existing 
+        //       structures (like Lut1D and Lut3D) by encapsulating
+        //       all the data and adding high-level behaviors.
+    }
+
     float LogTransform::getBase() const
     {
         return getImpl()->base_;

--- a/src/core/LookTransform.cpp
+++ b/src/core/LookTransform.cpp
@@ -113,7 +113,22 @@ OCIO_NAMESPACE_ENTER
     {
         getImpl()->dir_ = dir;
     }
-    
+
+    void LookTransform::validate() const
+    {
+        Transform::validate();
+
+        if (getImpl()->src_.empty())
+        {
+            throw Exception("LookTransform: empty source color space name");
+        }
+
+        if (getImpl()->dst_.empty())
+        {
+            throw Exception("LookTransform: empty destination color space name");
+        }
+    }
+
     const char * LookTransform::getSrc() const
     {
         return getImpl()->src_.c_str();

--- a/src/core/MatrixTransform.cpp
+++ b/src/core/MatrixTransform.cpp
@@ -110,6 +110,18 @@ OCIO_NAMESPACE_ENTER
         getImpl()->dir_ = dir;
     }
     
+    void MatrixTransform::validate() const
+    {
+        Transform::validate();
+
+        // TODO: Uncomment in upcoming PR that contains the OpData validate.
+        //       getImpl()->data_->validate()
+        //       
+        //       OpData classes are the enhancement of some existing 
+        //       structures (like Lut1D and Lut3D) by encapsulating
+        //       all the data and adding high-level behaviors.
+    }
+
     bool MatrixTransform::equals(const MatrixTransform & other) const
     {
         const float abserror = 1e-9f;

--- a/src/core/Transform.cpp
+++ b/src/core/Transform.cpp
@@ -33,13 +33,25 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Processor.h"
 
 #include <sstream>
+#include <typeinfo>
 
 OCIO_NAMESPACE_ENTER
 {
     Transform::~Transform()
     { }
-    
-    
+
+    void Transform::validate() const
+    { 
+        if (getDirection() != TRANSFORM_DIR_FORWARD
+            && getDirection() != TRANSFORM_DIR_INVERSE)
+        {
+            std::string err(typeid(*this).name());
+            err += ": invalid direction";
+
+            throw Exception(err.c_str());
+        }
+    }
+
     void BuildOps(OpRcPtrVec & ops,
                   const Config & config,
                   const ConstContextRcPtr & context,
@@ -107,9 +119,11 @@ OCIO_NAMESPACE_ENTER
         }
         else
         {
-            std::ostringstream os;
-            os << "Unknown transform type for Op Creation.";
-            throw Exception(os.str().c_str());
+            std::ostringstream error;
+            error << "Unknown transform type for creation: "
+                  << typeid(transform).name();
+
+            throw Exception(error.str().c_str());
         }
     }
     
@@ -175,8 +189,11 @@ OCIO_NAMESPACE_ENTER
         else
         {
             std::ostringstream error;
-            os << "Unknown transform type for serialization.";
+            error << "Unknown transform type for serialization: "
+                  << typeid(transform).name();
+
             throw Exception(error.str().c_str());
+
         }
         
         return os;

--- a/src/core/TruelightTransform.cpp
+++ b/src/core/TruelightTransform.cpp
@@ -131,6 +131,13 @@ OCIO_NAMESPACE_ENTER
         getImpl()->dir_ = dir;
     }
     
+    void TruelightTransform::validate() const
+    {
+        Transform::validate();
+
+        // TODO: Improve TruelightTransform::validate()
+    }
+
     void TruelightTransform::setConfigRoot(const char * configroot)
     {
         getImpl()->configroot_ = configroot;


### PR DESCRIPTION
When reading the Op data from an OCIO config. file, some validations could already be done (i.e. without waiting the corresponding Op(s) creation):

1. Refactoring the code to have the validation method
2. Add some preliminary validations