### PR TITLE
Fix wrong display returned by getDefaultDisplay()

### DIFF
--- a/src/OpenColorIO/Display.cpp
+++ b/src/OpenColorIO/Display.cpp
@@ -114,13 +114,13 @@ OCIO_NAMESPACE_ENTER
         // Apply the env override if it's not empty.
         if(!activeDisplaysEnvOverride.empty())
         {
-            displayCache = IntersectStringVecsCaseIgnore(displayMasterList, activeDisplaysEnvOverride);
+            displayCache = IntersectStringVecsCaseIgnore(activeDisplaysEnvOverride, displayMasterList);
             if(!displayCache.empty()) return;
         }
         // Otherwise, aApply the active displays if it's not empty.
         else if(!activeDisplays.empty())
         {
-            displayCache = IntersectStringVecsCaseIgnore(displayMasterList, activeDisplays);
+            displayCache = IntersectStringVecsCaseIgnore(activeDisplays, displayMasterList);
             if(!displayCache.empty()) return;
         }
         


### PR DESCRIPTION
The issue was caused by wrong logic around parsing display/views
override environment variable: if it is missing, it was converted
to an empty string. That empty string was considered an override
of one element display, with an empty name.

Now splitting empty string into vector will give empty result,
which seems to be what is expected.