### PR TITLE
Add CONTRIBUTING and GOVERNANCE documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,12 +25,9 @@ and general color questions.
 
 * [Slack](https://opencolorio.slack.com):
 The OpenColorIO Slack group is where developers and expert users go to have
-real-time communication around OCIO. This group is invitation only, but we’re
-quite lackadaisical in our barrier for entry. Simply put, if you just have
-a quick question it's not worth joining, but if you want to start actively
-participating and communicating more “casually” with project developers, this is
-the place for you. Please request an invitation on the ocio-dev email list
-mentioned above.
+real-time communication around OCIO. The group is invitation only, but just
+email us and we'll add anyone who is interested in participating in the
+discussion.
 
 * [GitHub Issues](https://github.com/imageworks/OpenColorIO/issues):
 GitHub **issues** are a great place to start a conversation! Issues aren’t
@@ -120,7 +117,58 @@ for merging after all builds have succeeded.
 who may discuss, offer constructive feedback, request changes, or approve
 the work.
 
-7. Upon receiving the required number of Committer approvals (as outlined in
-[GOVERNANCE.md](https://github.com/imageworks/OpenColorIO/blob/master/GOVERNANCE.md#committers)),
-a Committer other than the PR contributor may squash and merge changes into the
-master branch.
+7. Upon receiving the required number of Committer approvals (as outlined
+in [Required Approvals](#required-approvals)), a Committer other than the PR
+contributor may squash and merge changes into the master branch.
+
+## Required Approvals
+
+Modifications of the contents of the OpenColorIO repository are made on a
+collaborative basis. Anyone with a GitHub account may propose a modification via
+pull request and it will be considered by the project Committers.
+
+Pull requests must meet a minimum number of Committer approvals prior to being
+merged. Rather than having a hard rule for all PRs, the requirement is based on
+the complexity and risk of the proposed changes, factoring in the length of
+time the PR has been open to discussion. The following guidelines outline the
+project's established approval rules for merging:
+
+* Core design decisions, large new features, or anything that might be perceived
+as changing the overall direction of the project should be discussed at length
+in the mail list before any PR is submitted, in order to: solicit feedback, try
+to get as much consensus as possible, and alert all the stakeholders to be on
+the lookout for the eventual PR when it appears.
+
+* Small changes (bug fixes, docs, tests, cleanups) can be approved and merged by
+a single Committer.
+
+* Big changes that can alter behavior, add major features, or present a high
+degree of risk should be signed off by TWO Committers, ideally one of whom
+should be the "owner" for that section of the codebase (if a specific owner
+has been designated). If the person submitting the PR is him/herself the "owner"
+of that section of the codebase, then only one additional Committer approval is
+sufficient. But in either case, a 48 hour minimum is helpful to give everybody a
+chance to see it, unless it's a critical emergency fix (which would probably put
+it in the previous "small fix" category, rather than a "big feature").
+
+* Escape valve: big changes can nonetheless be merged by a single Committer if
+the PR has been open for over two weeks without any unaddressed objections from
+other Committers. At some point, we have to assume that the people who know and
+care are monitoring the PRs and that an extended period without objections is
+really assent.
+
+Approval must be from Committers who are not authors of the change. If one or
+more Committers oppose a proposed change, then the change cannot be accepted
+unless:
+
+* Discussions and/or additional changes result in no Committers objecting to the
+change. Previously-objecting Committers do not necessarily have to sign-off on
+the change, but they should not be opposed to it.
+
+* The change is escalated to the TSC and the TSC votes to approve the change.
+This should only happen if disagreements between Committers cannot be resolved
+through discussion.
+
+Committers may opt to elevate significant or controversial modifications to the
+TSC by assigning the `tsc-review` label to a pull request or issue. The TSC
+should serve as the final arbiter where required.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,126 @@
+# Contributing to OpenColorIO
+
+Thank you for your interest in contributing to OpenColorIO. This document
+explains our contribution process and procedures, so please review it first.
+
+## Get Connected
+
+The first thing to do, before anything else, is talk to us! Whether you're
+reporting an issue, requesting or implementing a feature, or just asking a
+question; please don’t hesitate to reach out to project maintainers or the
+community as a whole. This is an important first step because your issue,
+feature, or the question may have been solved or discussed already, and you’ll
+save yourself a lot of time by asking first.
+
+How do you talk to us? There are several ways to get in touch:
+
+* [ocio-dev](https://groups.google.com/forum/#!forum/ocio-dev):
+This is a development focused mail list with a deep history of technical
+conversations and decisions that have shaped the project.
+
+* [ocio-users](https://groups.google.com/forum/#!forum/ocio-users):
+This is an end-user oriented mail list, focused on how to use OCIO’s features
+within a host application. Common topics include crafting configs, DCC behavior,
+and general color questions.
+
+* [Slack](https://opencolorio.slack.com):
+The OpenColorIO Slack group is where developers and expert users go to have
+real-time communication around OCIO. This group is invitation only, but we’re
+quite lackadaisical in our barrier for entry. Simply put, if you just have
+a quick question it's not worth joining, but if you want to start actively
+participating and communicating more “casually” with project developers, this is
+the place for you. Please request an invitation on the ocio-dev email list
+mentioned above.
+
+* [GitHub Issues](https://github.com/imageworks/OpenColorIO/issues):
+GitHub **issues** are a great place to start a conversation! Issues aren’t
+restricted to bugs; we happily welcome feature requests and other suggestions
+submitted as issues. The only conversations we would direct away from issues are
+questions in the form of “How do I do X”. Please direct these to the ocio-dev or
+ocio-users mail lists, and consider contributing what you've learned to our
+docs if appropriate!
+
+## Getting Started
+
+So you’ve broken the ice and chatted with us, and it turns out you’ve found a
+gnarly bug that you have a beautiful solution for. Wonderful!
+
+From here on out we’ll be using a significant amount of Git and GitHub based
+terminology. If you’re unfamiliar with these tools or their lingo, please look
+at the [GitHub Glossary](https://help.github.com/articles/github-glossary/) or
+browse [GitHub Help](https://help.github.com/). It can be a bit confusing at
+first, but feel free to reach out if you need assistance.
+
+The first requirement for contributing is to have a GitHub account. This is
+needed in order to push changes to the upstream repository. After setting up
+your account you should then **fork** the OpenColorIO repository to your
+account. This creates a copy of the repository under your user namespace and
+serves as the “home base” for your development branches, from which you will
+submit **pull requests** to the upstream repository to be merged.
+
+You will also need Git installed on your local development machine. If you need
+setup assistance, please see the official
+[Git Documentation](https://git-scm.com/doc).
+
+Once your Git environment is operational, the next step is to locally
+**clone** your forked OpenColorIO repository, and add a **remote** pointing to
+the upstream OpenColorIO repository. These topics are covered in
+[Cloning a repository](https://help.github.com/articles/cloning-a-repository/)
+and
+[Configuring a remote for a fork](https://help.github.com/articles/configuring-a-remote-for-a-fork/),
+but again, if you need assistance feel free to reach out on the ocio-dev mail
+list.
+
+You are now ready to contribute.
+
+## Repository Structure
+
+The OpenColorIO repository has a relatively straight-forward structure, and a
+simple branching and merging strategy.
+
+All development work is done directly on the master branch. This represents the
+bleeding-edge of the project and any contributions should be done on top of it.
+
+After sufficient work is done on the master branch and OCIO leadership
+determines that a release is due, we will bump the relevant internal versioning
+and tag a commit with the corresponding version number, e.g. v2.0.1. Each Minor
+version also has its own “Release Branch”, e.g. RB-1.1. This marks a branch of
+code dedicated to that Major.Minor version, which allows upstream bug fixes to
+be cherry-picked to a given version while still allowing the master branch to
+continue forward onto higher versions. This basic repository structure keeps
+maintenance low, while remaining simple to understand.
+
+## Development and Pull Requests
+
+Contributions should be submitted as Github pull requests. See
+[Creating a pull request](https://help.github.com/articles/creating-a-pull-request/)
+if you're unfamiliar with this concept.
+
+The development cycle for a code change should follow this protocol:
+
+1. Create a topic branch in your local repository, following the naming format
+"feature/<your-feature>" or "bugfix/<your-fix>".
+
+2. Make changes, compile, and test thoroughly. Code style should match existing
+style and conventions, and changes should be focused on the topic the pull
+request will be addressing. Make unrelated changes in a separate topic branch
+with a separate pull request.
+
+3. Push commits to your fork.
+
+4. Create a Github pull request from your topic branch.
+
+5. All pull requests trigger CI builds on [Travis CI](https://travis-ci.org/)
+for Linux and Mac OS and [AppVeyor](https://www.appveyor.com/) for Windows.
+These builds verify that code compiles and all unit tests succeed. CI build
+status is displayed on the GitHub PR page, and changes will only be considered
+for merging after all builds have succeeded.
+
+6. Pull requests will be reviewed by project Committers and Contributors,
+who may discuss, offer constructive feedback, request changes, or approve
+the work.
+
+7. Upon receiving the required number of Committer approvals (as outlined in
+[GOVERNANCE.md](https://github.com/imageworks/OpenColorIO/blob/master/GOVERNANCE.md#committers)),
+a Committer other than the PR contributor may squash and merge changes into the
+master branch.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -18,60 +18,10 @@ are Contributors who have earned the ability to modify source code,
 documentation, or other technical artifacts to the project. Upon becoming
 Committers, they become members of the OCIO leadership team.
 
-Their privileges include but are not limited to:
+Their privileges include, but are not limited to:
 
 * Commit access to the OpenColorIO repository
 * Moderator status on all communication channels
-
-Modifications of the contents of the OpenColorIO repository are made on a
-collaborative basis. Anyone with a GitHub account may propose a modification via
-pull request and it will be considered by the project Committers.
-
-Pull requests must meet a minimum number of Committer approvals prior to being
-merged. Rather than having a hard rule for all PRs, the requirement is based on
-the complexity and risk of the proposed changes, factoring in the length of
-time the PR has been open to discussion. The following guidelines outline the
-project's established approval rules for merging:
-
-* Core design decisions, large new features, or anything that might be perceived
-as changing the overall direction of the project should be discussed at length
-in the mail list before any PR is submitted, in order to: solicit feedback, try
-to get as much consensus as possible, and alert all the stakeholders to be on
-the lookout for the eventual PR when it appears.
-
-* Small changes (bug fixes, docs, tests, cleanups) can be approved and merged by
-a single Committer.
-
-* Big changes that can alter behavior, add major features, or present a high
-degree of risk should be signed off by TWO Committers, ideally one of whom
-should be the "owner" for that section of the codebase (if a specific owner
-has been designated). If the person submitting the PR is him/herself the "owner"
-of that section of the codebase, then only one additional Committer approval is
-sufficient. But in either case, a 48 hour minimum is helpful to give everybody a
-chance to see it, unless it's a critical emergency fix (which would probably put
-it in the previous "small fix" category, rather than a "big feature").
-
-* Escape valve: big changes can nonetheless be merged by a single Committer if
-the PR has been open for over two weeks without any unaddressed objections from
-other Committers. At some point, we have to assume that the people who know and
-care are monitoring the PRs and that an extended period without objections is
-really assent.
-
-Approval must be from Committers who are not authors of the change. If one or
-more Committers oppose a proposed change, then the change cannot be accepted
-unless:
-
-* Discussions and/or additional changes result in no Committers objecting to the
-change. Previously-objecting Committers do not necessarily have to sign-off on
-the change, but they should not be opposed to it.
-
-* The change is escalated to the TSC and the TSC votes to approve the change.
-This should only happen if disagreements between Committers cannot be resolved
-through discussion.
-
-Committers may opt to elevate significant or controversial modifications to the
-TSC by assigning the `tsc-review` label to a pull request or issue. The TSC
-should serve as the final arbiter where required.
 
 ### Committer Activities
 
@@ -87,7 +37,7 @@ The TSC periodically reviews the Committer list to identify inactive Committers.
 Past Committers are typically given Emeritus status. Emeriti may request that
 the TSC restore them to active Committer status.
 
-## Committer Nominations
+### Committer Nominations
 
 Any existing Committer can nominate an individual making significant and
 valuable contributions to the OpenColorIO project to become a new Committer.
@@ -95,7 +45,7 @@ valuable contributions to the OpenColorIO project to become a new Committer.
 To nominate a new Committer, open an issue in the OCIO repository, with a
 summary of the nominee's contributions.
 
-If there are no objections raised by any Committers one week after the issue is
+If there are no objections raised by any Committers two weeks after the issue is
 opened, the nomination will be considered as accepted. Should there be any
 objections against the nomination, the TSC is responsible for working with the
 individuals involved and finding a resolution. The nomination must be approved
@@ -114,7 +64,7 @@ directly.
 
 A subset of the Committers forms the Technical Steering Committee (TSC), which
 has final authority over this project. As defined in the project charter, TSC
-responsibilities include, but not limited to:
+responsibilities include, but are not limited to:
 
 * Coordinating technical direction of the Project
 * Project governance and process (including this policy)
@@ -128,7 +78,7 @@ communities
 matters relating to the code base that affect multiple projects
 * Coordinating any marketing, events, or communications regarding the project
 
-Within the TSC are three elected leadership roles to be held by its members and
+Within the TSC are two elected leadership roles to be held by its members and
 voted on annually. Any TSC member can express interest in serving in a role, or
 nominate another member to serve. There are no term limits, and one person may
 hold multiple roles simultaneously. Should a TSC member resign from a leadership
@@ -143,14 +93,15 @@ providing oversight to project administration.
 technical decisions, and is responsible for avoiding "design by committee"
 pitfalls.
 
-* ASWF TAC Representative: This position represents the project at all ASWF
-(Academy Software Foundation) TAC (Technical Advisory Council) meetings.
+At the time of election, the TSC will also agree upon which of these two leaders
+will serve as the OpenColorIO ASWF (Academy Software Foundation) TAC (Technical
+Advisory Council) representative for the term. This member represents the
+project at all ASWF TAC meetings.
 
 ### TSC Leaders
 
 * Chair: TBD
 * Chief Architect: TBD
-* ASWF TAC Representative: TBD
 
 ### TSC Members
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,219 @@
+# OpenColorIO Project Governance
+
+The OpenColorIO project is governed by its Committers, including a Technical
+Steering Committee (TSC) which is responsible for high-level guidance of the
+project.
+
+## Contributors
+
+The OpenColorIO project grows and thrives from assistance from Contributors.
+Contributors include anyone in the community that contributes code,
+documentation, or other technical artifacts that have been incorporated into the
+projects repository.
+
+## Committers
+
+The OpenColorIO GitHub repository is maintained by OCIO Committers. Committers
+are Contributors who have earned the ability to modify source code,
+documentation, or other technical artifacts to the project. Upon becoming
+Committers, they become members of the OCIO leadership team.
+
+Their privileges include but are not limited to:
+
+* Commit access to the OpenColorIO repository
+* Moderator status on all communication channels
+
+Modifications of the contents of the OpenColorIO repository are made on a
+collaborative basis. Anyone with a GitHub account may propose a modification via
+pull request and it will be considered by the project Committers.
+
+Pull requests must meet a minimum number of Committer approvals prior to being
+merged. Rather than having a hard rule for all PRs, the requirement is based on
+the complexity and risk of the proposed changes, factoring in the length of
+time the PR has been open to discussion. The following guidelines outline the
+project's established approval rules for merging:
+
+* Core design decisions, large new features, or anything that might be perceived
+as changing the overall direction of the project should be discussed at length
+in the mail list before any PR is submitted, in order to: solicit feedback, try
+to get as much consensus as possible, and alert all the stakeholders to be on
+the lookout for the eventual PR when it appears.
+
+* Small changes (bug fixes, docs, tests, cleanups) can be approved and merged by
+a single Committer.
+
+* Big changes that can alter behavior, add major features, or present a high
+degree of risk should be signed off by TWO Committers, ideally one of whom
+should be the "owner" for that section of the codebase (if a specific owner
+has been designated). If the person submitting the PR is him/herself the "owner"
+of that section of the codebase, then only one additional Committer approval is
+sufficient. But in either case, a 48 hour minimum is helpful to give everybody a
+chance to see it, unless it's a critical emergency fix (which would probably put
+it in the previous "small fix" category, rather than a "big feature").
+
+* Escape valve: big changes can nonetheless be merged by a single Committer if
+the PR has been open for over two weeks without any unaddressed objections from
+other Committers. At some point, we have to assume that the people who know and
+care are monitoring the PRs and that an extended period without objections is
+really assent.
+
+Approval must be from Committers who are not authors of the change. If one or
+more Committers oppose a proposed change, then the change cannot be accepted
+unless:
+
+* Discussions and/or additional changes result in no Committers objecting to the
+change. Previously-objecting Committers do not necessarily have to sign-off on
+the change, but they should not be opposed to it.
+
+* The change is escalated to the TSC and the TSC votes to approve the change.
+This should only happen if disagreements between Committers cannot be resolved
+through discussion.
+
+Committers may opt to elevate significant or controversial modifications to the
+TSC by assigning the `tsc-review` label to a pull request or issue. The TSC
+should serve as the final arbiter where required.
+
+### Committer Activities
+
+Typical activities of a Committer include:
+
+* Helping users and novice contributors
+* Contributing code and documentation changes that improve the project
+* Reviewing and commenting on issues and pull requests
+* Participation in working groups
+* Merging pull requests
+
+The TSC periodically reviews the Committer list to identify inactive Committers.
+Past Committers are typically given Emeritus status. Emeriti may request that
+the TSC restore them to active Committer status.
+
+## Committer Nominations
+
+Any existing Committer can nominate an individual making significant and
+valuable contributions to the OpenColorIO project to become a new Committer.
+
+To nominate a new Committer, open an issue in the OCIO repository, with a
+summary of the nominee's contributions.
+
+If there are no objections raised by any Committers one week after the issue is
+opened, the nomination will be considered as accepted. Should there be any
+objections against the nomination, the TSC is responsible for working with the
+individuals involved and finding a resolution. The nomination must be approved
+by the TSC, which is assumed when there are no objections from any TSC members.
+
+Prior to the public nomination, the Committer initiating it may seek feedback
+from other Committers in private channels and work with the nominee to improve
+the nominee's contribution profile, in order to make the nomination as
+frictionless as possible.
+
+If individuals making valuable contributions do not believe they have been
+considered for a nomination, they may log an issue or contact a Committer
+directly.
+
+## Technical Steering Committee
+
+A subset of the Committers forms the Technical Steering Committee (TSC), which
+has final authority over this project. As defined in the project charter, TSC
+responsibilities include, but not limited to:
+
+* Coordinating technical direction of the Project
+* Project governance and process (including this policy)
+* Contribution policy
+* GitHub repository hosting
+* Conduct guidelines
+* Maintaining the list of additional Committers
+* Appointing representatives to work with other open source or open standards
+communities
+* Discussions, seeking consensus, and where necessary, voting on technical
+matters relating to the code base that affect multiple projects
+* Coordinating any marketing, events, or communications regarding the project
+
+Within the TSC are three elected leadership roles to be held by its members and
+voted on annually. Any TSC member can express interest in serving in a role, or
+nominate another member to serve. There are no term limits, and one person may
+hold multiple roles simultaneously. Should a TSC member resign from a leadership
+role before their term is complete, a successor shall be elected through the
+standard nomination and voting process to complete the remainder of the term.
+The leadership roles are:
+
+* Chair: This position acts as the project manager, organizing meetings and
+providing oversight to project administration.
+
+* Chief Architect: This position makes all the final calls on design and
+technical decisions, and is responsible for avoiding "design by committee"
+pitfalls.
+
+* ASWF TAC Representative: This position represents the project at all ASWF
+(Academy Software Foundation) TAC (Technical Advisory Council) meetings.
+
+### TSC Leaders
+
+* Chair: TBD
+* Chief Architect: TBD
+* ASWF TAC Representative: TBD
+
+### TSC Members
+
+* Mark Boorer - ILM
+* Sean Cooper - DNEG
+* Michael Dolan - SPI
+* Larry Gritz - SPI
+* Patrick Hodoul - Autodesk
+* Doug Walker - Autodesk
+
+### TSC Meetings
+
+Any meetings of the TSC are intended to be open to the public, except where
+there is a reasonable need for privacy. The TSC meets regularly in a voice
+conference call, at a cadence deemed appropriate by the TSC. The meeting is run
+by a designated meeting chair approved by the TSC. Meetings may also be streamed
+online where appropriate; connection details will be posted to the ocio-dev mail
+list in advance of the scheduled meeting.
+
+Items are added to the TSC agenda which are considered contentious or are
+modifications of governance, contribution policy, TSC membership, or release
+process, in addition to topics involving the high-level technical direction of
+the project.
+
+The intention of the agenda is not to approve or review all patches. That should
+happen continuously on GitHub and be handled by the larger group of Committers.
+
+Any community member or Contributor can ask that something be reviewed by the
+TSC by logging a GitHub issue. Any Committer, TSC member, or the meeting chair
+can bring the issue to the TSC's attention by applying the `tsc-review` label.
+
+Prior to each TSC meeting, the meeting chair will share the agenda with members
+of the TSC. TSC members can also add items to the agenda at the beginning of
+each meeting. The meeting chair and the TSC cannot veto or remove items.
+
+The TSC may invite additional persons to participate in a non-voting capacity.
+
+The meeting chair is responsible for ensuring that minutes are taken and that
+notes are submitted after the meeting to the public mailing list.
+
+Due to the challenges of scheduling a global meeting with participants in
+several time zones, the TSC will seek to resolve as many agenda items as
+possible outside of meetings on the public mailing list.
+
+### TSC Nomination
+
+Any proposal for additional members of the TSC may be submitted by Committers
+and/or TSC members by opening an issue outlining their case. Formal consensus
+should be reached by the existing TSC members. No objections raised by any TSC
+members two weeks after the issue is opened does not imply acceptance, if
+general consensus cannot be reached by this time a formal vote is required.
+
+Should there be any objections against the nomination, the TSC is responsible
+for working with the individuals involved and finding a resolution.
+
+### TSC Succession
+
+A voting member of the TSC may nominate a successor in the event that such
+voting member decides to leave the TSC, and the TSC, including the departing
+member, shall confirm or reject such nomination by a vote.
+
+In the event that the departing member’s nomination for successor is rejected by
+vote of the TSC, the departing member shall be entitled to continue nominating
+successors until one such successor is confirmed by vote of the TSC. If the
+departing member fails or is unable to nominate a successor, the TSC may
+nominate one on the departing member’s behalf.


### PR DESCRIPTION
These CONTRIBUTING and GOVERNANCE documents are being referenced in the OCIO ASWF Charter and application. The content of this work is based on an initial pass by @scoopxyz , and comments from @lgritz and Doug Walker, which I have consolidated and edited.

Changes of note since the original Google Doc presented on Slack:
- Divided document into separate CONTRIBUTING and GOVERNANCE documents
- Expanded CONTRIBUTING "Development" section with inspiration from the OIIO CONTRIBUTING file. As we refine project standards and practices, the OIIO document will be a solid reference point for language and structure.
- Added links to relevant documentation and pages referenced in CONTRIBUTING.
- Incorporated Larry's suggested PR approval procedures from Issue #578 into GOVERNANCE
- Drafted TSC leadership role explanation and descriptions, based on discussion from Slack gov channel, present in the GOVERNANCE "Technical Steering Committee" section
- Added sections to outline elected leaders and TSC membership. 
- Added the current OCIO committer/leader names to the TSC list tentatively. All leadership roles are "TBD".

This is a working document. Please comment and suggest edits.