### PR TITLE
Adsk Contrib - Simplify travis Linux build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,7 @@ env:
 before_install:
   # Linux ones
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      sudo apt-get update -qq;
       sudo apt-get install -y -qq texlive-full;
-      sudo apt-get install -y -qq freeglut3-dev libglew-dev libxmu-dev libxi-dev;
       mkdir ${TRAVIS_BUILD_DIR}/_cmake;
       wget https://cmake.org/files/v3.12/cmake-3.12.2-Linux-x86_64.sh;
       sh cmake-3.12.2-Linux-x86_64.sh -- --skip-license --prefix=${TRAVIS_BUILD_DIR}/_cmake;


### PR DESCRIPTION
Simplify the travis Linux buid to avoid the timeout when updating the OS.