### PR TITLE
Adsk Contrib - Lut1D improvements (WIP)

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -163,7 +163,7 @@ if(NOT BUILD_SHARED_LIBS)
 	message(WARNING " Building STATIC libOpenColorIO using the in-built ILMBASE. ILMBASE's symbols are NOT included in the output binary!")
 endif()
 
-set(ILMBASE_INCLUDE_DIRS "${ILMBASE_INSTALL_DIR}/include/ilmbase")
+set(ILMBASE_INCLUDE_DIRS "${ILMBASE_INSTALL_DIR}/include")
 set(ILMBASE_LIBRARY ${ILMBASE_INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}ilmbase${CMAKE_STATIC_LIBRARY_SUFFIX})
 
 ExternalProject_Add(ILMBASE

--- a/ext/ilmbasehalf-2.2.1.patch
+++ b/ext/ilmbasehalf-2.2.1.patch
@@ -1,7 +1,7 @@
 diff -Naur ilmbasehalf-2.2.1.orig/CMakeLists.txt ilmbasehalf-2.2.1/CMakeLists.txt
 --- ilmbasehalf-2.2.1.orig/CMakeLists.txt   1970-01-01 01:00:00.000000000 +0100
 +++ ilmbasehalf-2.2.1/CMakeLists.txt    2015-03-12 00:52:50.095773400 +0100
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,38 @@
 +project(ilmbase)
 +
 +cmake_minimum_required(VERSION 2.8)
@@ -23,6 +23,11 @@ diff -Naur ilmbasehalf-2.2.1.orig/CMakeLists.txt ilmbasehalf-2.2.1/CMakeLists.tx
 +set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE})
 +
 +add_library(${PROJECT_NAME} STATIC ${HEADERS} ${SOURCES})
++
++if(UNIX)
++    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
++endif()
 +
 +set_target_properties(${PROJECT_NAME} PROPERTIES
 +   LIBRARY_OUTPUT_NAME "${PROJECT_NAME}"

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -48,6 +48,9 @@ set(SOURCES
 	ops/Exponent/ExponentOps.cpp
 	ops/Log/LogOps.cpp
 	ops/Lut1D/Lut1DOp.cpp
+	ops/Lut1D/Lut1DOpCPU.cpp
+	ops/Lut1D/Lut1DOpData.cpp
+	ops/Lut1D/Lut1DOpGPU.cpp
 	ops/Lut3D/Lut3DOp.cpp
 	ops/Lut3D/Lut3DOpCPU.cpp
 	ops/Lut3D/Lut3DOpData.cpp

--- a/src/OpenColorIO/MathUtils.h
+++ b/src/OpenColorIO/MathUtils.h
@@ -35,12 +35,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#include "ilmbase/half.h"
 #include "Op.h"
 #include "Platform.h"
-
-#ifdef WINDOWS
-#include <float.h>
-#endif
 
 OCIO_NAMESPACE_ENTER
 {
@@ -55,7 +52,7 @@ OCIO_NAMESPACE_ENTER
     //  
     //  abs (x1 - x2) <= e
     //
-    // equalWithRelError (x1, x2, e)
+    // EqualWithRelError (x1, x2, e)
     //
     //  Returns true if x1 is the same as x2 with an relative error of
     //  no more than e,
@@ -169,7 +166,7 @@ inline double GetHalfMax()
 
 inline double GetHalfMin()
 {
-    return 5.96046448e-08;  // Smallest positive half;
+    return 5.96046448e-08;  // Smallest positive half
 }
 
 inline double GetHalfNormMin()
@@ -177,10 +174,12 @@ inline double GetHalfNormMin()
     return 6.10351562e-05;  // Smallest positive normalized half
 }
 
-//! Clamp the specified value to the valid range of normalized half.
-// (can be either positive or negative though
-
+// Clamp the specified value to the valid range of normalized half.
+// (can be either positive or negative though).
 double ClampToNormHalf(double val);
+
+// Convert an half representation to the corresponding float.
+float ConvertHalfBitsToFloat(unsigned short val);
 
 float GetSafeScalarInverse(float v, float defaultValue = 1.0);
 
@@ -191,7 +190,7 @@ float GetSafeScalarInverse(float v, float defaultValue = 1.0);
 // v : 4 column vector
 
 // Return the 4x4 inverse, and whether the inverse has succeeded.
-// Supports in-place operations
+// Supports in-place operations.
 bool GetM44Inverse(float* mout, const float* m);
 
 // Is an identity matrix? (with fltmin tolerance)
@@ -203,13 +202,9 @@ bool IsM44Diagonal(const float* m);
 // Extract the diagonal
 void GetM44Diagonal(float* vout, const float* m);
 
-// Get the product, out = m1*m2
-// Supports in-place operations
-void GetM44Product(float* mout, const float* m1, const float* m2);
-
-// Combine two transforms in the mx+b form, into a single transform
+// Combine two transforms in the mx+b form, into a single transform.
 // mout*x+vout == m2*(m1*x+v1)+v2
-// Supports in-place operations
+// Supports in-place operations.
 void GetMxbCombine(float* mout, float* vout,
                    const float* m1, const float* v1,
                    const float* m2, const float* v2);
@@ -223,7 +218,7 @@ bool GetMxbInverse(float* mout, float* vout,
 //
 // x : floating-point number
 //
-// Return reinterpreted float bit representation as an integer 
+// Return reinterpreted float bit representation as an integer.
 inline unsigned FloatAsInt(const float x)
 {
     union {
@@ -240,7 +235,7 @@ inline unsigned FloatAsInt(const float x)
 //
 // x : integer number
 //
-// Return reinterpreted integer bit representation as a float
+// Return reinterpreted integer bit representation as a float.
 inline float IntAsFloat(const unsigned x)
 {
     union {
@@ -284,6 +279,12 @@ inline float AddULP(const float f, const int ulp)
 //              compressDenorms flag.
 bool FloatsDiffer(const float expected, const float actual, 
                   const int tolerance, const bool compressDenorms);
+
+// Compares half-floats as raw integers with a tolerance (essentially in ULPs).
+// Returns true if the integer difference is strictly greater than the tolerance.
+// If aimHalf is a NaN, valHalf must also be one of the NaNs.
+// Inf is treated like any other value (diff from HALFMAX is 1).
+bool HalfsDiffer(const half expected, const half actual, const int tolerance);
 
 }
 OCIO_NAMESPACE_EXIT

--- a/src/OpenColorIO/OpTools.cpp
+++ b/src/OpenColorIO/OpTools.cpp
@@ -30,439 +30,52 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "BitDepthUtils.h"
 #include "OpTools.h"
-#include "ops/Lut3D/Lut3DOp.h"
-#include "ops/Matrix/MatrixOps.h"
-
 
 OCIO_NAMESPACE_ENTER
 {
-
-    unsigned long GetLutIdealSize(BitDepth incomingBitDepth)
+    void EvalTransform(const float * in,
+                       float * out,
+                       long numPixels,
+                       OpRcPtrVec & ops)
     {
-        // Return the number of entries needed in order to do a lookup 
-        // for the specified bit-depth.
+        std::vector<float> tmp(numPixels * 4);
 
-        // For 32f, a look-up is impractical so in that case return 64k.
-
-        switch(incomingBitDepth)
+        // Render the LUT entries (domain) through the ops.
+        const float * values = in;
+        for (long idx = 0; idx<numPixels; ++idx)
         {
-            case BIT_DEPTH_UINT8:
-            case BIT_DEPTH_UINT10:
-            case BIT_DEPTH_UINT12:
-            case BIT_DEPTH_UINT16:
-                return (unsigned long)(GetBitDepthMaxValue(incomingBitDepth) + 1);
+            tmp[4 * idx + 0] = values[0];
+            tmp[4 * idx + 1] = values[1];
+            tmp[4 * idx + 2] = values[2];
+            tmp[4 * idx + 3] = 1.0f;
 
-            case BIT_DEPTH_UNKNOWN:
-            case BIT_DEPTH_UINT14:
-            case BIT_DEPTH_UINT32:
-            default:
-            {
-                std::string err("Bit depth is not supported: ");
-                err += BitDepthToString(incomingBitDepth);
-                throw Exception(err.c_str());
-                break;
-            }
-
-            case BIT_DEPTH_F16:
-            case BIT_DEPTH_F32:
-                break;
+            values += 3;
         }
 
-        return 65536;
-    }
+        // NB: We assume finalize will set the bit-depth at each op interface
+        // to 32f so there is never any quantization to integer.
+        // Furthermore, to avoid improper recursion we must never call
+        // the renderer with an integer input depth.
+        // TODO: Currently the OCIO finalize is hard-coded to 32f.
+        //       When that changes we need to update this to request 32f input
+        //       and output bit depths.
+        FinalizeOpVec(ops);
 
-    //----------------------------------------------------------------------------------------------
-    //
-    // Functional composition is a concept from mathematics where two functions
-    // are combined into a single function.  This idea may be applied to ops
-    // where we generate a single op that has the same (or similar) effect as
-    // applying the two ops separately.  The motivation is faster processing.
-    //
-    // When composing LUTs, the algorithm produces a result which takes the
-    // domain of the first op into the range of the last op.  So the algorithm
-    // needs to render values through the ops.  In some cases the domain of
-    // the first op is sufficient, in other cases we need to create a new more
-    // finely sampled domain to try and make the result less lossy.
-
-
-    //----------------------------------------------------------------------------------------------
-    // Calculate a new LUT by evaluating a new domain (A) through a set of ops (B).
-    //
-    // Note1: The caller must ensure that B is separable (channel independent).
-    //
-    // Note2: Unlike compose(Lut1DOp,Lut1DOp), this function does not try to resize
-    //        the first LUT (A), so the caller needs to create a suitable domain.
-    //
-    Lut1DOpDataRcPtr Compose(const Lut1DOpDataRcPtr & A, const OpRcPtrVec & B)
-    {
-        // TODO: review this code when working on 1D LUT update
-
-        if (A->getOutputBitDepth() != B[0]->getInputBitDepth())
+        for (OpRcPtrVec::size_type i = 0, size = ops.size(); i<size; ++i)
         {
-            throw Exception("A bit depth mismatch forbids the composition of LUTs");
+            ops[i]->apply(&tmp[0], numPixels);
         }
 
-        OpRcPtrVec ops;
-
-        // Insert an op to compensate for the bitdepth scaling of A.
-        //
-        // The values in A's array have a certain scaling which needs to be
-        // normalized since ops will have an in-depth of 32f.
-        // Although it may seem like we could use the constructor to create
-        // a bit-depth conversion identity from A's out-depth to 32f,
-        // this doesn't work.  When pM gets appended, the set depth call
-        // would cause the scale factor to disappear.  In this case, the
-        // append set depth and the finalize set depth cancel out and we
-        // are left with our desired scale being applied.
-
-        const float iScale = 1.f / GetBitDepthMaxValue(A->getOutputBitDepth());
-        const float iScale4[4] = { iScale, iScale, iScale, iScale };
-        CreateScaleOp(ops, iScale4, TRANSFORM_DIR_FORWARD);
-
-        // Copy and append B.
-        for(OpRcPtrVec::size_type i=0, size = B.size(); i<size; ++i)
+        float * result = out;
+        for (long idx = 0; idx<numPixels; ++idx)
         {
-            ops.push_back(B[i]->clone());
+            result[0] = tmp[4 * idx + 0];
+            result[1] = tmp[4 * idx + 1];
+            result[2] = tmp[4 * idx + 2];
+
+            result += 3;
         }
-
-        // Insert an op to compensate for the bitdepth scaling of B.
-        //
-        // We render at 32f but need to create an array which may be inserted
-        // into a LUT with B's output depth, so apply the scaling manually.
-        // For the explanation of the bit-depths used, see the comment above.
-
-        const float oScale = GetBitDepthMaxValue(B[B.size()-1]->getOutputBitDepth());
-        const float oScale4[4] = { oScale, oScale, oScale, oScale };
-        CreateScaleOp(ops, oScale4, TRANSFORM_DIR_FORWARD);
-
-        // Evaluate
-
-        const size_t newLength = A->luts[0].size();
-
-        std::vector<float> in;
-        in.resize(newLength*4);
-        for(size_t idx=0; idx<newLength; ++idx)
-        {
-            in[4*idx + 0] = A->luts[0][idx];
-            in[4*idx + 1] = A->luts[1][idx];
-            in[4*idx + 2] = A->luts[2][idx];
-            in[4*idx + 3] =	1.0f;
-        }
-
-        for(OpRcPtrVec::size_type i=0, size = ops.size(); i<size; ++i)
-        {
-            ops[i]->apply(&in[0], (long)newLength);
-        }
-
-        Lut1DOpDataRcPtr lut(Lut1DOpData::Create());
-        lut->setInputBitDepth(A->getInputBitDepth());
-        lut->setOutputBitDepth(B[B.size()-1]->getOutputBitDepth());
-        lut->luts[0].resize(newLength);
-        lut->luts[1].resize(newLength);
-        lut->luts[2].resize(newLength);
-
-        for(size_t idx=0; idx<newLength; ++idx)
-        {
-            lut->luts[0][idx] = in[4*idx + 0];
-            lut->luts[1][idx] = in[4*idx + 1];
-            lut->luts[2][idx] = in[4*idx + 2];
-        }
-
-        return lut;
-    }
-
-    Lut1DOpDataRcPtr Compose(const Lut1DOpDataRcPtr & A, const OpRcPtr & B, ComposeMethod compFlag)
-    {
-        if (A->getOutputBitDepth() != B->getInputBitDepth())
-        {
-            throw Exception("A bit depth mismatch forbids the composition of LUTs");
-        }
-
-        OpRcPtrVec ops;
-
-        unsigned long min_size = 0;
-        BitDepth resampleDepth = BIT_DEPTH_UINT16;
-        switch (compFlag)
-        {
-            case COMPOSE_RESAMPLE_NO:
-            {
-                min_size = 0;
-                break;
-            }
-            case COMPOSE_RESAMPLE_INDEPTH:
-            {
-                // TODO: Composition of LUTs is a potentially lossy operation.
-                //
-                // We try to be safe by ensuring that the result will be finely
-                // sampled enough to do a look-up for the current input bit-depth,
-                // but it is possible that that bit-depth will need to be reset
-                // later.
-                // In particular, if B is longer than this and the bit-depth is later
-                // reset to be higher, we will have thrown away needed precision.
-                // RESAMPLE_BIG is designed to avoid that problem but it has a
-                // performance cost.
-                resampleDepth = A->getInputBitDepth();
-                min_size = GetLutIdealSize(resampleDepth);
-                break;
-            }
-            case COMPOSE_RESAMPLE_BIG:
-            {
-                resampleDepth = BIT_DEPTH_UINT16;
-                min_size = (unsigned long)GetBitDepthMaxValue(resampleDepth) + 1;
-                break;
-            }
-
-            // TODO: May want to add another style which is the maximum of
-            //       B size (careful of half domain), and in-depth ideal size.
-        }
-
-        const unsigned long Asz = (unsigned long)A->luts[0].size();
-        const bool goodDomain = Asz >= min_size;
-        const bool useOrigDomain = compFlag == COMPOSE_RESAMPLE_NO;
-
-        Lut1DOpDataRcPtr domain;
-
-        if ( goodDomain || useOrigDomain )
-        {
-            // Use the original domain.
-            domain = A;
-        }
-        else
-        {
-            // Create identity with finer domain.
-
-            // TODO: Should not need to create a new LUT object for this.
-            //       Perhaps add a utility function to be shared with the constructor.
-            domain = Lut1DOpData::CreateIdentity(resampleDepth, A->getInputBitDepth());
-
-            // Interpolate through both LUTs in this case (resample).
-            CreateLut1DOp(ops, A, INTERP_LINEAR, TRANSFORM_DIR_FORWARD);
-        }
-
-        ops.push_back(B);
-
-        // Create the result LUT by composing the domain through the desired ops.
-        return Compose(domain, ops);
     }
 
 }
 OCIO_NAMESPACE_EXIT
-
-
-///////////////////////////////////////////////////////////////////////////////
-
-#ifdef OCIO_UNIT_TEST
-
-#include <cstring>
-
-namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
-
-OIIO_ADD_TEST(OpTools, Lut1D_compose)
-{
-    OCIO::Lut1DOpDataRcPtr lut1
-        = OCIO::Lut1DOpData::CreateIdentity(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32);
-
-    lut1->luts[0].resize(8);
-    lut1->luts[1].resize(8);
-    lut1->luts[2].resize(8);
-
-    lut1->luts[0][0] = 0.0f;      lut1->luts[1][0] = 0.0f;      lut1->luts[2][0] = 0.002333f;
-    lut1->luts[0][1] = 0.0f;      lut1->luts[1][1] = 0.291341f; lut1->luts[2][1] = 0.015624f;
-    lut1->luts[0][2] = 0.106521f; lut1->luts[1][2] = 0.334331f; lut1->luts[2][2] = 0.462431f;
-    lut1->luts[0][3] = 0.515851f; lut1->luts[1][3] = 0.474151f; lut1->luts[2][3] = 0.624611f;
-    lut1->luts[0][4] = 0.658791f; lut1->luts[1][4] = 0.527381f; lut1->luts[2][4] = 0.685071f;
-    lut1->luts[0][5] = 0.908501f; lut1->luts[1][5] = 0.707951f; lut1->luts[2][5] = 0.886331f;
-    lut1->luts[0][6] = 0.926671f; lut1->luts[1][6] = 0.846431f; lut1->luts[2][6] = 1.0f;
-    lut1->luts[0][7] = 1.0f;      lut1->luts[1][7] = 1.0f;      lut1->luts[2][7] = 1.0f;
-
-    OCIO::Lut1DOpDataRcPtr lut2
-        = OCIO::Lut1DOpData::CreateIdentity(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32);
-
-    lut2->luts[0].resize(8);
-    lut2->luts[1].resize(8);
-    lut2->luts[2].resize(8);
-
-    lut2->luts[0][0] = 0.0f;        lut2->luts[1][0] = 0.0f;       lut2->luts[2][0] = 0.0023303f;
-    lut2->luts[0][1] = 0.0f;        lut2->luts[1][1] = 0.0029134f; lut2->luts[2][1] = 0.015624f;
-    lut2->luts[0][2] = 0.00010081f; lut2->luts[1][2] = 0.0059806f; lut2->luts[2][2] = 0.023362f;
-    lut2->luts[0][3] = 0.0045628f;  lut2->luts[1][3] = 0.024229f;  lut2->luts[2][3] = 0.05822f;
-    lut2->luts[0][4] = 0.0082598f;  lut2->luts[1][4] = 0.033831f;  lut2->luts[2][4] = 0.074063f;
-    lut2->luts[0][5] = 0.028595f;   lut2->luts[1][5] = 0.075003f;  lut2->luts[2][5] = 0.13552f;
-    lut2->luts[0][6] = 0.69154f;    lut2->luts[1][6] = 0.9213f;    lut2->luts[2][6] = 1.0f;
-    lut2->luts[0][7] = 0.76038f;    lut2->luts[1][7] = 1.0f;       lut2->luts[2][7] = 1.0f;
-
-    OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW( 
-        OCIO::CreateLut1DOp(ops, lut2, OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 1);
-
-    {
-        const OCIO::Lut1DOpDataRcPtr lut = OCIO::Compose(lut1, ops[0], OCIO::COMPOSE_RESAMPLE_NO);
-
-        OIIO_CHECK_EQUAL( lut->luts[0].size(), 8 );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][0], 0.0f,           1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][0], 0.0f,           1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][0], 0.00254739914f, 1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][1], 0.0f,           1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][1], 0.00669934973f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][1], 0.00378420483f, 1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][2], 0.0f,           1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][2], 0.0121908365f,  1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][2], 0.0619750582f,  1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][3], 0.00682150759f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][3], 0.0272925831f,  1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][3], 0.096942015f,   1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][4], 0.0206955168f,  1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][4], 0.0308703855f,  1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][4], 0.12295182f,    1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][5], 0.716288447f,   1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][5], 0.0731772855f,  1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][5], 1.0f,           1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][6], 0.725044191f,   1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][6], 0.857842028f,   1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][6], 1.0f,           1e-6f );
-    }
-
-    {
-        const OCIO::Lut1DOpDataRcPtr lut = Compose(lut1, ops[0], OCIO::COMPOSE_RESAMPLE_INDEPTH);
-
-        OIIO_CHECK_EQUAL( lut->luts[0].size(), 65536 );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][0], 0.0f,           1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][0], 0.0f,           1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][0], 0.00254739914f, 1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][1], 0.0f,            1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][1], 6.34463504e-07f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][1], 0.00254753046f,  1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][2], 0.0f,            1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][2], 1.26915984e-06f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][2], 0.00254766271f,  1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][3], 0.0f,            1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][3], 1.90362334e-06f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][3], 0.00254779495f,  1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][4], 0.0f,            1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][4], 2.53855251e-06f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][4], 0.0025479272f,   1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][5], 0.0f,            1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][5], 3.17324884e-06f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][5], 0.00254805945f,  1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][100], 0.0f,            1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][100], 6.3463347e-05f,  1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][100], 0.00256060902f,  1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][300], 0.0f,            1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][300], 0.000190390972f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][300], 0.00258703064f,  1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][900], 0.0f,            1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][900], 0.000571172219f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][900], 0.00266629551f,  1e-6f );
-    }
-}
-
-OIIO_ADD_TEST(OpTools, Lut1D_compose__with_bit_depth)
-{
-    OCIO::Lut1DOpDataRcPtr lut1 
-        = OCIO::Lut1DOpData::CreateIdentity(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT8);
-    lut1->luts[0].resize(2);
-    lut1->luts[1].resize(2);
-    lut1->luts[2].resize(2);
-
-    lut1->luts[0][0] =  64.0f; lut1->luts[1][0] =  64.0f; lut1->luts[2][0] =  64.0f;
-    lut1->luts[0][1] = 196.0f; lut1->luts[1][1] = 196.0f; lut1->luts[2][1] = 196.0f;
-
-    OCIO::Lut1DOpDataRcPtr lut2
-        = OCIO::Lut1DOpData::CreateIdentity(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_F32);
-    lut2->luts[0].resize(32);
-    lut2->luts[1].resize(32);
-    lut2->luts[2].resize(32);
-
-    lut2->luts[0][ 0] = 0.0f;       lut2->luts[1][ 0] = 0.0f;       lut2->luts[2][ 0] = 0.0023303f;
-    lut2->luts[0][ 1] = 0.0f;       lut2->luts[1][ 1] = 0.00018689f;lut2->luts[2][ 1] = 0.0052544f;
-    lut2->luts[0][ 2] = 0.0f;       lut2->luts[1][ 2] = 0.0010572f; lut2->luts[2][ 2] = 0.0096338f;
-    lut2->luts[0][ 3] = 0.0f;       lut2->luts[1][ 3] = 0.0029134f; lut2->luts[2][ 3] = 0.015624f;
-    lut2->luts[0][ 4] = 0.00010081f;lut2->luts[1][ 4] = 0.0059806f; lut2->luts[2][ 4] = 0.023362f;
-    lut2->luts[0][ 5] = 0.00070343f;lut2->luts[1][ 5] = 0.010448f;  lut2->luts[2][ 5] = 0.032968f;
-    lut2->luts[0][ 6] = 0.002112f;  lut2->luts[1][ 6] = 0.016481f;  lut2->luts[2][ 6] = 0.044554f;
-    lut2->luts[0][ 7] = 0.0045628f; lut2->luts[1][ 7] = 0.024229f;  lut2->luts[2][ 7] = 0.05822f;
-    lut2->luts[0][ 8] = 0.0082598f; lut2->luts[1][ 8] = 0.033831f;  lut2->luts[2][ 8] = 0.074063f;
-    lut2->luts[0][ 9] = 0.013387f;  lut2->luts[1][ 9] = 0.045415f;  lut2->luts[2][ 9] = 0.092171f;
-    lut2->luts[0][10] = 0.020113f;  lut2->luts[1][10] = 0.059101f;  lut2->luts[2][10] = 0.11263f;
-    lut2->luts[0][11] = 0.028595f;  lut2->luts[1][11] = 0.075003f;  lut2->luts[2][11] = 0.13552f;
-    lut2->luts[0][12] = 0.038983f;  lut2->luts[1][12] = 0.093229f;  lut2->luts[2][12] = 0.16091f;
-    lut2->luts[0][13] = 0.051418f;  lut2->luts[1][13] = 0.11388f;   lut2->luts[2][13] = 0.18888f;
-    lut2->luts[0][14] = 0.066034f;  lut2->luts[1][14] = 0.13706f;   lut2->luts[2][14] = 0.2195f;
-    lut2->luts[0][15] = 0.082962f;  lut2->luts[1][15] = 0.16286f;   lut2->luts[2][15] = 0.25283f;
-    lut2->luts[0][16] = 0.10233f;   lut2->luts[1][16] = 0.19138f;   lut2->luts[2][16] = 0.28895f;
-    lut2->luts[0][17] = 0.12425f;   lut2->luts[1][17] = 0.2227f;    lut2->luts[2][17] = 0.3279f;
-    lut2->luts[0][18] = 0.14885f;   lut2->luts[1][18] = 0.25691f;   lut2->luts[2][18] = 0.36976f;
-    lut2->luts[0][19] = 0.17623f;   lut2->luts[1][19] = 0.29409f;   lut2->luts[2][19] = 0.41459f;
-    lut2->luts[0][20] = 0.20652f;   lut2->luts[1][20] = 0.33433f;   lut2->luts[2][20] = 0.46243f;
-    lut2->luts[0][21] = 0.23982f;   lut2->luts[1][21] = 0.3777f;    lut2->luts[2][21] = 0.51334f;
-    lut2->luts[0][22] = 0.27622f;   lut2->luts[1][22] = 0.42428f;   lut2->luts[2][22] = 0.56739f;
-    lut2->luts[0][23] = 0.31585f;   lut2->luts[1][23] = 0.47415f;   lut2->luts[2][23] = 0.62461f;
-    lut2->luts[0][24] = 0.35879f;   lut2->luts[1][24] = 0.52738f;   lut2->luts[2][24] = 0.68507f;
-    lut2->luts[0][25] = 0.40515f;   lut2->luts[1][25] = 0.58404f;   lut2->luts[2][25] = 0.74881f;
-    lut2->luts[0][26] = 0.45502f;   lut2->luts[1][26] = 0.64421f;   lut2->luts[2][26] = 0.81588f;
-    lut2->luts[0][27] = 0.5085f;    lut2->luts[1][27] = 0.70795f;   lut2->luts[2][27] = 0.88633f;
-    lut2->luts[0][28] = 0.56569f;   lut2->luts[1][28] = 0.77534f;   lut2->luts[2][28] = 0.96021f;
-    lut2->luts[0][29] = 0.62667f;   lut2->luts[1][29] = 0.84643f;   lut2->luts[2][29] = 1.0f;
-    lut2->luts[0][30] = 0.69154f;   lut2->luts[1][30] = 0.9213f;    lut2->luts[2][30] = 1.0f;
-    lut2->luts[0][31] = 0.76038f;   lut2->luts[1][31] = 1.0f;       lut2->luts[2][31] = 1.0f;
-
-    OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW( 
-        OCIO::CreateLut1DOp(ops, lut2, OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 1);
-
-    {
-        const OCIO::Lut1DOpDataRcPtr lut = OCIO::Compose(lut1, ops[0], OCIO::COMPOSE_RESAMPLE_NO);
-
-        OIIO_CHECK_EQUAL( lut->luts[0].size(), 2 );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][0], 0.00744791f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][0], 0.03172233f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][0], 0.07058375f, 1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][1], 0.3513808f,  1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][1], 0.51819527f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][1], 0.67463773f, 1e-6f );
-    }
-/*
-    TODO: To uncomment when the Op bit depth will be implemented
-
-    {
-        const OCIO::Lut1DOpDataRcPtr lut = Compose(lut1, ops[0], OCIO::COMPOSE_RESAMPLE_INDEPTH);
-
-        OIIO_CHECK_EQUAL( lut->luts[0].size(), 256 );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][0], 0.00744791f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][0], 0.03172233f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][0], 0.07058375f, 1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][127], 0.0f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][127], 0.0f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][127], 0.0f, 1e-6f );
-
-        OIIO_CHECK_CLOSE( lut->luts[0][255], 0.3513808f,  1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[1][255], 0.51819527f, 1e-6f );
-        OIIO_CHECK_CLOSE( lut->luts[2][255], 0.67463773f, 1e-6f );
-    }
-*/
-}
-
-#endif // OCIO_UNIT_TEST

--- a/src/OpenColorIO/OpTools.h
+++ b/src/OpenColorIO/OpTools.h
@@ -32,25 +32,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <OpenColorIO/OpenColorIO.h>
 
-#include "ops/Lut1D/Lut1DOp.h"
+#include "Op.h"
 
 
 OCIO_NAMESPACE_ENTER
 {
-    // Returns the ideal LUT size based on a specific bit depth
-    unsigned long GetLutIdealSize(BitDepth incomingBitDepth);
 
-    // Control behavior of 1D LUT composition.
-    enum ComposeMethod
-    {
-        COMPOSE_RESAMPLE_NO      = 0, // Preserve original domain
-        COMPOSE_RESAMPLE_INDEPTH = 1, // InDepth controls min size
-        COMPOSE_RESAMPLE_BIG     = 2  // Min size is 65536
-    };
+    void EvalTransform(const float * in, float * out,
+                       long numPixels,
+                       OpRcPtrVec & ops);
 
-    // Use functional composition to generate a single op that 
-    // approximates the effect of the pair of ops.
-    Lut1DOpDataRcPtr Compose(const Lut1DOpDataRcPtr & A, const OpRcPtr & B, ComposeMethod compFlag);
 }
 OCIO_NAMESPACE_EXIT
 

--- a/src/OpenColorIO/fileformats/FileFormat3DL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormat3DL.cpp
@@ -114,15 +114,15 @@ OCIO_NAMESPACE_ENTER
                 has1D(false),
                 has3D(false)
             {
-                lut1D = Lut1DOpData::Create();
+                lut1D = Lut1D::Create();
                 lut3D = Lut3D::Create();
             };
             ~LocalCachedFile() {};
             
             bool has1D;
             bool has3D;
-            Lut1DOpDataRcPtr lut1D;
-            // TODO: use opdata
+            // TODO: Switch to the OpData classes.
+            Lut1DRcPtr lut1D;
             Lut3DRcPtr lut3D;
         };
         
@@ -397,7 +397,7 @@ OCIO_NAMESPACE_ENTER
                 
                 const int FORMAT3DL_SHAPER_CODEVALUE_TOLERANCE = 2;
                 cachedFile->lut1D->maxerror = FORMAT3DL_SHAPER_CODEVALUE_TOLERANCE*scale;
-                cachedFile->lut1D->errortype = Lut1DOpData::ERROR_ABSOLUTE;
+                cachedFile->lut1D->errortype = Lut1D::ERROR_ABSOLUTE;
             }
             
             
@@ -803,7 +803,7 @@ OIIO_ADD_TEST(FileFormat3DL, TestLoad)
 
     OIIO_CHECK_ASSERT(lutFile->has1D);
     OIIO_CHECK_ASSERT(lutFile->has3D);
-    OIIO_CHECK_EQUAL(OCIO::Lut1DOpData::ERROR_ABSOLUTE, lutFile->lut1D->errortype);
+    OIIO_CHECK_EQUAL(OCIO::Lut1D::ERROR_ABSOLUTE, lutFile->lut1D->errortype);
     OIIO_CHECK_EQUAL(0.00195503421f, lutFile->lut1D->maxerror);
     OIIO_CHECK_EQUAL(0.0f, lutFile->lut1D->from_min[1]);
     OIIO_CHECK_EQUAL(1.0f, lutFile->lut1D->from_max[1]);

--- a/src/OpenColorIO/fileformats/FileFormatCSP.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCSP.cpp
@@ -316,8 +316,8 @@ OCIO_NAMESPACE_ENTER
                 csptype("unknown"),
                 metadata("none")
             {
-                prelut = Lut1DOpData::Create();
-                lut1D = Lut1DOpData::Create();
+                prelut = Lut1D::Create();
+                lut1D = Lut1D::Create();
                 lut3D = Lut3D::Create();
             };
             ~CachedFileCSP() {};
@@ -325,9 +325,9 @@ OCIO_NAMESPACE_ENTER
             bool hasprelut;
             std::string csptype;
             std::string metadata;
-            Lut1DOpDataRcPtr prelut;
-            Lut1DOpDataRcPtr lut1D;
-            // TODO: switch to opdata
+            // TODO: Switch to the OpData classes.
+            Lut1DRcPtr prelut;
+            Lut1DRcPtr lut1D;
             Lut3DRcPtr lut3D;
         };
         typedef OCIO_SHARED_PTR<CachedFileCSP> CachedFileCSPRcPtr;
@@ -394,9 +394,9 @@ OCIO_NAMESPACE_ENTER
                 throw Exception ("file stream empty when trying to read csp LUT");
             }
             
-            Lut1DOpDataRcPtr prelut_ptr = Lut1DOpData::Create();
-            Lut1DOpDataRcPtr lut1d_ptr = Lut1DOpData::Create();
-            // TODO: switch to opdata
+            // TODO: Switch to the OpData classes.
+            Lut1DRcPtr prelut_ptr = Lut1D::Create();
+            Lut1DRcPtr lut1d_ptr = Lut1D::Create();
             Lut3DRcPtr lut3d_ptr = Lut3D::Create();
 
             // try and read the LUT header
@@ -628,7 +628,7 @@ OCIO_NAMESPACE_ENTER
                 }
                 
                 prelut_ptr->maxerror = 1e-6f;
-                prelut_ptr->errortype = Lut1DOpData::ERROR_RELATIVE;
+                prelut_ptr->errortype = Lut1D::ERROR_RELATIVE;
                 
                 cachedFile->prelut = prelut_ptr;
             }
@@ -636,7 +636,7 @@ OCIO_NAMESPACE_ENTER
             if(csptype == "1D")
             {
                 lut1d_ptr->maxerror = 0.0f;
-                lut1d_ptr->errortype = Lut1DOpData::ERROR_RELATIVE;
+                lut1d_ptr->errortype = Lut1D::ERROR_RELATIVE;
                 cachedFile->lut1D = lut1d_ptr;
             }
             else if (csptype == "3D")

--- a/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
@@ -629,11 +629,12 @@ OCIO_NAMESPACE_ENTER
         public:
             LocalCachedFile ()
             {
-                lut1D = Lut1DOpData::Create();
+                lut1D = Lut1D::Create();
             };
             ~LocalCachedFile() {};
             
-            Lut1DOpDataRcPtr lut1D;
+            // TODO: Switch to the OpData class.
+            Lut1DRcPtr lut1D;
         };
         
         typedef OCIO_SHARED_PTR<LocalCachedFile> LocalCachedFileRcPtr;
@@ -733,7 +734,7 @@ OCIO_NAMESPACE_ENTER
             // Same as 3dl
             const int FORMAT1DL_SHAPER_CODEVALUE_TOLERANCE = 2;
             cachedFile->lut1D->maxerror = FORMAT1DL_SHAPER_CODEVALUE_TOLERANCE/maxVal[0];
-            cachedFile->lut1D->errortype = Lut1DOpData::ERROR_ABSOLUTE;
+            cachedFile->lut1D->errortype = Lut1D::ERROR_ABSOLUTE;
 
             Lut1dUtils::IMLutFree(&discreetLut1d);
             return cachedFile;
@@ -844,7 +845,7 @@ OIIO_ADD_TEST(FileFormatD1DL, Test)
     OIIO_CHECK_NO_THROW(lutFile = LoadLutFile(discreetLut));
 
     // Current implementation of Discreet 1D LUT is converting table to floats
-    OIIO_CHECK_EQUAL(OCIO::Lut1DOpData::ERROR_ABSOLUTE, lutFile->lut1D->errortype);
+    OIIO_CHECK_EQUAL(OCIO::Lut1D::ERROR_ABSOLUTE, lutFile->lut1D->errortype);
     OIIO_CHECK_EQUAL(0.00784313772f, lutFile->lut1D->maxerror);
 
     for (int c = 0; c < 3; ++c) {
@@ -871,7 +872,7 @@ OIIO_ADD_TEST(FileFormatD1DL, Test)
     OIIO_CHECK_NO_THROW(lutFile = LoadLutFile(discreetLut1216fp));
 
     // Current implementation of Discreet 1D LUT is converting table to floats
-    OIIO_CHECK_EQUAL(OCIO::Lut1DOpData::ERROR_ABSOLUTE, lutFile->lut1D->errortype);
+    OIIO_CHECK_EQUAL(OCIO::Lut1D::ERROR_ABSOLUTE, lutFile->lut1D->errortype);
     OIIO_CHECK_EQUAL(3.05180438e-05f, lutFile->lut1D->maxerror);
 
     for (int c = 0; c < 3; ++c) {

--- a/src/OpenColorIO/fileformats/FileFormatHDL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatHDL.cpp
@@ -252,7 +252,7 @@ OCIO_NAMESPACE_ENTER
                 hdltype = "unknown";
                 hdlblack = 0.0;
                 hdlwhite = 1.0;
-                lut1D = Lut1DOpData::Create();
+                lut1D = Lut1D::Create();
                 lut3D = Lut3D::Create();
             };
             ~CachedFileHDL() {};
@@ -263,8 +263,8 @@ OCIO_NAMESPACE_ENTER
             float to_max; // TODO: maybe add this to Lut1DOp?
             float hdlblack;
             float hdlwhite;
-            Lut1DOpDataRcPtr lut1D;
-            // TODO: opdata
+            // TODO: Switch to the OpData classes.
+            Lut1DRcPtr lut1D;
             Lut3DRcPtr lut3D;
         };
         typedef OCIO_SHARED_PTR<CachedFileHDL> CachedFileHDLRcPtr;
@@ -314,8 +314,8 @@ OCIO_NAMESPACE_ENTER
 
             //
             CachedFileHDLRcPtr cachedFile = CachedFileHDLRcPtr (new CachedFileHDL ());
-            Lut1DOpDataRcPtr lut1d_ptr = Lut1DOpData::Create();
-            // TODO: opdata
+            // TODO: Switch to the OpData classes.
+            Lut1DRcPtr lut1d_ptr = Lut1D::Create();
             Lut3DRcPtr lut3d_ptr = Lut3D::Create();
 
             // Parse headers into key-value pairs
@@ -508,7 +508,7 @@ OCIO_NAMESPACE_ENTER
                 lut1d_ptr->luts[1] = lut_iter->second;
                 lut1d_ptr->luts[2] = lut_iter->second;
                 lut1d_ptr->maxerror = 0.0f;
-                lut1d_ptr->errortype = Lut1DOpData::ERROR_RELATIVE;
+                lut1d_ptr->errortype = Lut1D::ERROR_RELATIVE;
                 cachedFile->lut1D = lut1d_ptr;
             }
 
@@ -571,7 +571,7 @@ OCIO_NAMESPACE_ENTER
                 lut1d_ptr->luts[1] = lut_iter->second;
                 lut1d_ptr->luts[2] = lut_iter->second;
                 lut1d_ptr->maxerror = 0.0f;
-                lut1d_ptr->errortype = Lut1DOpData::ERROR_RELATIVE;
+                lut1d_ptr->errortype = Lut1D::ERROR_RELATIVE;
                 cachedFile->lut1D = lut1d_ptr;
             }
 

--- a/src/OpenColorIO/fileformats/FileFormatICC.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatICC.cpp
@@ -63,8 +63,8 @@ OCIO_NAMESPACE_ENTER
         // Gamma
         float mGammaRGB[4];
 
-        // 1D LUT
-        Lut1DOpDataRcPtr lut;
+        // TODO: Switch to the OpData class.
+        Lut1DRcPtr lut;
     };
 
     typedef OCIO_SHARED_PTR<LocalCachedFile> LocalCachedFileRcPtr;
@@ -350,7 +350,7 @@ OCIO_NAMESPACE_ENTER
                 // normalized by 65535 to interpret them as [0,1].
                 // The LUT will be inverted to convert output-linear values
                 // into values that may be sent to the display.
-                cachedFile->lut = Lut1DOpData::Create();
+                cachedFile->lut = Lut1D::Create();
                 cachedFile->lut->luts[0] = red->GetCurve();
                 cachedFile->lut->luts[1] = green->GetCurve();
                 cachedFile->lut->luts[2] = blue->GetCurve();
@@ -570,7 +570,7 @@ OIIO_ADD_TEST(FileFormatICC, TestFile)
         // Knowing the LUT has 1024 elements
         // and is inverted, verify values for a given index
         // are converted to index * step
-        const float error = 1e-6f;
+        const float error = 1e-5f;
         
         // value at index 200
         tmp[0] = 0.0317235067f;

--- a/src/OpenColorIO/fileformats/FileFormatIridasCube.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasCube.cpp
@@ -97,15 +97,15 @@ OCIO_NAMESPACE_ENTER
                 has1D(false),
                 has3D(false)
             {
-                lut1D = Lut1DOpData::Create();
+                lut1D = Lut1D::Create();
                 lut3D = Lut3D::Create();
             };
             ~LocalCachedFile() {};
             
             bool has1D;
             bool has3D;
-            Lut1DOpDataRcPtr lut1D;
-            // TODO: swotch to opdata
+            // TODO: Switch to the OpData classes.
+            Lut1DRcPtr lut1D;
             Lut3DRcPtr lut3D;
         };
         
@@ -351,7 +351,7 @@ OCIO_NAMESPACE_ENTER
                     // 0.000001 not equal
                     
                     cachedFile->lut1D->maxerror = 1e-5f;
-                    cachedFile->lut1D->errortype = Lut1DOpData::ERROR_RELATIVE;
+                    cachedFile->lut1D->errortype = Lut1D::ERROR_RELATIVE;
                 }
             }
             else if(in3d)

--- a/src/OpenColorIO/fileformats/FileFormatIridasItx.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasItx.cpp
@@ -78,7 +78,7 @@ OCIO_NAMESPACE_ENTER
             };
             ~LocalCachedFile() {};
             
-            // TODO: switch opdata
+            // TODO: Switch to the OpData class.
             Lut3DRcPtr lut3D;
         };
         

--- a/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
@@ -28,11 +28,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cstdio>
 #include <cstring>
-#include <expat/expat.h>
 #include <iterator>
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#include "expat/expat.h"
 #include "ops/Lut1D/Lut1DOp.h"
 #include "ops/Lut3D/Lut3DOp.h"
 #include "ParseUtils.h"
@@ -507,7 +507,7 @@ OCIO_NAMESPACE_ENTER
             };
             ~LocalCachedFile() {};
 
-            // TODO: switch opdata
+            // TODO: Switch to the OpData class.
             Lut3DRcPtr lut3D;
         };
 

--- a/src/OpenColorIO/fileformats/FileFormatPandora.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatPandora.cpp
@@ -51,7 +51,7 @@ OCIO_NAMESPACE_ENTER
             };
             ~LocalCachedFile() {};
             
-            // TODO: switch opdata
+            // TODO: Switch to the OpData class.
             Lut3DRcPtr lut3D;
         };
         

--- a/src/OpenColorIO/fileformats/FileFormatResolveCube.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatResolveCube.cpp
@@ -204,15 +204,15 @@ OCIO_NAMESPACE_ENTER
                 has1D(false),
                 has3D(false)
             {
-                lut1D = Lut1DOpData::Create();
+                lut1D = Lut1D::Create();
                 lut3D = Lut3D::Create();
             };
             ~LocalCachedFile() {};
             
             bool has1D;
             bool has3D;
-            Lut1DOpDataRcPtr lut1D;
-            // TODO: switch opdata
+            // TODO: Switch to the OpData classes.
+            Lut1DRcPtr lut1D;
             Lut3DRcPtr lut3D;
         };
         
@@ -491,7 +491,7 @@ OCIO_NAMESPACE_ENTER
                     // 0.000001 not equal
                     
                     cachedFile->lut1D->maxerror = 1e-5f;
-                    cachedFile->lut1D->errortype = Lut1DOpData::ERROR_RELATIVE;
+                    cachedFile->lut1D->errortype = Lut1D::ERROR_RELATIVE;
                 }
             }
             if(has3d)

--- a/src/OpenColorIO/fileformats/FileFormatSpi1D.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpi1D.cpp
@@ -61,11 +61,12 @@ OCIO_NAMESPACE_ENTER
         public:
             LocalCachedFile()
             {
-                lut = Lut1DOpData::Create();
+                lut = Lut1D::Create();
             };
             ~LocalCachedFile() {};
             
-            Lut1DOpDataRcPtr lut;
+            // TODO: Switch to the OpData class.
+            Lut1DRcPtr lut;
         };
         
         typedef OCIO_SHARED_PTR<LocalCachedFile> LocalCachedFileRcPtr;
@@ -112,7 +113,7 @@ OCIO_NAMESPACE_ENTER
             std::istream & istream,
             const std::string & fileName ) const
         {
-            Lut1DOpDataRcPtr lut1d = Lut1DOpData::Create();
+            Lut1DRcPtr lut1d = Lut1D::Create();
 
             // Parse Header Info
             int lut_size = -1;
@@ -264,7 +265,7 @@ OCIO_NAMESPACE_ENTER
             // 0.0
             // 0.000001 not equal
             lut1d->maxerror = 1e-5f;
-            lut1d->errortype = Lut1DOpData::ERROR_RELATIVE;
+            lut1d->errortype = Lut1D::ERROR_RELATIVE;
 
             LocalCachedFileRcPtr cachedFile = LocalCachedFileRcPtr(new LocalCachedFile());
             cachedFile->lut = lut1d;
@@ -373,7 +374,7 @@ OIIO_ADD_TEST(FileFormatSpi1D, Test)
     OIIO_CHECK_EQUAL(4.511920005404118f, cachedFile->lut->luts[2][1970]);
 
     OIIO_CHECK_EQUAL(1e-5f, cachedFile->lut->maxerror);
-    OIIO_CHECK_EQUAL(OCIO::Lut1DOpData::ERROR_RELATIVE, cachedFile->lut->errortype);
+    OIIO_CHECK_EQUAL(OCIO::Lut1D::ERROR_RELATIVE, cachedFile->lut->errortype);
 }
 
 void ReadSpi1d(const std::string & fileContent)

--- a/src/OpenColorIO/fileformats/FileFormatSpi3D.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpi3D.cpp
@@ -64,7 +64,7 @@ OCIO_NAMESPACE_ENTER
             };
             ~LocalCachedFile() {};
             
-            // TODO: switch opdata
+            // TODO: Switch to the OpData class.
             Lut3DRcPtr lut;
         };
         
@@ -110,7 +110,7 @@ OCIO_NAMESPACE_ENTER
             const int MAX_LINE_SIZE = 4096;
             char lineBuffer[MAX_LINE_SIZE];
 
-            // TODO: switch opdata
+            // TODO: Switch to the OpData class.
             Lut3DRcPtr lut3d = Lut3D::Create();
 
             // Read header information

--- a/src/OpenColorIO/fileformats/FileFormatTruelight.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatTruelight.cpp
@@ -67,15 +67,15 @@ OCIO_NAMESPACE_ENTER
                 has1D(false),
                 has3D(false)
             {
-                lut1D = Lut1DOpData::Create();
+                lut1D = Lut1D::Create();
                 lut3D = Lut3D::Create();
             };
             ~LocalCachedFile() {};
             
             bool has1D;
             bool has3D;
-            Lut1DOpDataRcPtr lut1D;
-            // TODO: switch opdata
+            // TODO: Switch to the OpData class.
+            Lut1DRcPtr lut1D;
             Lut3DRcPtr lut3D;
         };
         
@@ -284,7 +284,7 @@ OCIO_NAMESPACE_ENTER
                 // 0.000001 not equal
                 
                 cachedFile->lut1D->maxerror = 1e-5f;
-                cachedFile->lut1D->errortype = Lut1DOpData::ERROR_RELATIVE;
+                cachedFile->lut1D->errortype = Lut1D::ERROR_RELATIVE;
             }
             
             // Reformat 3D data

--- a/src/OpenColorIO/fileformats/FileFormatVF.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatVF.cpp
@@ -54,7 +54,7 @@ OCIO_NAMESPACE_ENTER
             };
             ~LocalCachedFile() {};
             
-            // TODO: switch opdata
+            // TODO: Switch to the OpData classes.
             Lut3DRcPtr lut3D;
             float m44[16];
             bool useMatrix;

--- a/src/OpenColorIO/fileformats/cdl/CDLParser.cpp
+++ b/src/OpenColorIO/fileformats/cdl/CDLParser.cpp
@@ -26,10 +26,9 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#include <expat/expat.h>
-
 #include <sstream>
 
+#include "expat/expat.h"
 #include "fileformats/cdl/CDLParser.h"
 #include "fileformats/cdl/CDLReaderHelper.h"
 #include "transforms/CDLTransform.h"

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOp.cpp
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOp.cpp
@@ -595,7 +595,7 @@ OCIO_NAMESPACE_ENTER
             ConstLut1DOpRcPtr typedRcPtr = DynamicPtrCast<const Lut1DOp>(op);
             if (typedRcPtr)
             {
-				ConstLut1DOpDataRcPtr lutData = typedRcPtr->lut1DData();
+                ConstLut1DOpDataRcPtr lutData = typedRcPtr->lut1DData();
                 return lut1DData()->isInverse(lutData);
             }
 

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOpCPU.cpp
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOpCPU.cpp
@@ -1,0 +1,1849 @@
+/*
+Copyright (c) 2003-2010 Sony Pictures Imageworks Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <algorithm>
+#include <math.h>
+#include <memory>
+#include <stdint.h>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "BitDepthUtils.h"
+#include "MathUtils.h"
+#include "ops/Lut1D/Lut1DOpCPU.h"
+#include "OpTools.h"
+#include "Platform.h"
+#include "SSE.h"
+
+#define L_ADJUST(val) \
+    ((isOutInteger) ? clamp((val)+0.5f, outMin,  outMax) : SanitizeFloat(val))
+
+OCIO_NAMESPACE_ENTER
+{
+namespace
+{
+inline uint8_t GetLookupValue(const uint8_t& val)
+{
+    return val;
+}
+
+inline uint16_t GetLookupValue(const uint16_t& val)
+{
+    return val;
+}
+
+inline unsigned short GetLookupValue(const half& val)
+{
+    return val.bits();
+}
+
+// When instantiating all templates this case is needed.
+// But it will never be used as the 32f is not a lookup case.
+inline uint16_t GetLookupValue(const float& val)
+{
+    return (uint16_t)val;
+}
+
+template<typename InType, typename OutType>
+struct LookupLut
+{
+    static inline OutType compute(const OutType* lutData,
+                                  const InType& val)
+    {
+        return lutData[GetLookupValue(val)];
+    }
+};
+
+class BaseLut1DRenderer : public OpCPU
+{
+public:
+    BaseLut1DRenderer(ConstLut1DOpDataRcPtr & lut);
+    virtual ~BaseLut1DRenderer();
+
+    virtual void updateData(ConstLut1DOpDataRcPtr & lut) = 0;
+
+    void resetData();
+
+protected:
+    unsigned long m_dim;
+
+    // TODO: Anticipates tmpLut eventually allowing integer data types.
+    std::vector<float> m_tmpLutR;
+    std::vector<float> m_tmpLutG;
+    std::vector<float> m_tmpLutB;
+
+    float m_alphaScaling;
+
+    BitDepth m_outBitDepth;
+
+private:
+    BaseLut1DRenderer() = delete;
+    BaseLut1DRenderer(const BaseLut1DRenderer &) = delete;
+    BaseLut1DRenderer & operator=(const BaseLut1DRenderer &) = delete;
+};
+
+class Lut1DRendererHalfCode : public BaseLut1DRenderer
+{
+public:
+    explicit Lut1DRendererHalfCode(ConstLut1DOpDataRcPtr & lut);
+    virtual ~Lut1DRendererHalfCode();
+
+    // Structure used to keep track of the interpolation data for
+    // special case 16f/64k 1D LUT.
+    struct IndexPair
+    {
+        unsigned short valA;
+        unsigned short valB;
+        float fraction;
+
+    public:
+        IndexPair()
+        {
+            valA = 0;
+            valB = 0;
+            fraction = 0.0f;
+        }
+    };
+
+    void updateData(ConstLut1DOpDataRcPtr & lut) override;
+
+    void apply(float * rgbaBuffer, long numPixels) const override;
+
+protected:
+    // Interpolation helper to gather data.
+    IndexPair getEdgeFloatValues(float fIn) const;
+};
+
+class Lut1DRenderer : public BaseLut1DRenderer
+{
+public:
+
+    Lut1DRenderer(ConstLut1DOpDataRcPtr & lut);
+    virtual ~Lut1DRenderer();
+
+    void updateData(ConstLut1DOpDataRcPtr & lut) override;
+
+    void apply(float * rgbaBuffer, long numPixels) const override;
+
+protected:
+    float m_step;
+    float m_dimMinusOne;
+};
+
+class Lut1DRendererHueAdjust : public Lut1DRenderer
+{
+public:
+    Lut1DRendererHueAdjust(ConstLut1DOpDataRcPtr & lut);
+    virtual ~Lut1DRendererHueAdjust();
+
+    void apply(float * rgbaBuffer, long numPixels) const override;
+};
+
+class Lut1DRendererHalfCodeHueAdjust : public Lut1DRendererHalfCode
+{
+public:
+    Lut1DRendererHalfCodeHueAdjust(ConstLut1DOpDataRcPtr & lut);
+    virtual ~Lut1DRendererHalfCodeHueAdjust();
+
+    void apply(float * rgbaBuffer, long numPixels) const override;
+};
+
+class InvLut1DRenderer : public OpCPU
+{
+public:
+    InvLut1DRenderer(ConstLut1DOpDataRcPtr & lut);
+    virtual ~InvLut1DRenderer();
+
+    void apply(float * rgbaBuffer, long numPixels) const override;
+
+    void resetData();
+
+    virtual void updateData(ConstLut1DOpDataRcPtr & lut);
+
+public:
+    // Holds the parameters of a color component.
+    // Note: The structure does not own any of the pointers.
+    struct ComponentParams
+    {
+        ComponentParams()
+            : lutStart(nullptr), startOffset(0.f), lutEnd(nullptr)
+            , negLutStart(nullptr), negStartOffset(0.f), negLutEnd(nullptr)
+            , flipSign(1.f), bisectPoint(0.f)
+        {}
+
+        const float * lutStart;   // copy of the pointer to start of effective lutData
+        float startOffset;        // difference between real and effective start of lut
+        const float * lutEnd;     // copy of the pointer to end of effective lutData
+        const float * negLutStart;// lutStart for negative part of half domain LUT
+        float negStartOffset;     // startOffset for negative part of half domain LUT
+        const float * negLutEnd;  // lutEnd for negative part of half domain LUT
+        float flipSign;           // flip the sign of value to handle decreasing luts
+        float bisectPoint;        // point of switching from pos to neg of half domain
+    };
+
+    void setComponentParams(ComponentParams & params,
+                            const Lut1DOpData::ComponentProperties & properties,
+                            const float * lutPtr,
+                            const float lutZeroEntry);
+
+protected:
+    float m_scale; // output scaling for the r, g and b components
+
+    ComponentParams m_paramsR;
+    ComponentParams m_paramsG;
+    ComponentParams m_paramsB;
+
+    unsigned long      m_dim;
+    std::vector<float> m_tmpLutR;
+    std::vector<float> m_tmpLutG;
+    std::vector<float> m_tmpLutB;
+    float              m_alphaScaling;  // bit-depth scale factor for alpha channel
+
+private:
+    InvLut1DRenderer() = delete;
+    InvLut1DRenderer(const InvLut1DRenderer&) = delete;
+    InvLut1DRenderer& operator=(const InvLut1DRenderer&) = delete;
+};
+
+class InvLut1DRendererHalfCode : public InvLut1DRenderer
+{
+public:
+    InvLut1DRendererHalfCode(ConstLut1DOpDataRcPtr & lut);
+    virtual ~InvLut1DRendererHalfCode();
+
+    void updateData(ConstLut1DOpDataRcPtr & lut) override;
+
+    void apply(float * rgbaBuffer, long numPixels) const override;
+};
+
+class InvLut1DRendererHueAdjust : public InvLut1DRenderer
+{
+public:
+    InvLut1DRendererHueAdjust(ConstLut1DOpDataRcPtr & lut);
+    virtual ~InvLut1DRendererHueAdjust();
+
+    void apply(float * rgbaBuffer, long numPixels) const override;
+};
+
+class InvLut1DRendererHalfCodeHueAdjust : public InvLut1DRendererHalfCode
+{
+public:
+    InvLut1DRendererHalfCodeHueAdjust(ConstLut1DOpDataRcPtr & lut);
+    virtual ~InvLut1DRendererHalfCodeHueAdjust();
+
+    void apply(float * rgbaBuffer, long numPixels) const override;
+};
+
+BaseLut1DRenderer::BaseLut1DRenderer(ConstLut1DOpDataRcPtr & lut)
+    :   OpCPU()
+    ,   m_dim(lut->getArray().getLength())
+    ,   m_alphaScaling(0.0f)
+    ,   m_outBitDepth(lut->getOutputBitDepth())
+{
+}
+
+void BaseLut1DRenderer::resetData()
+{
+    m_tmpLutR.resize(0);
+    m_tmpLutG.resize(0);
+    m_tmpLutB.resize(0);
+}
+
+BaseLut1DRenderer::~BaseLut1DRenderer()
+{
+    resetData();
+}
+
+Lut1DRendererHalfCode::Lut1DRendererHalfCode(ConstLut1DOpDataRcPtr & lut)
+    :  BaseLut1DRenderer(lut)
+{
+    updateData(lut);
+}
+
+void Lut1DRendererHalfCode::updateData(ConstLut1DOpDataRcPtr & lut)
+{
+    resetData();
+
+    m_dim = lut->getArray().getLength();
+
+    const BitDepth inBD = lut->getInputBitDepth();
+    const BitDepth outBD = lut->getOutputBitDepth();
+
+    const float outMax = GetBitDepthMaxValue(outBD);
+    const float outMin = 0.0f;
+
+    const bool isLookup = inBD != BIT_DEPTH_F32 && inBD != BIT_DEPTH_UINT32;
+
+    const bool isOutInteger = !IsFloatBitDepth(outBD);
+
+    const bool mustResample = !lut->mayLookup(inBD);
+
+    // If we are able to lookup, need to resample the LUT based on inBitDepth.
+    if (isLookup && mustResample)
+    {
+        Lut1DOpDataRcPtr newLut
+            = Lut1DOpData::MakeLookupDomain(inBD);
+
+        // Note: Compose should render at 32f, to avoid infinite recursion.
+        Lut1DOpData::Compose(newLut,
+                             lut,
+                             // Prevent compose from modifying newLut domain.
+                             Lut1DOpData::COMPOSE_RESAMPLE_NO);
+
+        m_dim = newLut->getArray().getLength();
+
+        m_tmpLutR.resize(m_dim);
+        m_tmpLutG.resize(m_dim);
+        m_tmpLutB.resize(m_dim);
+
+        const Array::Values & 
+            lutValues = newLut->getArray().getValues();
+
+        // TODO: Would be faster if R, G, B were adjacent in memory?
+        for(unsigned long i=0; i<m_dim; ++i)
+        {
+            m_tmpLutR[i] = L_ADJUST(lutValues[i*3+0]);
+            m_tmpLutG[i] = L_ADJUST(lutValues[i*3+1]);
+            m_tmpLutB[i] = L_ADJUST(lutValues[i*3+2]);
+        }
+    }
+    else
+    {
+        const Array::Values & 
+            lutValues = lut->getArray().getValues();
+
+        m_tmpLutR.resize(m_dim);
+        m_tmpLutG.resize(m_dim);
+        m_tmpLutB.resize(m_dim);
+
+        for(unsigned long i=0; i<m_dim; ++i)
+        {
+            m_tmpLutR[i] = L_ADJUST(lutValues[i*3+0]);
+            m_tmpLutG[i] = L_ADJUST(lutValues[i*3+1]);
+            m_tmpLutB[i] = L_ADJUST(lutValues[i*3+2]);
+        }
+    }
+
+    m_alphaScaling = GetBitDepthMaxValue(outBD)
+                     / GetBitDepthMaxValue(inBD);
+}
+
+Lut1DRendererHalfCode::~Lut1DRendererHalfCode()
+{
+}
+
+void Lut1DRendererHalfCode::apply(float * rgbaBuffer, long numPixels) const
+{
+    // TODO: Add ability for input or output to be an integer rather than
+    // always float.
+
+    // TODO: To uncomment when apply bit-depth is in.
+    // const bool isLookup = GET_BIT_DEPTH( PF_IN ) != OCIO::BIT_DEPTH_F32;
+    const bool isLookup = false; 
+
+    const float * lutR = m_tmpLutR.data();
+    const float * lutG = m_tmpLutG.data();
+    const float * lutB = m_tmpLutB.data();
+
+    if (isLookup)
+    {
+        float * rgba = rgbaBuffer;
+
+        for(long idx=0; idx<numPixels; ++idx)
+        {
+            rgba[0] = LookupLut<float, float>::compute(lutR, rgba[0]);
+            rgba[1] = LookupLut<float, float>::compute(lutG, rgba[1]);
+            rgba[2] = LookupLut<float, float>::compute(lutB, rgba[2]);
+            rgba[3] = rgba[3] * m_alphaScaling;
+
+            rgba += 4;
+        }
+    }
+    else  // Need to interpolate rather than simply lookup.
+    {
+        float * rgba = rgbaBuffer;
+
+        for(long idx=0; idx<numPixels; ++idx)
+        {
+            IndexPair redInterVals = getEdgeFloatValues(rgba[0]);
+            IndexPair greenInterVals = getEdgeFloatValues(rgba[1]);
+            IndexPair blueInterVals = getEdgeFloatValues(rgba[2]);
+
+            // Since fraction is in the domain [0, 1), interpolate using
+            // 1-fraction in order to avoid cases like -/+Inf * 0.
+            rgba[0] = lerpf(lutR[redInterVals.valB],
+                            lutR[redInterVals.valA],
+                            1.0f-redInterVals.fraction);
+
+            rgba[1] = lerpf(lutG[greenInterVals.valB],
+                            lutG[greenInterVals.valA],
+                            1.0f-greenInterVals.fraction);
+
+            rgba[2] = lerpf(lutB[blueInterVals.valB],
+                            lutB[blueInterVals.valA],
+                            1.0f-blueInterVals.fraction);
+
+            rgba[3] = rgba[3] * m_alphaScaling;
+
+            rgba += 4;
+        }
+    }
+}
+
+Lut1DRendererHalfCode::IndexPair Lut1DRendererHalfCode::getEdgeFloatValues(float fIn) const
+{
+    // TODO: Could we speed this up (perhaps alternate nan/inf behavior)?
+
+    half halfVal;
+    IndexPair idxPair;
+
+    halfVal = half( fIn );
+    if(halfVal.isInfinity())
+    {
+        halfVal = halfVal.isNegative() ? -HALF_MAX : HALF_MAX;
+        fIn = halfVal;
+    }
+
+    // Convert back to float to compare to fIn
+    // and interpolate both values.
+    const float floatTemp = (float) halfVal;
+
+    // Strict comparison required otherwise negative fractions will occur.
+    if (fabs(floatTemp)> fabs(fIn)) 
+    {
+        idxPair.valB = halfVal.bits();
+        idxPair.valA = idxPair.valB;
+        --(idxPair.valA);
+    }
+    else
+    {
+        idxPair.valA = halfVal.bits();
+        idxPair.valB = idxPair.valA;
+        ++(idxPair.valB);
+
+        halfVal.setBits(idxPair.valB);
+        if(halfVal.isInfinity())
+        {
+            halfVal =  halfVal.isNegative () ? -HALF_MAX : HALF_MAX;
+            idxPair.valB = halfVal.bits();
+        }
+    }
+
+    halfVal.setBits(idxPair.valA);
+    const float fA = (float) halfVal;
+
+    halfVal.setBits(idxPair.valB);
+    const float fB = (float) halfVal;
+
+    idxPair.fraction = (fIn - fA) / (fB - fA);
+
+    if (isnan(idxPair.fraction)) idxPair.fraction = 0.0f;
+
+    return idxPair;
+}
+
+Lut1DRenderer::Lut1DRenderer(ConstLut1DOpDataRcPtr & lut)
+    :  BaseLut1DRenderer(lut)
+    ,   m_step(0.0f)
+    ,   m_dimMinusOne(0.0f)
+{
+    updateData(lut);
+}
+
+void Lut1DRenderer::updateData(ConstLut1DOpDataRcPtr & lut)
+{
+    resetData();
+
+    m_dim = lut->getArray().getLength();
+
+    const BitDepth inBD = lut->getInputBitDepth();
+    const BitDepth outBD= lut->getOutputBitDepth();
+
+    const float outMin = 0.0f;
+    const float outMax = GetBitDepthMaxValue(outBD);
+
+    // TODO: To uncomment when apply bit-depth will be in
+    const bool isLookup = false; //GET_BIT_DEPTH( PF_IN ) != BIT_DEPTH_F32;
+
+    const bool isOutInteger = !IsFloatBitDepth(outBD);
+
+    const bool mustResample = !lut->mayLookup(inBD);
+
+    // If we are able to lookup, need to resample the LUT based on inBitDepth.
+    if (isLookup && mustResample)
+    {
+        Lut1DOpDataRcPtr newLut
+            = Lut1DOpData::MakeLookupDomain(lut->getInputBitDepth());
+
+        // Note: Compose should render at 32f, to avoid infinite recursion.
+        Lut1DOpData::Compose(newLut,
+                             lut,
+                             // Prevent compose from modifying newLut domain.
+                             Lut1DOpData::COMPOSE_RESAMPLE_NO);
+
+        m_dim = newLut->getArray().getLength();
+
+        const Array::Values& lutValues = newLut->getArray().getValues();
+
+        m_tmpLutR.resize(m_dim);
+        m_tmpLutG.resize(m_dim);
+        m_tmpLutB.resize(m_dim);
+
+        // TODO: Would be faster if R, G, B were adjacent in memory?
+        for(unsigned long i=0; i<m_dim; ++i)
+        {
+            m_tmpLutR[i] = L_ADJUST(lutValues[i*3+0]);
+            m_tmpLutG[i] = L_ADJUST(lutValues[i*3+1]);
+            m_tmpLutB[i] = L_ADJUST(lutValues[i*3+2]);
+        }
+    }
+    else  // Just copy the array into tmpLut.
+    {
+        m_step = ((float)m_dim - 1.0f)
+                 / GetBitDepthMaxValue(lut->getInputBitDepth());
+
+        const Array::Values & lutValues = lut->getArray().getValues();
+
+        m_tmpLutR.resize(m_dim);
+        m_tmpLutG.resize(m_dim);
+        m_tmpLutB.resize(m_dim);
+
+        // TODO: Would be faster if R, G, B were adjacent in memory?
+        for(unsigned long i=0; i<m_dim; ++i)
+        {
+            // Urgent TODO: The tmpLut must contain unclamped floats.
+            // Clamping/quantizing before interpolation will cause errors.
+            // TODO: We need two tmpLut arrays, a float array that can be
+            // used when we're interpolating and a templated type that
+            // gets used for lookups.
+            m_tmpLutR[i] = L_ADJUST(lutValues[i*3+0]);
+            m_tmpLutG[i] = L_ADJUST(lutValues[i*3+1]);
+            m_tmpLutB[i] = L_ADJUST(lutValues[i*3+2]);
+        }
+    }
+
+    m_alphaScaling = GetBitDepthMaxValue(outBD)
+                        / GetBitDepthMaxValue(inBD);
+
+    m_dimMinusOne = (float)m_dim - 1.0f;
+
+}
+
+Lut1DRenderer::~Lut1DRenderer()
+{
+}
+
+void Lut1DRenderer::apply(float * rgbaBuffer, long numPixels) const
+{
+    const float * lutR = m_tmpLutR.data();
+    const float * lutG = m_tmpLutG.data();
+    const float * lutB = m_tmpLutB.data();
+
+    // TODO: To uncomment when apply bit depth is in.
+    // const bool isLookup = GET_BIT_DEPTH( PF_IN ) != BIT_DEPTH_F32;
+    const bool isLookup = false; 
+
+    // NB: The if/else is expanded at compile time based on the template args.
+    //     (Should be no runtime cost.)
+    if (isLookup)
+    {
+        float * rgba = rgbaBuffer;
+
+        for(long idx=0; idx<numPixels; ++idx)
+        {
+            rgba[0] = LookupLut<float, float>::compute(lutR, rgba[0]);
+            rgba[1] = LookupLut<float, float>::compute(lutG, rgba[1]);
+            rgba[2] = LookupLut<float, float>::compute(lutB, rgba[2]);
+            rgba[3] = rgba[3] * m_alphaScaling;
+
+            rgba += 4;
+        }
+    }
+    else  // Need to interpolate rather than simply lookup.
+    {
+        float * rgba = rgbaBuffer;
+
+        for(long i=0; i<numPixels; ++i)
+        {
+#ifdef USE_SSE
+            __m128 idx
+                = _mm_mul_ps(_mm_set_ps(rgba[3],
+                                        rgba[2],
+                                        rgba[1],
+                                        rgba[0]),
+                             _mm_set_ps(1.0f,
+                                        m_step,
+                                        m_step,
+                                        m_step));
+
+            // _mm_max_ps => NaNs become 0
+            idx = _mm_min_ps(_mm_max_ps(idx, EZERO),
+                             _mm_set1_ps(m_dimMinusOne));
+
+            // zero < std::floor(idx) < maxIdx
+            // SSE => zero < truncate(idx) < maxIdx
+            //
+            __m128 lIdx = _mm_cvtepi32_ps(_mm_cvttps_epi32(idx));
+
+            // zero < std::ceil(idx) < maxIdx
+            // SSE => (lowIdx (already truncated) + 1) < maxIdx
+            // then clamp to prevent hIdx from falling off the end
+            // of the LUT
+            __m128 hIdx = _mm_min_ps(_mm_add_ps(lIdx, EONE),
+                                     _mm_set1_ps(m_dimMinusOne));
+
+            // Computing delta relative to high rather than lowIdx
+            // to save computing (1-delta) below.
+            __m128 d = _mm_sub_ps(hIdx, idx);
+
+            float delta[4];   _mm_storeu_ps(delta, d);
+            float lowIdx[4];  _mm_storeu_ps(lowIdx, lIdx);
+            float highIdx[4]; _mm_storeu_ps(highIdx, hIdx);
+#else
+            float idx[3];
+            idx[0] = m_step * rgba[0];
+            idx[1] = m_step * rgba[1];
+            idx[2] = m_step * rgba[2];
+
+            // NaNs become 0
+            idx[0] = std::min(std::max(0.f, idx[0]), m_dimMinusOne);
+            idx[1] = std::min(std::max(0.f, idx[1]), m_dimMinusOne);
+            idx[2] = std::min(std::max(0.f, idx[2]), m_dimMinusOne);
+
+            unsigned int lowIdx[3];
+            lowIdx[0] = static_cast<unsigned int>(std::floor(idx[0]));
+            lowIdx[1] = static_cast<unsigned int>(std::floor(idx[1]));
+            lowIdx[2] = static_cast<unsigned int>(std::floor(idx[2]));
+
+            // When the idx is exactly equal to an index (e.g. 0,1,2...)
+            // then the computation of highIdx is wrong. However,
+            // the delta is then equal to zero (e.g. lowIdx-idx),
+            // so the highIdx has no impact.
+            unsigned int highIdx[3];
+            highIdx[0] = static_cast<unsigned int>(std::ceil(idx[0]));
+            highIdx[1] = static_cast<unsigned int>(std::ceil(idx[1]));
+            highIdx[2] = static_cast<unsigned int>(std::ceil(idx[2]));
+
+            // Computing delta relative to high rather than lowIdx
+            // to save computing (1-delta) below.
+            float delta[3];
+            delta[0] = (float)highIdx[0] - idx[0];
+            delta[1] = (float)highIdx[1] - idx[1];
+            delta[2] = (float)highIdx[2] - idx[2];
+
+#endif
+            // TODO: If the LUT is a lookup one and the
+            //       the output bit-depth is different from float,
+            //       then this computation implicitely introduces
+            //       several type conversions.
+            //       Could it impact performance ?
+            //       To be investigated...
+
+            // Since fraction is in the domain [0, 1), interpolate using 1-fraction
+            // in order to avoid cases like -/+Inf * 0. Therefore we never multiply by 0 and
+            // thus handle the case where A or B is infinity and return infinity rather than
+            // 0*Infinity (which is NaN).
+            rgba[0] = lerpf(lutR[(unsigned int)highIdx[0]], lutR[(unsigned int)lowIdx[0]], delta[0]);
+            rgba[1] = lerpf(lutG[(unsigned int)highIdx[1]], lutG[(unsigned int)lowIdx[1]], delta[1]);
+            rgba[2] = lerpf(lutB[(unsigned int)highIdx[2]], lutB[(unsigned int)lowIdx[2]], delta[2]);
+            rgba[3] = rgba[3] * m_alphaScaling;
+
+            rgba += 4;
+        }
+    }
+}
+
+namespace GamutMapUtils
+{
+    // Compute the indices for the smallest, middle, and largest elements of
+    // RGB[3]. (Trying to be clever and do this without branching.)
+    inline void Order3(const float* RGB, int& min, int& mid, int& max)
+    {
+        //                                    0  1  2  3  4  5  6  7  8  (typical val - 3)
+        static const int table[] = { 2, 1, 0, 2, 1, 0, 2, 1, 2, 0, 1, 2 };
+
+        int val = (int(RGB[0] > RGB[1]) * 5 + int(RGB[1] > RGB[2]) * 4)
+                  - int(RGB[0] > RGB[2]) * 3 + 3;
+
+        // A NaN in a logical comparison always results in False.
+        // So the case to be careful of here is { A, NaN, B } with A > B.
+        // In that case, the first two compares are false but the third is true
+        // (something that would never happen with regular numbers).
+        // So that is the reason for the +3, to make val 0 in that case.
+
+        max = table[val];
+        mid = table[++val];
+        min = table[++val];
+    }
+};
+
+
+// TODO:  Below largely copy/pasted the regular and halfCode renderers in order
+// to implement the hueAdjust versions quickly and without risk of breaking
+// the original renderers.
+
+Lut1DRendererHalfCodeHueAdjust::Lut1DRendererHalfCodeHueAdjust(ConstLut1DOpDataRcPtr & lut)
+    :  Lut1DRendererHalfCode(lut)
+{
+    // Regardless of the desired out-depth, we need the LUT1D to produce a 32f
+    // result to be used in the hue adjust post-process.
+    m_outBitDepth = BIT_DEPTH_F32;
+
+    updateData(lut);
+}
+
+Lut1DRendererHalfCodeHueAdjust::~Lut1DRendererHalfCodeHueAdjust()
+{
+}
+
+void Lut1DRendererHalfCodeHueAdjust::apply(float * rgbaBuffer, long numPixels) const
+{
+    // TODO: To uncomment when apply bit-depth will be in
+    const bool isLookup = false; //GET_BIT_DEPTH( PF_IN ) != BIT_DEPTH_F32;
+
+    // The LUT entries should always be 32f in this case 
+    // since we need to do additional computations.
+    const float* lutR = m_tmpLutR.data();
+    const float* lutG = m_tmpLutG.data();
+    const float* lutB = m_tmpLutB.data();
+
+    // NB: The if/else is expanded at compile time based on the template args.
+    // (Should be no runtime cost.)
+
+    if (isLookup)
+    {
+        float * rgba = rgbaBuffer;
+
+        for(long idx=0; idx<numPixels; ++idx)
+        {
+            const float RGB[] = {rgba[0], rgba[1], rgba[2]};
+
+            // TODO: Refactor to use SSE2 intrinsic instructions.
+
+            int min, mid, max;
+            GamutMapUtils::Order3( RGB, min, mid, max);
+
+            const float orig_chroma = RGB[max] - RGB[min];
+            const float hue_factor 
+                = orig_chroma == 0.f  ?  0.f 
+                                      :  (RGB[mid] - RGB[min]) / orig_chroma;
+
+            float RGB2[] = {
+                LookupLut<float, float>::compute(lutR, rgba[0]),
+                LookupLut<float, float>::compute(lutG, rgba[1]),
+                LookupLut<float, float>::compute(lutB, rgba[2])   };
+
+            const float new_chroma = RGB2[max] - RGB2[min];
+
+            RGB2[mid] = hue_factor * new_chroma + RGB2[min];
+
+            rgba[0] = RGB2[0];
+            rgba[1] = RGB2[1];
+            rgba[2] = RGB2[2];
+            rgba[3] = rgba[3] * m_alphaScaling;
+
+            rgba += 4;
+        }
+    }
+    else  // Need to interpolate rather than simply lookup.
+    {
+        float * rgba = rgbaBuffer;
+
+        for(long idx=0; idx<numPixels; ++idx)
+        {
+            const float RGB[] = {rgba[0], rgba[1], rgba[2]};
+
+            int min, mid, max;
+            GamutMapUtils::Order3(RGB, min, mid, max);
+            IndexPair redInterVals = getEdgeFloatValues(RGB[0]);
+            IndexPair greenInterVals = getEdgeFloatValues(RGB[1]);
+            IndexPair blueInterVals = getEdgeFloatValues(RGB[2]);
+
+            // Since fraction is in the domain [0, 1), interpolate using
+            // 1-fraction in order to avoid cases like -/+Inf * 0.
+            float RGB2[] = {
+                lerpf(lutR[redInterVals.valB],
+                      lutR[redInterVals.valA],
+                      1.0f-redInterVals.fraction),
+                lerpf(lutG[greenInterVals.valB],
+                      lutG[greenInterVals.valA],
+                      1.0f-greenInterVals.fraction),
+                lerpf(lutB[blueInterVals.valB],
+                      lutB[blueInterVals.valA],
+                      1.0f-blueInterVals.fraction)  };
+
+            // TODO: ease SSE implementation (may be applied to all chans):
+            // RGB2[channel] = (RGB[channel] - RGB(min)) 
+            //                 * new_chroma / orig_chroma + RGB2[min].
+            const float orig_chroma = RGB[max] - RGB[min];
+            const float hue_factor 
+                = orig_chroma == 0.f  ? 0.f
+                                      : (RGB[mid] - RGB[min]) / orig_chroma;
+
+            const float new_chroma = RGB2[max] - RGB2[min];
+            RGB2[mid] = hue_factor * new_chroma + RGB2[min];
+
+            rgba[0] = RGB2[0];
+            rgba[1] = RGB2[1];
+            rgba[2] = RGB2[2];
+            rgba[3] = rgba[3] * m_alphaScaling;
+
+            rgba += 4;
+        }
+    }
+}
+
+Lut1DRendererHueAdjust::Lut1DRendererHueAdjust(ConstLut1DOpDataRcPtr & lut)
+    :  Lut1DRenderer(lut)
+{
+    // Regardless of the desired out-depth, we need the LUT1D to produce a 32f
+    // result to be used in the hue adjust post-process.
+    m_outBitDepth = BIT_DEPTH_F32;
+
+    // Need to recalculate the tmpLUTs at 32f outdepth.
+    updateData(lut);
+}
+
+Lut1DRendererHueAdjust::~Lut1DRendererHueAdjust()
+{
+}
+
+void Lut1DRendererHueAdjust::apply(float * rgbaBuffer, long numPixels) const
+{
+    // TODO: To uncomment when apply bit-depth will be in
+    //const bool isLookup = GET_BIT_DEPTH( PF_IN ) != OCIO::BIT_DEPTH_F32;
+    const bool isLookup = false; 
+
+    // The LUT entries should always be 32f in this case 
+    // since we need to do additional computations.
+    const float * lutR = m_tmpLutR.data();
+    const float * lutG = m_tmpLutG.data();
+    const float * lutB = m_tmpLutB.data();
+
+    // NB: The if/else is expanded at compile time based on the template args.
+    // (Should be no runtime cost.)
+
+    if (isLookup)
+    {
+        float * rgba = rgbaBuffer;
+
+        for(long idx=0; idx<numPixels; ++idx)
+        {
+            const float RGB[] = {rgba[0], rgba[1], rgba[2]};
+
+            int min, mid, max;
+            GamutMapUtils::Order3(RGB, min, mid, max);
+                
+            const float orig_chroma = RGB[max] - RGB[min];
+            const float hue_factor
+                = orig_chroma == 0.f ? 0.f
+                                     : (RGB[mid] - RGB[min]) / orig_chroma;
+
+            float RGB2[] = {
+                LookupLut<float, float>::compute(lutR, rgba[0]),
+                LookupLut<float, float>::compute(lutG, rgba[1]),
+                LookupLut<float, float>::compute(lutB, rgba[2])
+            };
+
+            const float new_chroma = RGB2[max] - RGB2[min];
+
+            RGB2[mid] = hue_factor * new_chroma + RGB2[min];
+
+            rgba[0] = RGB2[0];
+            rgba[1] = RGB2[1];
+            rgba[2] = RGB2[2];
+            rgba[3] = rgba[3] * m_alphaScaling;
+
+            rgba += 4;
+        }
+    }
+    else  // Need to interpolate rather than simply lookup.
+    {
+        float * rgba = rgbaBuffer;
+
+        for(long i=0; i<numPixels; ++i)
+        {
+            const float RGB[] = {rgba[0], rgba[1], rgba[2]};
+
+            int min, mid, max;
+            GamutMapUtils::Order3( RGB, min, mid, max);
+
+            const float orig_chroma = RGB[max] - RGB[min];
+            const float hue_factor 
+                = orig_chroma == 0.f ? 0.f
+                                     : (RGB[mid] - RGB[min]) / orig_chroma;
+
+#ifdef USE_SSE
+            __m128 idx
+                = _mm_mul_ps(_mm_set_ps(rgba[3],
+                                        RGB[2],
+                                        RGB[1],
+                                        RGB[0]),
+                             _mm_set_ps(1.0f,
+                                        m_step,
+                                        m_step,
+                                        m_step));
+
+            // _mm_max_ps => NaNs become 0
+            idx = _mm_min_ps(_mm_max_ps(idx, EZERO),
+                             _mm_set1_ps(m_dimMinusOne));
+
+            // zero < std::floor(idx) < maxIdx
+            // SSE => zero < truncate(idx) < maxIdx
+            // then clamp to prevent hIdx from falling off the end
+            // of the LUT
+            __m128 lIdx = _mm_cvtepi32_ps(_mm_cvttps_epi32(idx));
+
+            // zero < std::ceil(idx) < maxIdx
+            // SSE => (lowIdx (already truncated) + 1) < maxIdx
+            __m128 hIdx = _mm_min_ps(_mm_add_ps(lIdx, EONE),
+                                     _mm_set1_ps(m_dimMinusOne));
+
+            // Computing delta relative to high rather than lowIdx
+            // to save computing (1-delta) below.
+            __m128 d = _mm_sub_ps(hIdx, idx);
+
+            float delta[4];   _mm_storeu_ps(delta, d);
+            float lowIdx[4];  _mm_storeu_ps(lowIdx, lIdx);
+            float highIdx[4]; _mm_storeu_ps(highIdx, hIdx);
+#else
+            float idx[3];
+            idx[0] = m_step * RGB[0];
+            idx[1] = m_step * RGB[1];
+            idx[2] = m_step * RGB[2];
+
+            // NaNs become 0
+            idx[0] = std::min(std::max(0.f, idx[0]), m_dimMinusOne);
+            idx[1] = std::min(std::max(0.f, idx[1]), m_dimMinusOne);
+            idx[2] = std::min(std::max(0.f, idx[2]), m_dimMinusOne);
+
+            unsigned int lowIdx[3];
+            lowIdx[0] = static_cast<unsigned int>(std::floor(idx[0]));
+            lowIdx[1] = static_cast<unsigned int>(std::floor(idx[1]));
+            lowIdx[2] = static_cast<unsigned int>(std::floor(idx[2]));
+
+            // When the idx is exactly equal to an index (e.g. 0,1,2...)
+            // then the computation of highIdx is wrong. However,
+            // the delta is then equal to zero (e.g. lowIdx-idx),
+            // so the highIdx has no impact.
+            unsigned int highIdx[3];
+            highIdx[0] = static_cast<unsigned int>(std::ceil(idx[0]));
+            highIdx[1] = static_cast<unsigned int>(std::ceil(idx[1]));
+            highIdx[2] = static_cast<unsigned int>(std::ceil(idx[2]));
+
+            // Computing delta relative to high rather than lowIdx
+            // to save computing (1-delta) below.
+            float delta[3];
+            delta[0] = (float)highIdx[0] - idx[0];
+            delta[1] = (float)highIdx[1] - idx[1];
+            delta[2] = (float)highIdx[2] - idx[2];
+#endif
+            // TODO: If the LUT is a lookup one and the
+            //       the output bit-depth is different from float,
+            //       then this computation implicitely introduces
+            //       several type conversions.
+            //       Could it impact performance ?
+            //       To be investigated...
+
+            // Since fraction is in the domain [0, 1), interpolate using 1-fraction
+            // in order to avoid cases like -/+Inf * 0. Therefore we never multiply by 0 and
+            // thus handle the case where A or B is infinity and return infinity rather than
+            // 0*Infinity (which is NaN).
+            float RGB2[] = {
+                lerpf(lutR[(unsigned int)highIdx[0]], lutR[(unsigned int)lowIdx[0]], delta[0]),
+                lerpf(lutG[(unsigned int)highIdx[1]], lutG[(unsigned int)lowIdx[1]], delta[1]),
+                lerpf(lutB[(unsigned int)highIdx[2]], lutB[(unsigned int)lowIdx[2]], delta[2])
+            };
+
+            const float new_chroma = RGB2[max] - RGB2[min];
+
+            RGB2[mid] = hue_factor * new_chroma + RGB2[min];
+
+            rgba[0] = RGB2[0];
+            rgba[1] = RGB2[1];
+            rgba[2] = RGB2[2];
+            rgba[3] = rgba[3] * m_alphaScaling;
+
+            rgba += 4;
+        }
+    }
+}
+
+namespace
+{
+// TODO: Use SSE intrinsics to speed this up.
+
+// Calculate the inverse of a value resulting from linear interpolation
+// in a 1d LUT.
+// start:       Pointer to the first effective LUT entry (end of flat spot).
+// startOffset: Distance between first LUT entry and start.
+// end:         Pointer to the last effective LUT entry (start of flat spot).
+// flipSign:    Flips val if we're working with the negative of the orig LUT.
+// scale:       From LUT index units to outDepth units.
+// val:         The value to invert.
+// Return the result that would produce val if used 
+// in a forward linear interpolation in the LUT.
+float FindLutInv(const float * start,
+                 const float   startOffset,
+                 const float * end,
+                 const float   flipSign,
+                 const float   scale,
+                 const float   val)
+{
+    // Note that the LUT data pointed to by start/end must be in increasing order,
+    // regardless of whether the original LUT was increasing or decreasing because
+    // this function uses std::lower_bound().
+
+    // Clamp the value to the range of the LUT.
+    const float cv = std::min( std::max( val * flipSign, *start ), *end );
+
+    // std::lower_bound()
+    // "Returns an iterator pointing to the first element in the range [first,last) 
+    // which does not compare less than val (but could be equal)."
+    // (NB: This is correct using either end or end+1 since lower_bound will return a
+    //  value one greater than the second argument if no values in the array are >= cv.)
+    // http://www.sgi.com/tech/stl/lower_bound.html
+    const float* lowbound = std::lower_bound(start, end, cv);
+
+    // lower_bound() returns first entry >= val so decrement it unless val == *start.
+    if (lowbound > start) {
+        --lowbound;
+    }
+
+    const float* highbound = lowbound;
+    if (highbound < end) {
+        ++highbound;
+    }
+
+    // Delta is the fractional distance of val between the adjacent LUT entries.
+    float delta = 0.f;
+    if (*highbound > *lowbound) {   // (handle flat spots by leaving delta = 0)
+        delta = (cv - *lowbound) / (*highbound - *lowbound);
+    }
+
+    // Inds is the index difference from the effective start to lowbound.
+    const float inds = (float)( lowbound - start );
+
+    // Correct for the fact that start is not the beginning of the LUT if it
+    // starts with a flat spot.
+    // (NB: It may seem like lower_bound would automatically find the end of the
+    //  flat spot, so start could always simply be the start of the LUT, however
+    //  this fails when val equals the flat spot value.)
+    const float totalInds = inds + startOffset;
+
+    // Scale converts from units of [0,dim] to [0,outDepth].
+    return (totalInds + delta) * scale;
+}
+
+// Calculate the inverse of a value resulting from linear interpolation
+// in a half domain 1d LUT.
+// start:       Pointer to the first effective LUT entry (end of flat spot).
+// startOffset: Distance between first LUT entry and start.
+// end:         Pointer to the last effective LUT entry (start of flat spot).
+// flipSign:    Flips val if we're working with the negative of the orig LUT.
+// scale:       From LUT index units to outDepth units.
+// val:         The value to invert.
+// Return the result that would produce val if used in a forward linear
+// interpolation in the LUT.
+float FindLutInvHalf(const float * start,
+                     const float   startOffset,
+                     const float * end,
+                     const float   flipSign,
+                     const float   scale,
+                     const float   val)
+{
+    // Note that the LUT data pointed to by start/end must be in increasing order,
+    // regardless of whether the original LUT was increasing or decreasing because
+    // this function uses std::lower_bound().
+
+    // Clamp the value to the range of the LUT.
+    const float cv = std::min( std::max( val * flipSign, *start ), *end );
+
+    const float* lowbound = std::lower_bound(start, end, cv);
+
+    // lower_bound() returns first entry >= val so decrement it unless val == *start.
+    if (lowbound > start) {
+        --lowbound;
+    }
+
+    const float* highbound = lowbound;
+    if (highbound < end) {
+        ++highbound;
+    }
+
+    // Delta is the fractional distance of val between the adjacent LUT entries.
+    float delta = 0.f;
+    if (*highbound > *lowbound) {   // (handle flat spots by leaving delta = 0)
+        delta = (cv - *lowbound) / (*highbound - *lowbound);
+    }
+
+    // Inds is the index difference from the effective start to lowbound.
+    const float inds = (float)( lowbound - start );
+
+    // Correct for the fact that start is not the beginning of the LUT if it
+    // starts with a flat spot.
+    // (NB: It may seem like lower_bound would automatically find the end of the
+    //  flat spot, so start could always simply be the start of the LUT, however
+    //  this fails when val equals the flat spot value.)
+    const float totalInds = inds + startOffset;
+
+    // For a half domain LUT, the entries are not a constant distance apart,
+    // so convert the indices (which are half floats) into real floats in order
+    // to calculate what distance the delta factor is working over.
+    half h;
+    h.setBits((unsigned short)totalInds);
+    float base = h;
+    h.setBits((unsigned short)(totalInds + 1));
+    float basePlus1 = h;
+    float domain = base + delta * (basePlus1 - base);
+
+    // Scale converts from units of [0,dim] to [0,outDepth].
+    return domain * scale;
+}
+}
+
+InvLut1DRenderer::InvLut1DRenderer(ConstLut1DOpDataRcPtr & lut) 
+    :   OpCPU()
+    ,   m_dim(0)
+    ,   m_alphaScaling(0.0f)
+{
+    updateData(lut);
+}
+
+InvLut1DRenderer::~InvLut1DRenderer()
+{
+    resetData();
+}
+
+void InvLut1DRenderer::setComponentParams(
+    InvLut1DRenderer::ComponentParams & params,
+    const Lut1DOpData::ComponentProperties & properties,
+    const float * lutPtr,
+    const float lutZeroEntry)
+{
+    params.flipSign = properties.isIncreasing ? 1.f: -1.f;
+    params.bisectPoint = lutZeroEntry;
+    params.startOffset = (float) properties.startDomain;
+    params.lutStart = lutPtr + properties.startDomain;
+    params.lutEnd   = lutPtr + properties.endDomain;
+    params.negStartOffset = (float) properties.negStartDomain;
+    params.negLutStart = lutPtr + properties.negStartDomain;
+    params.negLutEnd   = lutPtr + properties.negEndDomain;
+}
+
+void InvLut1DRenderer::resetData()
+{
+    m_tmpLutR.resize(0);
+    m_tmpLutG.resize(0);
+    m_tmpLutB.resize(0);
+}
+
+void InvLut1DRenderer::updateData(ConstLut1DOpDataRcPtr & lut)
+{
+    resetData();
+
+    const bool hasSingleLut = lut->hasSingleLut();
+
+    m_dim = lut->getArray().getLength();
+
+    // Allocated temporary LUT(s)
+
+    m_tmpLutR.resize(m_dim);
+    m_tmpLutG.resize(0);
+    m_tmpLutB.resize(0);
+
+    if( !hasSingleLut )
+    {
+        m_tmpLutG.resize(m_dim);
+        m_tmpLutB.resize(m_dim);
+    }
+
+    // Get component properties and initialize component parameters structure.
+    const Lut1DOpData::ComponentProperties & redProperties = lut->getRedProperties();
+    const Lut1DOpData::ComponentProperties & greenProperties = lut->getGreenProperties();
+    const Lut1DOpData::ComponentProperties & blueProperties = lut->getBlueProperties();
+
+    setComponentParams(m_paramsR, redProperties, m_tmpLutR.data(), 0.f);
+
+    if( hasSingleLut )
+    {
+        // NB: All pointers refer to _tmpLutR.
+        m_paramsB = m_paramsG = m_paramsR;
+    }
+    else
+    {
+        setComponentParams(m_paramsG, greenProperties, m_tmpLutG.data(), 0.f);
+        setComponentParams(m_paramsB, blueProperties, m_tmpLutB.data(), 0.f);
+    }
+
+    // Fill temporary LUT.
+    // Note: Since FindLutInv requires increasing arrays, if the LUT is
+    // decreasing we negate the values to obtain the required sort order
+    // of smallest to largest.
+
+    const Array::Values& lutValues = lut->getArray().getValues();
+    for(unsigned long i = 0; i<m_dim; ++i)
+    {
+        m_tmpLutR[i] = redProperties.isIncreasing ? lutValues[i*3+0]: -lutValues[i*3+0];
+
+        if(!hasSingleLut)
+        {
+            m_tmpLutG[i] = greenProperties.isIncreasing ? lutValues[i*3+1]: -lutValues[i*3+1];
+            m_tmpLutB[i] = blueProperties.isIncreasing ? lutValues[i*3+2]: -lutValues[i*3+2];
+        }
+    }
+
+    const float outMax = GetBitDepthMaxValue(lut->getOutputBitDepth());
+
+    m_alphaScaling = outMax / GetBitDepthMaxValue(lut->getInputBitDepth());
+
+    // Converts from index units to inDepth units of the original LUT.
+    // (Note that inDepth of the original LUT is outDepth of the inverse LUT.)
+    m_scale = outMax / (float) (m_dim - 1);
+}
+
+void InvLut1DRenderer::apply(float * rgbaBuffer, long numPixels) const
+{
+    float * rgba = rgbaBuffer;
+
+    for(long idx=0; idx<numPixels; ++idx)
+    {
+        // red
+        rgba[0] = FindLutInv(m_paramsR.lutStart,
+                             m_paramsR.startOffset,
+                             m_paramsR.lutEnd,
+                             m_paramsR.flipSign,
+                             m_scale,
+                             rgba[0]);
+
+        // green
+        rgba[1] = FindLutInv(m_paramsG.lutStart,
+                             m_paramsG.startOffset,
+                             m_paramsG.lutEnd,
+                             m_paramsG.flipSign,
+                             m_scale,
+                             rgba[1]);
+
+        // blue
+        rgba[2] = FindLutInv(m_paramsB.lutStart,
+                             m_paramsB.startOffset,
+                             m_paramsB.lutEnd,
+                             m_paramsB.flipSign,
+                             m_scale,
+                             rgba[2]);
+
+        // alpha
+        rgba[3] = rgba[3] * m_alphaScaling;
+
+        rgba += 4;
+    }
+}
+
+InvLut1DRendererHueAdjust::InvLut1DRendererHueAdjust(ConstLut1DOpDataRcPtr & lut) 
+    :  InvLut1DRenderer(lut)
+{
+    updateData(lut);
+}
+
+InvLut1DRendererHueAdjust::~InvLut1DRendererHueAdjust()
+{
+}
+
+void InvLut1DRendererHueAdjust::apply(float * rgbaBuffer, long numPixels) const
+{
+    float * rgba = rgbaBuffer;
+
+    for(long idx=0; idx<numPixels; ++idx)
+    {
+        const float RGB[] = {rgba[0], rgba[1], rgba[2]};
+
+        int min, mid, max;
+        GamutMapUtils::Order3(RGB, min, mid, max);
+
+        const float orig_chroma = RGB[max] - RGB[min];
+        const float hue_factor
+            = (orig_chroma == 0.f) ? 0.f
+                                   : (RGB[mid] - RGB[min]) / orig_chroma;
+
+        float RGB2[] = {
+            // red
+            FindLutInv(m_paramsR.lutStart,
+                       m_paramsR.startOffset,
+                       m_paramsR.lutEnd,
+                       m_paramsR.flipSign,
+                       m_scale,
+                       RGB[0]),
+            // green
+            FindLutInv(m_paramsG.lutStart,
+                       m_paramsG.startOffset,
+                       m_paramsG.lutEnd,
+                       m_paramsG.flipSign,
+                       m_scale,
+                       RGB[1]),
+            // blue
+            FindLutInv(m_paramsB.lutStart,
+                       m_paramsB.startOffset,
+                       m_paramsB.lutEnd,
+                       m_paramsB.flipSign,
+                       m_scale,
+                       RGB[2])
+        };
+
+        const float new_chroma = RGB2[max] - RGB2[min];
+
+        RGB2[mid] = hue_factor * new_chroma + RGB2[min];
+
+        rgba[0] = RGB2[0];
+        rgba[1] = RGB2[1];
+        rgba[2] = RGB2[2];
+        rgba[3] = rgba[3] * m_alphaScaling;
+
+        rgba += 4;
+    }
+}
+
+InvLut1DRendererHalfCode::InvLut1DRendererHalfCode(ConstLut1DOpDataRcPtr & lut) 
+    :  InvLut1DRenderer(lut)
+{
+    updateData(lut);
+}
+
+InvLut1DRendererHalfCode::~InvLut1DRendererHalfCode()
+{
+    resetData();
+}
+
+void InvLut1DRendererHalfCode::updateData(ConstLut1DOpDataRcPtr & lut)
+{
+    resetData();
+
+    const bool hasSingleLut = lut->hasSingleLut();
+
+    m_dim = lut->getArray().getLength();
+
+    // Allocated temporary LUT(s)
+
+    m_tmpLutR.resize(m_dim);
+    m_tmpLutG.resize(0);
+    m_tmpLutB.resize(0);
+
+    if( !hasSingleLut )
+    {
+        m_tmpLutG.resize(m_dim);
+        m_tmpLutB.resize(m_dim);
+    }
+
+    // Get component properties and initialize component parameters structure.
+    const Lut1DOpData::ComponentProperties & redProperties = lut->getRedProperties();
+    const Lut1DOpData::ComponentProperties & greenProperties = lut->getGreenProperties();
+    const Lut1DOpData::ComponentProperties & blueProperties = lut->getBlueProperties();
+
+    const Array::Values & lutValues = lut->getArray().getValues();
+
+    setComponentParams(m_paramsR, redProperties, m_tmpLutR.data(), lutValues[0]);
+
+    if( hasSingleLut )
+    {
+        // NB: All pointers refer to m_tmpLutR.
+        m_paramsB = m_paramsG = m_paramsR;
+    }
+    else
+    {
+        setComponentParams(m_paramsG, greenProperties, m_tmpLutG.data(), lutValues[1]);
+        setComponentParams(m_paramsB, blueProperties, m_tmpLutB.data(), lutValues[2]);
+    }
+
+    // Fill temporary LUT.
+    // Note: Since FindLutInv requires increasing arrays, if the LUT is
+    // decreasing we negate the values to obtain the required sort order
+    // of smallest to largest.
+    for(unsigned long i = 0; i < 32768; ++i)     // positive half domain
+    {
+        m_tmpLutR[i] = redProperties.isIncreasing ? lutValues[i*3+0]: -lutValues[i*3+0];
+
+        if( !hasSingleLut )
+        {
+            m_tmpLutG[i] = greenProperties.isIncreasing ? lutValues[i*3+1]: -lutValues[i*3+1];
+            m_tmpLutB[i] = blueProperties.isIncreasing ? lutValues[i*3+2]: -lutValues[i*3+2];
+        }
+    }
+
+    for(unsigned long i = 32768; i < 65536; ++i) // negative half domain
+    {
+        // (Per above, the LUT must be increasing, so negative half domain is sign reversed.)
+        m_tmpLutR[i] = redProperties.isIncreasing ? -lutValues[i*3+0]: lutValues[i*3+0];
+
+        if( !hasSingleLut )
+        {
+            m_tmpLutG[i] = greenProperties.isIncreasing ? -lutValues[i*3+1]: lutValues[i*3+1];
+            m_tmpLutB[i] = blueProperties.isIncreasing ? -lutValues[i*3+2]: lutValues[i*3+2];
+        }
+    }
+
+    const float outMax = GetBitDepthMaxValue(lut->getOutputBitDepth());
+
+    m_alphaScaling = outMax / GetBitDepthMaxValue(lut->getInputBitDepth());
+
+    // Note the difference for half domain LUTs, since the distance between
+    // between adjacent entries is not constant, we cannot roll it into the
+    // scale.
+    m_scale = outMax;
+}
+
+void InvLut1DRendererHalfCode::apply(float * rgbaBuffer, long numPixels) const
+{
+    const bool redIsIncreasing = m_paramsR.flipSign > 0.f;
+    const bool grnIsIncreasing = m_paramsG.flipSign > 0.f;
+    const bool bluIsIncreasing = m_paramsB.flipSign > 0.f;
+
+    float * rgba = rgbaBuffer;
+
+    for(long idx=0; idx<numPixels; ++idx)
+    {
+        // Test the values against the bisectPoint to determine which half of
+        // the float domain to do the inverse eval in.
+
+        // Note that since the clamp of values outside the effective domain
+        // happens in FindLutInvHalf, that input values < the bisectPoint
+        // but > the neg effective domain will get clamped to -0 or wherever
+        // the neg effective domain starts.
+        // If this proves to be a problem, could move the clamp here instead.
+
+        const float redIn = rgba[0];
+        const float redOut 
+            = (redIsIncreasing == (redIn >= m_paramsR.bisectPoint)) 
+                ? FindLutInvHalf(m_paramsR.lutStart,
+                                 m_paramsR.startOffset,
+                                 m_paramsR.lutEnd,
+                                 m_paramsR.flipSign,
+                                 m_scale,
+                                 redIn) 
+                : FindLutInvHalf(m_paramsR.negLutStart,
+                                 m_paramsR.negStartOffset,
+                                 m_paramsR.negLutEnd,
+                                 -m_paramsR.flipSign,
+                                 m_scale,
+                                 redIn);
+
+        const float grnIn = rgba[1];
+        const float grnOut 
+            = (grnIsIncreasing == (grnIn >= m_paramsG.bisectPoint)) 
+                ? FindLutInvHalf(m_paramsG.lutStart,
+                                 m_paramsG.startOffset,
+                                 m_paramsG.lutEnd,
+                                 m_paramsG.flipSign,
+                                 m_scale,
+                                 grnIn) 
+                : FindLutInvHalf(m_paramsG.negLutStart,
+                                 m_paramsG.negStartOffset,
+                                 m_paramsG.negLutEnd,
+                                 -m_paramsG.flipSign,
+                                 m_scale,
+                                 grnIn);
+
+        const float bluIn = rgba[2];
+        const float bluOut 
+            = (bluIsIncreasing == (bluIn >= m_paramsB.bisectPoint)) 
+                ? FindLutInvHalf(m_paramsB.lutStart,
+                                 m_paramsB.startOffset,
+                                 m_paramsB.lutEnd,
+                                 m_paramsB.flipSign,
+                                 m_scale,
+                                 bluIn)
+                : FindLutInvHalf(m_paramsB.negLutStart,
+                                 m_paramsB.negStartOffset,
+                                 m_paramsB.negLutEnd,
+                                 -m_paramsR.flipSign,
+                                 m_scale,
+                                 bluIn);
+
+        rgba[0] = redOut;
+        rgba[1] = grnOut;
+        rgba[2] = bluOut;
+        rgba[3] = rgba[3] * m_alphaScaling;
+
+        rgba += 4;
+    }
+}
+
+InvLut1DRendererHalfCodeHueAdjust::InvLut1DRendererHalfCodeHueAdjust(ConstLut1DOpDataRcPtr & lut) 
+    :  InvLut1DRendererHalfCode(lut)
+{
+    updateData(lut);
+}
+
+InvLut1DRendererHalfCodeHueAdjust::~InvLut1DRendererHalfCodeHueAdjust()
+{
+}
+
+void InvLut1DRendererHalfCodeHueAdjust::apply(float * rgbaBuffer, long numPixels) const
+{
+    const bool redIsIncreasing = m_paramsR.flipSign > 0.f;
+    const bool grnIsIncreasing = m_paramsG.flipSign > 0.f;
+    const bool bluIsIncreasing = m_paramsB.flipSign > 0.f;
+
+    float * rgba = rgbaBuffer;
+
+    for(long idx=0; idx<numPixels; ++idx)
+    {
+        const float RGB[] = {rgba[0], rgba[1], rgba[2]};
+
+        int min, mid, max;
+        GamutMapUtils::Order3( RGB, min, mid, max);
+
+        const float orig_chroma = RGB[max] - RGB[min];
+        const float hue_factor 
+            = orig_chroma == 0.f ? 0.f
+                                 : (RGB[mid] - RGB[min]) / orig_chroma;
+
+        const float redOut 
+            = (redIsIncreasing == (RGB[0] >= m_paramsR.bisectPoint)) 
+                ? FindLutInvHalf(m_paramsR.lutStart,
+                                 m_paramsR.startOffset,
+                                 m_paramsR.lutEnd,
+                                 m_paramsR.flipSign,
+                                 m_scale,
+                                 RGB[0])
+                : FindLutInvHalf(m_paramsR.negLutStart,
+                                 m_paramsR.negStartOffset,
+                                 m_paramsR.negLutEnd,
+                                 -m_paramsR.flipSign,
+                                 m_scale,
+                                 RGB[0]);
+
+        const float grnOut 
+            = (grnIsIncreasing == (RGB[1] >= m_paramsG.bisectPoint)) 
+                ? FindLutInvHalf(m_paramsG.lutStart,
+                                 m_paramsG.startOffset,
+                                 m_paramsG.lutEnd,
+                                 m_paramsG.flipSign,
+                                 m_scale,
+                                 RGB[1]) 
+                : FindLutInvHalf(m_paramsG.negLutStart,
+                                 m_paramsG.negStartOffset,
+                                 m_paramsG.negLutEnd,
+                                 -m_paramsG.flipSign,
+                                 m_scale,
+                                 RGB[1]);
+
+        const float bluOut 
+            = (bluIsIncreasing == (RGB[2] >= m_paramsB.bisectPoint)) 
+                ? FindLutInvHalf(m_paramsB.lutStart,
+                                 m_paramsB.startOffset,
+                                 m_paramsB.lutEnd,
+                                 m_paramsB.flipSign,
+                                 m_scale,
+                                 RGB[2]) 
+                : FindLutInvHalf(m_paramsB.negLutStart,
+                                 m_paramsB.negStartOffset,
+                                 m_paramsB.negLutEnd,
+                                 -m_paramsR.flipSign,
+                                 m_scale,
+                                 RGB[2]);
+
+        float RGB2[] = { redOut, grnOut, bluOut };
+
+        const float new_chroma = RGB2[max] - RGB2[min];
+
+        RGB2[mid] = hue_factor * new_chroma + RGB2[min];
+
+        rgba[0] = RGB2[0];
+        rgba[1] = RGB2[1];
+        rgba[2] = RGB2[2];
+        rgba[3] = rgba[3] * m_alphaScaling;
+
+        rgba += 4;
+    }
+}
+
+OpCPURcPtr GetForwardLut1DRenderer(ConstLut1DOpDataRcPtr & lut)
+{
+    // NB: Unlike bit-depth, the half domain status of a LUT
+    //     may not be changed.
+    if (lut->isInputHalfDomain())
+    {
+        if (lut->getHueAdjust() == Lut1DOpData::HUE_NONE)
+        {
+            return std::make_shared<Lut1DRendererHalfCode>(lut);
+        }
+        else
+        {
+            return std::make_shared<Lut1DRendererHalfCodeHueAdjust>(lut);
+        }
+    }
+    else
+    {
+        if (lut->getHueAdjust() == Lut1DOpData::HUE_NONE)
+        {
+            return std::make_shared<Lut1DRenderer>(lut);
+        }
+        else
+        {
+            return std::make_shared<Lut1DRendererHueAdjust>(lut);
+        }
+    }
+}
+}
+
+OpCPURcPtr GetLut1DRenderer(ConstLut1DOpDataRcPtr & lut)
+{
+    if (lut->getDirection() == TRANSFORM_DIR_FORWARD)
+    {
+        return GetForwardLut1DRenderer(lut);
+    }
+    else
+    {
+        if (lut->getInvStyle() == Lut1DOpData::INV_FAST)
+        {
+            ConstLut1DOpDataRcPtr newLut = Lut1DOpData::MakeFastLut1DFromInverse(lut, false);
+
+            // Render with a Lut1D renderer.
+            return GetForwardLut1DRenderer(newLut);
+        }
+        else  // INV_EXACT
+        {
+            if (lut->isInputHalfDomain())
+            {
+                if (lut->getHueAdjust() == Lut1DOpData::HUE_NONE)
+                {
+                    return std::make_shared<InvLut1DRendererHalfCode>(lut);
+                }
+                else
+                {
+                    return std::make_shared<InvLut1DRendererHalfCodeHueAdjust>(lut);
+                }
+            }
+            else
+            {
+                if (lut->getHueAdjust() == Lut1DOpData::HUE_NONE)
+                {
+                    return std::make_shared<InvLut1DRenderer>(lut);
+                }
+                else
+                {
+                    return std::make_shared<InvLut1DRendererHueAdjust>(lut);
+                }
+            }
+        }
+    }
+}
+
+}
+OCIO_NAMESPACE_EXIT
+
+
+#ifdef OCIO_UNIT_TEST
+
+namespace OCIO = OCIO_NAMESPACE;
+#include "unittest.h"
+
+OIIO_ADD_TEST(GamutMapUtil, order3_test)
+{
+    const float posinf = std::numeric_limits<float>::infinity();
+    const float qnan = std::numeric_limits<float>::quiet_NaN();
+
+    // { A, NaN, B } with A > B test (used to be a crash).
+    {
+        const float RGB[] = { 65504.f, -qnan, 0.f };
+        int min, mid, max;
+        OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
+        OIIO_CHECK_EQUAL(max, 2);
+        OIIO_CHECK_EQUAL(mid, 1);
+        OIIO_CHECK_EQUAL(min, 0);
+    }
+    // Triple NaN test.
+    {
+    const float RGB[] = { qnan, qnan, -qnan };
+    int min, mid, max;
+    OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
+    OIIO_CHECK_EQUAL(max, 2);
+    OIIO_CHECK_EQUAL(mid, 1);
+    OIIO_CHECK_EQUAL(min, 0);
+    }
+    // -Inf test.
+    {
+        const float RGB[] = { 65504.f, -posinf, 0.f };
+        int min, mid, max;
+        OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
+        OIIO_CHECK_EQUAL(max, 0);
+        OIIO_CHECK_EQUAL(mid, 2);
+        OIIO_CHECK_EQUAL(min, 1);
+    }
+    // Inf test.
+    {
+        const float RGB[] = { 0.f, posinf, -65504.f };
+        int min, mid, max;
+        OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
+        OIIO_CHECK_EQUAL(max, 1);
+        OIIO_CHECK_EQUAL(mid, 0);
+        OIIO_CHECK_EQUAL(min, 2);
+    }
+    // Double Inf test.
+    {
+        const float RGB[] = { posinf, posinf, -65504.f };
+        int min, mid, max;
+        OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
+        OIIO_CHECK_EQUAL(max, 1);
+        OIIO_CHECK_EQUAL(mid, 0);
+        OIIO_CHECK_EQUAL(min, 2);
+    }
+
+    // Equal values.
+    {
+        const float RGB[] = { 0.f, 0.f, 0.f };
+        int min, mid, max;
+        OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
+        // In this case we only really care that they are distinct and in [0,2]
+        // so this test could be changed (it is ok, but overly restrictive).
+        OIIO_CHECK_EQUAL(max, 2);
+        OIIO_CHECK_EQUAL(mid, 1);
+        OIIO_CHECK_EQUAL(min, 0);
+    }
+
+    // Now test the six typical possibilities.
+    {
+        const float RGB[] = { 3.f, 2.f, 1.f };
+        int min, mid, max;
+        OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
+        OIIO_CHECK_EQUAL(max, 0);
+        OIIO_CHECK_EQUAL(mid, 1);
+        OIIO_CHECK_EQUAL(min, 2);
+    }
+    {
+        const float RGB[] = { -3.f, -2.f, 1.f };
+        int min, mid, max;
+        OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
+        OIIO_CHECK_EQUAL(max, 2);
+        OIIO_CHECK_EQUAL(mid, 1);
+        OIIO_CHECK_EQUAL(min, 0);
+    }
+    {
+        const float RGB[] = { -3.f, 2.f, 1.f };
+        int min, mid, max;
+        OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
+        OIIO_CHECK_EQUAL(max, 1);
+        OIIO_CHECK_EQUAL(mid, 2);
+        OIIO_CHECK_EQUAL(min, 0);
+    }
+    {
+        const float RGB[] = { -0.3f, 2.f, -1.f };
+        int min, mid, max;
+        OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
+        OIIO_CHECK_EQUAL(max, 1);
+        OIIO_CHECK_EQUAL(mid, 0);
+        OIIO_CHECK_EQUAL(min, 2);
+    }
+    {
+        const float RGB[] = { 3.f, -2.f, 1.f };
+        int min, mid, max;
+        OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
+        OIIO_CHECK_EQUAL(max, 0);
+        OIIO_CHECK_EQUAL(mid, 2);
+        OIIO_CHECK_EQUAL(min, 1);
+    }
+    {
+        const float RGB[] = { 3.f, -2.f, 10.f };
+        int min, mid, max;
+        OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
+        OIIO_CHECK_EQUAL(max, 2);
+        OIIO_CHECK_EQUAL(mid, 0);
+        OIIO_CHECK_EQUAL(min, 1);
+    }
+
+}
+
+OIIO_ADD_TEST(Lut1DRenderer, nan_test)
+{
+    OCIO::Lut1DOpDataRcPtr lut =
+        std::make_shared<OCIO::Lut1DOpData>(OCIO::BIT_DEPTH_F32,
+                                            OCIO::BIT_DEPTH_F32,
+                                            OCIO::Lut1DOpData::LUT_STANDARD);
+
+    lut->getArray().resize(8, 3);
+    float * values = &lut->getArray().getValues()[0];
+
+    values[0]  = 0.0f;      values[1]  = 0.0f;      values[2]  = 0.002333f;
+    values[3]  = 0.0f;      values[4]  = 0.291341f; values[5]  = 0.015624f;
+    values[6]  = 0.106521f; values[7]  = 0.334331f; values[8]  = 0.462431f;
+    values[9]  = 0.515851f; values[10] = 0.474151f; values[11] = 0.624611f;
+    values[12] = 0.658791f; values[13] = 0.527381f; values[14] = 0.685071f;
+    values[15] = 0.908501f; values[16] = 0.707951f; values[17] = 0.886331f;
+    values[18] = 0.926671f; values[19] = 0.846431f; values[20] = 1.0f;
+    values[21] = 1.0f;      values[22] = 1.0f;      values[23] = 1.0f;
+
+    OCIO::ConstLut1DOpDataRcPtr lutConst = lut;
+    OCIO::OpCPURcPtr renderer = OCIO::GetLut1DRenderer(lutConst);
+
+    const float qnan = std::numeric_limits<float>::quiet_NaN();
+    float pixels[16] = { qnan, 0.5f, 0.3f, -0.2f, 
+                         0.5f, qnan, 0.3f, 0.2f, 
+                         0.5f, 0.3f, qnan, 1.2f,
+                         0.5f, 0.3f, 0.2f, qnan };
+
+    renderer->apply(pixels, 4);
+
+    OIIO_CHECK_CLOSE(pixels[0], values[0], 1e-7f);
+    OIIO_CHECK_CLOSE(pixels[5], values[1], 1e-7f);
+    OIIO_CHECK_CLOSE(pixels[10], values[2], 1e-7f);
+    OIIO_CHECK_ASSERT(std::isnan(pixels[15]));
+
+}
+
+OIIO_ADD_TEST(Lut1DRenderer, nan_half_test)
+{
+    OCIO::Lut1DOpDataRcPtr lut = std::make_shared<OCIO::Lut1DOpData>(
+        OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_F32,
+        "", OCIO::OpData::Descriptions(),
+        OCIO::INTERP_LINEAR,
+        OCIO::Lut1DOpData::LUT_INPUT_HALF_CODE);
+
+    float * values = &lut->getArray().getValues()[0];
+
+    // Changed values for nan input.
+    const int nanIdRed = 32256 * 3;
+    values[nanIdRed] = -1.0f;
+    values[nanIdRed + 1] = -2.0f;
+    values[nanIdRed + 2] = -3.0f;
+
+    OCIO::ConstLut1DOpDataRcPtr lutConst = lut;
+    OCIO::OpCPURcPtr renderer = OCIO::GetLut1DRenderer(lutConst);
+
+    const float qnan = std::numeric_limits<float>::quiet_NaN();
+    float pixels[16] = { qnan, 0.5f, 0.3f, -0.2f,
+                         0.5f, qnan, 0.3f, 0.2f,
+                         0.5f, 0.3f, qnan, 1.2f,
+                         0.5f, 0.3f, 0.2f, qnan };
+
+    renderer->apply(pixels, 4);
+
+    OIIO_CHECK_CLOSE(pixels[0], values[nanIdRed], 1e-7f);
+    OIIO_CHECK_CLOSE(pixels[5], values[nanIdRed + 1], 1e-7f);
+    OIIO_CHECK_CLOSE(pixels[10], values[nanIdRed + 2], 1e-7f);
+    OIIO_CHECK_ASSERT(std::isnan(pixels[15]));
+}
+#endif

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOpCPU.cpp
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOpCPU.cpp
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2003-2010 Sony Pictures Imageworks Inc., et al.
+Copyright (c) 2018 Autodesk Inc., et al.
 All Rights Reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOpCPU.h
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOpCPU.h
@@ -1,0 +1,43 @@
+/*
+Copyright (c) 2018 Autodesk Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef INCLUDED_OCIO_LUT1DOPCPU
+#define INCLUDED_OCIO_LUT1DOPCPU
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "ops/Lut1D/Lut1DOpData.h"
+
+OCIO_NAMESPACE_ENTER
+{
+OpCPURcPtr GetLut1DRenderer(ConstLut1DOpDataRcPtr & lut);
+}
+OCIO_NAMESPACE_EXIT
+
+
+#endif

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOpData.cpp
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOpData.cpp
@@ -833,7 +833,7 @@ void ComposeVec(Lut1DOpDataRcPtr & A, const OpRcPtrVec & B)
 //
 // Note1: If either LUT uses hue adjust, composition will not give the same
 // result as if they were applied sequentially.  However, we need to allow
-// composition because the Lut1D CPU renderer needs it to built the lookup
+// composition because the Lut1D CPU renderer needs it to build the lookup
 // table for the hue adjust renderer.  We could potentially do a lock object in
 // that renderer to over-ride the hue adjust temporarily like in invLut1d.
 // But for now, put the burdon on the caller to use Lut1DOpData::mayCompose first.

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOpData.cpp
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOpData.cpp
@@ -1,0 +1,2363 @@
+/*
+Copyright (c) 2018 Autodesk Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <sstream>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "BitDepthUtils.h"
+#include "HashUtils.h"
+#include "MathUtils.h"
+#include "md5/md5.h"
+#include "ops/Lut1D/Lut1DOp.h"
+#include "ops/Lut1D/Lut1DOpData.h"
+#include "ops/Matrix/MatrixOps.h"
+#include "ops/Range/RangeOpData.h"
+#include "OpTools.h"
+
+OCIO_NAMESPACE_ENTER
+{
+// Number of possible values for the Half domain.
+static const unsigned long HALF_DOMAIN_REQUIRED_ENTRIES = 65536;
+
+Lut1DOpData::Lut3by1DArray::Lut3by1DArray(BitDepth inBitDepth,
+                                          BitDepth outBitDepth,
+                                          HalfFlags halfFlags)
+{
+    resize(GetLutIdealSize(inBitDepth, halfFlags), getMaxColorComponents());
+    fill(halfFlags, outBitDepth);
+}
+
+Lut1DOpData::Lut3by1DArray::Lut3by1DArray(BitDepth outBitDepth,
+                                          HalfFlags halfFlags,
+                                          unsigned long length)
+{
+    resize(length, getMaxColorComponents());
+    fill(halfFlags, outBitDepth);
+}
+
+Lut1DOpData::Lut3by1DArray::~Lut3by1DArray()
+{
+}
+
+void Lut1DOpData::Lut3by1DArray::fill(HalfFlags halfFlags,
+                                      BitDepth outBitDepth)
+{
+    const unsigned long dim = getLength();
+    const unsigned long maxChannels = getMaxColorComponents();
+
+    Array::Values& values = getValues();
+    if (Lut1DOpData::IsInputHalfDomain(halfFlags))
+    {
+        const float scaleFactor = GetBitDepthMaxValue(outBitDepth);
+
+        for (unsigned long idx = 0; idx<dim; ++idx)
+        {
+            half htemp; htemp.setBits((unsigned short)idx);
+            const float ftemp = htemp * scaleFactor;
+
+            const unsigned long row = maxChannels * idx;
+            for (unsigned long channel = 0; channel<maxChannels; ++channel)
+            {
+                values[channel + row] = ftemp;
+            }
+        }
+
+    }
+    else
+    {
+        const float stepValue
+            = GetBitDepthMaxValue(outBitDepth) / ((float)dim - 1.0f);
+
+        for (unsigned long idx = 0; idx<dim; ++idx)
+        {
+            const float ftemp = (float)idx * stepValue;
+
+            const unsigned long row = maxChannels * idx;
+            for (unsigned long channel = 0; channel<maxChannels; ++channel)
+            {
+                values[channel + row] = ftemp;
+            }
+        }
+    }
+}
+
+void Lut1DOpData::Lut3by1DArray::scale(float scaleFactor)
+{
+    // Don't scale if scaleFactor = 1.0f.
+    if (scaleFactor != 1.0f)
+    {
+        Array::Values& arrayVals = getValues();
+        const size_t size = arrayVals.size();
+
+        for (size_t i = 0; i < size; i++)
+        {
+            arrayVals[i] *= scaleFactor;
+        }
+    }
+}
+
+bool Lut1DOpData::Lut3by1DArray::isIdentity(HalfFlags halfFlags,
+                                            BitDepth outBitDepth) const
+{
+    // An identity LUT does nothing except possibly bit-depth conversion.
+    //
+    // Note: OCIO v1 had a member variable so that this check would only need
+    // to be calculated once.  However, there were cases where m_isNoOp could
+    // get out of sync with the LUT contents.  It also required an unfinalize
+    // method.  It's not clear that this is a performance bottleneck since for
+    // most LUTs, we'll return false after only a few iterations of the loop.
+    // So for now we've remove the member to store the result of this computation.
+    //
+    const unsigned long dim = getLength();
+    const Array::Values& values = getValues();
+    const unsigned long maxChannels = getMaxColorComponents();
+
+    if (Lut1DOpData::IsInputHalfDomain(halfFlags))
+    {
+        const float scaleFactor = 1.0f / GetBitDepthMaxValue(outBitDepth);
+
+        for (unsigned long idx = 0; idx<dim; ++idx)
+        {
+            half aimHalf;
+            aimHalf.setBits((unsigned short)idx);
+
+            const unsigned long row = maxChannels * idx;
+            for (unsigned long channel = 0; channel<maxChannels; ++channel)
+            {
+                const half valHalf = scaleFactor * values[channel + row];
+                // Must be different by at least two ULPs to not be an identity.
+                if (HalfsDiffer(aimHalf, valHalf, 1))
+                {
+                    return false;
+                }
+            }
+        }
+    }
+    else
+    {
+        //
+        // Note: OCIO v1 allowed the ability to control the tolerance and
+        // set whether it is absolute or relative. There was a TODO that
+        // suggested making it automatic based on the bit-depth, and that
+        // is what's done here.
+        //
+        // Note: LUTs that are approximately identity transforms and
+        // contain a wide range of float values should use the
+        // half-domain representation.  The contents of most LUTs using 
+        // this branch will hence either not be close to an identity anyway
+        // or will be in units that are roughly perceptually uniform and hence
+        // it is more appropriate to use an absolute error based on the
+        // bit-depth rather than a fully relative error that will be both
+        // too sensitive near zero and too loose at the high end.
+        //
+        const float rel_tol = 1e-5f;
+        const float abs_tol = GetBitDepthMaxValue(outBitDepth) * rel_tol;
+        const float stepValue = GetBitDepthMaxValue(outBitDepth)
+                                / ((float)dim - 1.0f);
+
+        for (unsigned long idx = 0; idx<dim; ++idx)
+        {
+            const float aim = (float)idx * stepValue;
+
+            const unsigned long row = maxChannels * idx;
+            for (unsigned long channel = 0; channel<maxChannels; ++channel)
+            {
+                const float err = values[channel + row] - aim;
+
+                if (fabs(err) > abs_tol)
+                {
+                    return false;
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
+unsigned long Lut1DOpData::Lut3by1DArray::getNumValues() const
+{
+    return getLength() * getMaxColorComponents();
+}
+
+Lut1DOpData::Lut1DOpData(unsigned long dimension)
+    : OpData(BIT_DEPTH_F32, BIT_DEPTH_F32)
+    , m_interpolation(INTERP_LINEAR)
+    , m_array(getOutputBitDepth(), LUT_STANDARD, dimension)
+    , m_halfFlags(LUT_STANDARD)
+    , m_hueAdjust(HUE_NONE)
+    , m_direction(TRANSFORM_DIR_FORWARD)
+    , m_invStyle(Lut1DOpData::INV_FAST)
+    , m_fileBitDepth(BIT_DEPTH_UNKNOWN)
+{
+}
+
+Lut1DOpData::Lut1DOpData(BitDepth inBitDepth,
+                         BitDepth outBitDepth,
+                         HalfFlags halfFlags)
+    : OpData(inBitDepth, outBitDepth)
+    , m_interpolation(INTERP_LINEAR)
+    , m_array(getInputBitDepth(), getOutputBitDepth(), halfFlags)
+    , m_halfFlags(halfFlags)
+    , m_hueAdjust(HUE_NONE)
+    , m_direction(TRANSFORM_DIR_FORWARD)
+    , m_invStyle(Lut1DOpData::INV_FAST)
+    , m_fileBitDepth(BIT_DEPTH_UNKNOWN)
+{
+}
+
+Lut1DOpData::Lut1DOpData(BitDepth inBitDepth, BitDepth outBitDepth,
+                         const std::string& id,
+                         const Descriptions& descriptions,
+                         Interpolation interpolation,
+                         HalfFlags halfFlags)
+    : OpData(inBitDepth, outBitDepth, id, descriptions)
+    , m_interpolation(interpolation)
+    , m_array(getInputBitDepth(), getOutputBitDepth(), halfFlags)
+    , m_halfFlags(halfFlags)
+    , m_hueAdjust(HUE_NONE)
+    , m_direction(TRANSFORM_DIR_FORWARD)
+    , m_invStyle(Lut1DOpData::INV_FAST)
+    , m_fileBitDepth(BIT_DEPTH_UNKNOWN)
+{
+}
+
+Lut1DOpData::Lut1DOpData(BitDepth inBitDepth, BitDepth outBitDepth,
+                         const std::string& id,
+                         const Descriptions& descriptions,
+                         Interpolation interpolation,
+                         HalfFlags halfFlags,
+                         unsigned long dimension)
+    : OpData(inBitDepth, outBitDepth, id, descriptions)
+    , m_interpolation(interpolation)
+    , m_array(getInputBitDepth(), halfFlags, dimension)
+    , m_halfFlags(halfFlags)
+    , m_hueAdjust(HUE_NONE)
+    , m_direction(TRANSFORM_DIR_FORWARD)
+    , m_invStyle(Lut1DOpData::INV_FAST)
+    , m_fileBitDepth(BIT_DEPTH_UNKNOWN)
+{
+}
+
+Lut1DOpData::~Lut1DOpData()
+{
+}
+
+Interpolation Lut1DOpData::getConcreteInterpolation() const
+{
+    // TODO: currently INTERP_NEAREST is not implemented Lut1DOpCPU.
+    // This is a regression from OCIO v1.
+    // NB: To have the same interpolation support (i.e. same color processing)
+    // between the CPU & GPU paths, the 'Nearest' interpolation is implemented
+    // using the 'Linear' even if GPU path already support the 'Nearest'
+    // interpolation.
+    // NB: invalid interpolation will make validate() throw.
+    return INTERP_LINEAR;
+}
+
+void Lut1DOpData::setInterpolation(Interpolation algo)
+{
+    m_interpolation = algo;
+}
+
+void Lut1DOpData::setInvStyle(InvStyle style)
+{
+    m_invStyle = style;
+}
+
+bool Lut1DOpData::isIdentity() const
+{
+    return m_array.isIdentity(m_halfFlags, getOutputBitDepth());
+}
+
+bool Lut1DOpData::hasChannelCrosstalk() const
+{
+    if (getHueAdjust() != Lut1DOpData::HUE_NONE)
+    {
+        // Returning !isIdentity() would be time consuming.
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+bool Lut1DOpData::isNoOp() const
+{
+    if (isInputHalfDomain())
+    {
+        return isIdentity();
+    }
+    else
+    {
+        return false;
+    }
+}
+
+OpDataRcPtr Lut1DOpData::getIdentityReplacement() const
+{
+    const BitDepth inBD = getInputBitDepth();
+    const BitDepth outBD = getOutputBitDepth();
+
+    if (isInputHalfDomain())
+    {
+        return std::make_shared<MatrixOpData>(inBD, outBD);
+    }
+    else
+    {
+        return std::make_shared<RangeOpData>(inBD,
+                                             outBD,
+                                             0.,
+                                             GetBitDepthMaxValue(inBD),
+                                             0.,
+                                             GetBitDepthMaxValue(outBD));
+    }
+}
+
+void Lut1DOpData::setOutputBitDepth(BitDepth out)
+{
+    if (m_direction == TRANSFORM_DIR_FORWARD)
+    {
+        // Scale factor is max_new_depth/max_old_depth.
+        const float scaleFactor
+            = GetBitDepthMaxValue(out)
+            / GetBitDepthMaxValue(getOutputBitDepth());
+
+        // Scale array for the new bit-depth if scaleFactor != 1.
+        m_array.scale(scaleFactor);
+    }
+    // Call parent to set the output bit depth.
+    OpData::setOutputBitDepth(out);
+}
+
+void Lut1DOpData::setInputBitDepth(BitDepth in)
+{
+    if (m_direction == TRANSFORM_DIR_INVERSE)
+    {
+        // Recall that our array is for the LUT to be inverted, so this method
+        // is similar to set OUT depth for the original LUT.
+
+        // Scale factor is max_new_depth/max_old_depth.
+        const float scaleFactor
+            = GetBitDepthMaxValue(in)
+            / GetBitDepthMaxValue(getInputBitDepth());
+
+        // Scale array for the new bit-depth if scaleFactor != 1.
+        m_array.scale(scaleFactor);
+    }
+    // Call parent to set the input bit depth.
+    OpData::setInputBitDepth(in);
+}
+
+void Lut1DOpData::setInputHalfDomain(bool isHalfDomain)
+{
+    m_halfFlags = (isHalfDomain) ?
+        ((HalfFlags)(m_halfFlags | LUT_INPUT_HALF_CODE)) :
+        ((HalfFlags)(m_halfFlags & ~LUT_INPUT_HALF_CODE));
+}
+
+void Lut1DOpData::setOutputRawHalfs(bool isRawHalfs)
+{
+    m_halfFlags = (isRawHalfs) ?
+        ((HalfFlags)(m_halfFlags | LUT_OUTPUT_HALF_CODE)) :
+        ((HalfFlags)(m_halfFlags & ~LUT_OUTPUT_HALF_CODE));
+}
+
+namespace
+{
+bool IsValid(const Interpolation & interpolation)
+{
+    switch (interpolation)
+    {
+    case INTERP_BEST:
+    case INTERP_DEFAULT:
+    case INTERP_LINEAR:
+    case INTERP_NEAREST:
+        return true;
+    case INTERP_TETRAHEDRAL:
+    case INTERP_UNKNOWN:
+    default:
+        return false;
+    }
+}
+}
+
+void Lut1DOpData::validate() const
+{
+    OpData::validate();
+
+    if (!IsValid(m_interpolation))
+    {
+        std::ostringstream oss;
+        oss << "1D LUT does not support interpolation algorithm: ";
+        oss << InterpolationToString(getInterpolation());
+        oss << ".";
+        throw Exception(oss.str().c_str());
+    }
+
+    try
+    {
+        getArray().validate();
+    }
+    catch (Exception& e)
+    {
+        std::ostringstream oss;
+        oss << "1D LUT content array issue: ";
+        oss << e.what();
+
+        throw Exception(oss.str().c_str());
+    }
+
+    // If isHalfDomain is set, we need to make sure we have 65536 entries.
+    if (isInputHalfDomain() && getArray().getLength()
+        != HALF_DOMAIN_REQUIRED_ENTRIES)
+    {
+        std::ostringstream oss;
+        oss << "1D LUT: ";
+        oss << getArray().getLength();
+        oss << " entries found, ";
+        oss << HALF_DOMAIN_REQUIRED_ENTRIES;
+        oss << " required for halfDomain 1D LUT.";
+
+        throw Exception(oss.str().c_str());
+    }
+}
+
+unsigned long Lut1DOpData::GetLutIdealSize(BitDepth incomingBitDepth)
+{
+    // Return the number of entries needed in order to do a lookup 
+    // for the specified bit-depth.
+
+    // For 32f, a look-up is impractical so in that case return 64k.
+
+    switch (incomingBitDepth)
+    {
+    case BIT_DEPTH_UINT8:
+    case BIT_DEPTH_UINT10:
+    case BIT_DEPTH_UINT12:
+    case BIT_DEPTH_UINT14:
+    case BIT_DEPTH_UINT16:
+        return (unsigned long)(GetBitDepthMaxValue(incomingBitDepth) + 1);
+
+    case BIT_DEPTH_F16:
+    case BIT_DEPTH_F32:
+        break;
+
+    case BIT_DEPTH_UNKNOWN:
+    case BIT_DEPTH_UINT32:
+    default:
+    {
+        std::string err("Bit-depth is not supported: ");
+        err += BitDepthToString(incomingBitDepth);
+        throw Exception(err.c_str());
+        break;
+    }
+
+    }
+
+    return 65536;
+}
+
+unsigned long Lut1DOpData::GetLutIdealSize(BitDepth inputBitDepth,
+                                           HalfFlags halfFlags)
+{
+    // Returns the number of entries that fill() expects in order to make
+    // an identity LUT.
+
+    // For half domain always return 65536, since that is what fill() expects.
+    // However note that if the inputBitDepth is, e.g. 10i, this might not be
+    // the number of entries required for a look-up.
+
+    unsigned long size = HALF_DOMAIN_REQUIRED_ENTRIES;
+
+    if (Lut1DOpData::IsInputHalfDomain(halfFlags))
+    {
+        return size;
+    }
+
+    return GetLutIdealSize(inputBitDepth);
+}
+
+bool Lut1DOpData::mayLookup(BitDepth incomingDepth) const
+{
+    if (isInputHalfDomain())
+    {
+        return incomingDepth == BIT_DEPTH_F16;
+    }
+    else  // not a half-domain LUT
+    {
+        if (!IsFloatBitDepth(incomingDepth))
+        {
+            return m_array.getLength()
+                == (GetBitDepthMaxValue(incomingDepth) + 1);
+        }
+    }
+    return false;
+}
+
+Lut1DOpDataRcPtr Lut1DOpData::MakeLookupDomain(BitDepth incomingDepth)
+{
+    // For integer in-depths, we need a standard domain.
+    Lut1DOpData::HalfFlags domainType = Lut1DOpData::LUT_STANDARD;
+
+    // For 16f in-depth, we need a half domain.
+    // (Return same for 32f, even though a pure lookup wouldn't be appropriate.)
+    if (IsFloatBitDepth(incomingDepth))
+    {
+        domainType = Lut1DOpData::LUT_INPUT_HALF_CODE;
+    }
+
+    // Note that in this case the domainType is always appropriate for
+    // the incomingDepth, so it should be safe to rely on the constructor
+    // and fill() to always return the correct length.
+    // (E.g., we don't need to worry about 10i with a half domain.)
+    return std::make_shared<Lut1DOpData>(incomingDepth,
+                                         incomingDepth,
+                                         "", Descriptions(),
+                                         INTERP_LINEAR,
+                                         domainType);
+}
+
+bool Lut1DOpData::haveEqualBasics(const Lut1DOpData & B) const
+{
+    // Question:  Should interpolation style be considered?
+    return m_halfFlags == B.m_halfFlags &&
+           m_hueAdjust == B.m_hueAdjust &&
+           m_array == B.m_array;
+}
+
+bool Lut1DOpData::operator==(const OpData & other) const
+{
+    if (this == &other) return true;
+    if (getType() != other.getType()) return false;
+
+    const Lut1DOpData* lop = static_cast<const Lut1DOpData*>(&other);
+
+    if (m_direction != lop->m_direction
+        || m_interpolation != lop->m_interpolation
+        || m_invStyle != lop->m_invStyle)
+    {
+        return false;
+    }
+
+    if (!OpData::operator==(*lop))
+    {
+        return false;
+    }
+
+    return haveEqualBasics(*lop);
+}
+
+void Lut1DOpData::setHueAdjust(Lut1DOpData::HueAdjust algo)
+{
+    m_hueAdjust = algo;
+}
+
+Lut1DOpDataRcPtr Lut1DOpData::clone() const
+{
+    return std::make_shared<Lut1DOpData>(*this);
+}
+
+
+bool Lut1DOpData::IsInverse(const Lut1DOpData * lutfwd,
+                            const Lut1DOpData * lutinv)
+{
+    // Note: The inverse LUT 1D finalize modifies the array to make it
+    // monotonic, hence, this could return false in unexpected cases.
+    // However, one could argue that those LUTs should not be optimized
+    // out as an identity anyway.
+
+    // Need to check bit-depth because the array scaling is relative to it.
+    // (For LUT it is the out-depth, for inverse LUT it is the in-depth.)
+    // Note that we use MaxValue so that 16f and 32f are considered the same.
+    if (GetBitDepthMaxValue(lutfwd->getOutputBitDepth())
+        != GetBitDepthMaxValue(lutinv->getInputBitDepth()))
+    {
+        // Quick fail with array size.
+        if (lutfwd->getArray().getValues().size()
+            != lutinv->getArray().getValues().size())
+        {
+            return false;
+        }
+        // Harmonize array bit-depths to allow a proper array comparison.
+        Lut1DOpDataRcPtr scaledLut = lutfwd->clone();
+        scaledLut->setOutputBitDepth(lutinv->getInputBitDepth());
+
+        // Test the core parts such as array, half domain, and hue adjust while
+        // ignoring superficial differences such as in/out bit-depth.
+        return scaledLut->haveEqualBasics(*lutinv);
+    }
+    else
+    {
+        return lutfwd->haveEqualBasics(*lutinv);
+    }
+}
+
+bool Lut1DOpData::isInverse(ConstLut1DOpDataRcPtr & B) const
+{
+    if (m_direction == TRANSFORM_DIR_FORWARD
+        && B->m_direction == TRANSFORM_DIR_INVERSE)
+    {
+        return IsInverse(this, B.get());
+    }
+    else if (m_direction == TRANSFORM_DIR_INVERSE
+        && B->m_direction == TRANSFORM_DIR_FORWARD)
+    {
+        return IsInverse(B.get(), this);
+    }
+    return false;
+}
+
+bool Lut1DOpData::mayCompose(ConstLut1DOpDataRcPtr & B) const
+{
+    // NB: This does not check bypass or dynamic.
+    return   getHueAdjust() == HUE_NONE  &&
+             B->getHueAdjust() == HUE_NONE;
+}
+
+Lut1DOpDataRcPtr Lut1DOpData::inverse() const
+{
+    Lut1DOpDataRcPtr invLut = clone();
+
+    invLut->m_direction = (m_direction == TRANSFORM_DIR_FORWARD) ?
+        TRANSFORM_DIR_INVERSE : TRANSFORM_DIR_FORWARD;
+
+    // Swap input/output bitdepths.
+    // Note: Call for OpData::set*BitDepth() in order to only swap the
+    // bitdepths without any rescaling.
+    const BitDepth in = getInputBitDepth();
+    invLut->OpData::setInputBitDepth(getOutputBitDepth());
+    invLut->OpData::setOutputBitDepth(in);
+
+    return invLut;
+}
+
+namespace
+{
+const char* GetHueAdjustName(Lut1DOpData::HueAdjust algo)
+{
+    switch (algo)
+    {
+    case Lut1DOpData::HUE_DW3:
+    {
+        return "dw3";
+        break;
+    }
+    case Lut1DOpData::HUE_NONE:
+    {
+        return "none";
+        break;
+    }
+    }
+    throw Exception("1D LUT has an invalid hue adjust style.");
+}
+
+const char* GetInvStyleName(Lut1DOpData::InvStyle invStyle)
+{
+    switch (invStyle)
+    {
+    case Lut1DOpData::INV_EXACT:
+    {
+        return "exact";
+        break;
+    }
+    case Lut1DOpData::INV_FAST:
+    {
+        return "fast";
+        break;
+    }
+    }
+
+    throw Exception("1D LUT has an invalid inverse style.");
+}
+}
+
+void Lut1DOpData::finalize()
+{
+    if (m_direction == TRANSFORM_DIR_INVERSE)
+    {
+        initializeFromForward();
+    }
+
+    AutoMutex lock(m_mutex);
+
+    md5_state_t state;
+    md5_byte_t digest[16];
+
+    md5_init(&state);
+    md5_append(&state,
+        (const md5_byte_t *)&(getArray().getValues()[0]),
+        (int)(getArray().getValues().size() * sizeof(float)));
+    md5_finish(&state, digest);
+
+    std::ostringstream cacheIDStream;
+    cacheIDStream << GetPrintableHash(digest) << " ";
+    cacheIDStream << TransformDirectionToString(m_direction) << " ";
+    cacheIDStream << InterpolationToString(m_interpolation) << " ";
+    cacheIDStream << BitDepthToString(getInputBitDepth()) << " ";
+    cacheIDStream << BitDepthToString(getOutputBitDepth()) << " ";
+    cacheIDStream << isInputHalfDomain()?"half domain ":"standard domain ";
+    cacheIDStream << GetHueAdjustName(m_hueAdjust) << " ";
+    cacheIDStream << GetInvStyleName(m_invStyle);
+
+    m_cacheID = cacheIDStream.str();
+}
+
+namespace
+{
+//-----------------------------------------------------------------------------
+//
+// Functional composition is a concept from mathematics where two functions
+// are combined into a single function.  This idea may be applied to ops
+// where we generate a single op that has the same (or similar) effect as
+// applying the two ops separately.  The motivation is faster processing.
+//
+// When composing LUTs, the algorithm produces a result which takes the
+// domain of the first op into the range of the last op.  So the algorithm
+// needs to render values through the ops.  In some cases the domain of
+// the first op is sufficient, in other cases we need to create a new more
+// finely sampled domain to try and make the result less lossy.
+
+
+//-----------------------------------------------------------------------------
+// Calculate a new LUT by evaluating a new domain (A) through a set of ops (B).
+//
+// Note1: The caller must ensure that B is separable (i.e., it has no channel
+//        crosstalk).
+//
+// Note2: Unlike Compose(Lut1DOpDataRcPtr,Lut1DOpDataRcPtr, ), this function
+//        does not try to resize the first LUT (A), so the caller needs to
+//        create a suitable domain.
+//
+// Note3:  We do not attempt to propagate hueAdjust or bypass states.
+//         These must be taken care of by the caller.
+// 
+// A is used as in/out parameter. As input is it the first LUT in the composition,
+// as output it is the result of the composition.
+void ComposeVec(Lut1DOpDataRcPtr & A, const OpRcPtrVec & B)
+{
+    if (B.size() == 0)
+    {
+        throw Exception("There is nothing to compose the 1D LUT with");
+    }
+
+    if (A->getOutputBitDepth() != B[0]->getInputBitDepth())
+    {
+        throw Exception("A bit-depth mismatch forbids the "
+                        "composition of 1D LUTs");
+    }
+
+    OpRcPtrVec ops;
+
+    // Insert an op to compensate for the bitdepth scaling of A.
+    //
+    // The values in A's array have a certain scaling which needs to be
+    // normalized since ops will have an in-depth of 32f.
+    // Although it may seem like we could use the constructor to create
+    // a bit-depth conversion identity from A's out-depth to 32f,
+    // this doesn't work.  When pM gets appended, the set depth call
+    // would cause the scale factor to disappear.  In this case, the
+    // append set depth and the finalize set depth cancel out and we
+    // are left with our desired scale being applied.
+
+    const float iScale = 1.f / GetBitDepthMaxValue(A->getOutputBitDepth());
+    const float iScale4[4] = { iScale, iScale, iScale, iScale };
+    CreateScaleOp(ops, iScale4, TRANSFORM_DIR_FORWARD);
+
+    // Copy and append B.
+    for(OpRcPtrVec::size_type i=0, size = B.size(); i<size; ++i)
+    {
+        ops.push_back(B[i]);
+    }
+
+    // Insert an op to compensate for the bitdepth scaling of B.
+    //
+    // We render at 32f but need to create an array which may be inserted
+    // into a LUT with B's output depth, so apply the scaling manually.
+    // For the explanation of the bit-depths used, see the comment above.
+
+    const BitDepth outputBD = B[B.size() - 1]->getOutputBitDepth();
+    const float oScale = GetBitDepthMaxValue(outputBD);
+    const float oScale4[4] = { oScale, oScale, oScale, oScale };
+    CreateScaleOp(ops, oScale4, TRANSFORM_DIR_FORWARD);
+
+    // Set up so that the eval directly fills in the array of the result LUT.
+
+    const long numPixels = (long)A->getArray().getLength();
+
+    // TODO: Could keep it one channel in some cases.
+    A->getArray().resize(numPixels, 3);
+    Array::Values& inValues = A->getArray().getValues();
+
+    // Evaluate the transforms at 32f.
+    // Note: If any ops are bypassed, that will be respected here.
+
+    EvalTransform((const float*)(&inValues[0]),
+                  (float*)(&inValues[0]),
+                  numPixels,
+                  ops);
+
+    A->OpData::setOutputBitDepth(outputBD);
+
+}
+}
+
+// Compose two Lut1DOpData.
+//
+// Note1: If either LUT uses hue adjust, composition will not give the same
+// result as if they were applied sequentially.  However, we need to allow
+// composition because the Lut1D CPU renderer needs it to built the lookup
+// table for the hue adjust renderer.  We could potentially do a lock object in
+// that renderer to over-ride the hue adjust temporarily like in invLut1d.
+// But for now, put the burdon on the caller to use Lut1DOpData::mayCompose first.
+//
+// Note2: Likewise ideally we would prohibit composition if hasMatchingBypass
+// is false.  However, since the renderers may need to resample the LUTs,
+// do not want to raise an exception or require the new domain to be dynamic.
+// So again, it is up to the caller verify dynamic and bypass compatibility
+// when calling this function in a more general context.
+void Lut1DOpData::Compose(Lut1DOpDataRcPtr & A,
+                          ConstLut1DOpDataRcPtr & B,
+                          ComposeMethod compFlag)
+{
+    if (A->getOutputBitDepth() != B->getInputBitDepth())
+    {
+        throw Exception("A bit-depth mismatch forbids the composition of 1D LUTs");
+    }
+
+    OpRcPtrVec ops;
+
+    unsigned long min_size = 0;
+    BitDepth resampleDepth = BIT_DEPTH_UINT16;
+    switch (compFlag)
+    {
+    case COMPOSE_RESAMPLE_NO:
+    {
+        min_size = 0;
+        break;
+    }
+    case COMPOSE_RESAMPLE_INDEPTH:
+    {
+        // TODO: Composition of LUTs is a potentially lossy operation.
+        //
+        // We try to be safe by ensuring that the result will be finely
+        // sampled enough to do a look-up for the current input bit-depth,
+        // but it is possible that that bit-depth will need to be reset later.
+        // In particular, if B is longer than this and the bit-depth is later
+        // reset to be higher, we will have thrown away needed precision.
+        // RESAMPLE_BIG is designed to avoid that problem but it has a
+        // performance cost.
+        resampleDepth = A->getInputBitDepth();
+        min_size = GetLutIdealSize(resampleDepth,
+                                   A->getHalfFlags());
+        break;
+    }
+    case COMPOSE_RESAMPLE_BIG:
+    {
+        resampleDepth = BIT_DEPTH_UINT16;
+        min_size = (unsigned long)GetBitDepthMaxValue(resampleDepth) + 1;
+        break;
+    }
+
+    // TODO: May want to add another style which is the maximum of
+    //       B size (careful of half domain), and in-depth ideal size.
+    }
+
+    const unsigned long Asz = A->getArray().getLength();
+    const bool goodDomain = A->isInputHalfDomain() || (Asz >= min_size);
+    const bool useOrigDomain = compFlag == COMPOSE_RESAMPLE_NO;
+
+    if (!goodDomain && !useOrigDomain)
+    {
+        // Interpolate through both LUTs in this case (resample).
+        CreateLut1DOp(ops, A, TRANSFORM_DIR_FORWARD);
+
+        // Create identity with finer domain.
+
+        // TODO: Should not need to create a new LUT object for this.
+        //       Perhaps add a utility function to be shared with the constructor.
+        A = std::make_shared<Lut1DOpData>(resampleDepth,
+                                          A->getInputBitDepth(),
+                                          A->getId(),
+                                          A->getDescriptions(),
+                                          A->getInterpolation(),
+                                          // half case handled above
+                                          Lut1DOpData::LUT_STANDARD);
+
+    }
+
+    Lut1DOpDataRcPtr bCloned = B->clone();
+    CreateLut1DOp(ops, bCloned, TRANSFORM_DIR_FORWARD);
+
+    // TODO:  May want to revisit metadata propagation.
+    OpData::Descriptions newDesc;
+    newDesc += "1D LUT from composition";
+
+    // Create the result LUT by composing the domain through the desired ops.
+    ComposeVec(A, ops);
+
+    // Configure the metadata of the result LUT.
+    A->setId(A->getId() + B->getId());
+    newDesc += A->getDescriptions();
+    newDesc += B->getDescriptions();
+    A->getDescriptions() += newDesc;
+
+    // See note above: Taking these from B since the common use case is for B to be 
+    // the original LUT and A to be a new domain (e.g. used in LUT1D renderers).
+    // TODO: Adjust domain in Lut1D renderer to be one channel.
+    A->setHueAdjust(B->getHueAdjust());
+}
+
+
+// Allow us to temporarily manipulate the style without cloning the object.
+class Lut1DStyleGuard
+{
+public:
+    Lut1DStyleGuard(ConstLut1DOpDataRcPtr & lut)
+        : m_wasFast(lut->getInvStyle() == Lut1DOpData::INV_FAST)
+    {
+        m_lut = std::const_pointer_cast<Lut1DOpData>(lut);
+        m_lut->setInvStyle(Lut1DOpData::INV_EXACT);
+    }
+
+    ~Lut1DStyleGuard()
+    {
+        if (m_wasFast)
+        {
+            m_lut->setInvStyle(Lut1DOpData::INV_FAST);
+        }
+    }
+
+private:
+    Lut1DOpDataRcPtr m_lut;
+    bool             m_wasFast;
+};
+
+
+// The domain to use for the FastLut is a challenging problem since we don't
+// know the input and output color space of the LUT.  In particular, we don't
+// know if a half or normal domain would be better.  For now, we use a
+// heuristic which is based on the original input bit-depth of the inverse LUT
+// (the output bit-depth of the forward LUT).  (We preserve the original depth
+// as a member since typically by the time this routine is called, the depth
+// has been reset to 32f.)  However, there are situations where the origDepth
+// is not reliable (e.g. a user creates a transform in Custom mode and exports it).
+// Ultimately, the goal is to replace this with an automated algorithm that
+// computes the best domain based on analysis of the curvature of the LUT.
+Lut1DOpDataRcPtr Lut1DOpData::MakeFastLut1DFromInverse(ConstLut1DOpDataRcPtr & lut, bool forGPU)
+{
+    if (lut->getDirection() != TRANSFORM_DIR_INVERSE)
+    {
+        throw Exception("MakeFastLut1DFromInverse expects an inverse 1D LUT");
+    }
+
+    if (lut->m_fileBitDepth == BIT_DEPTH_UNKNOWN)
+    {
+        throw Exception("MakeFastLut1DFromInverse expects a defined file bit-depth");
+    }
+    BitDepth depth(lut->m_fileBitDepth);
+
+    // For typical LUTs (e.g. gamma tables from ICC monitor profiles)
+    // we can use a smaller FastLUT on the GPU.
+    // Currently allowing 16f to be subsampled for GPU but using 16i as a way
+    // to indicate not to subsample certain LUTs (e.g. float-conversion LUTs).
+    if (forGPU && depth != BIT_DEPTH_UINT16)
+    {
+        // GPU will always interpolate rather than look-up.
+        // Use a smaller table for better efficiency.
+
+        // TODO: Investigate performance/quality trade-off.
+
+        depth = BIT_DEPTH_UINT12;
+    }
+
+    // But if the LUT has values outside [0,1], use a half-domain fastLUT.
+    if (lut->hasExtendedDomain())
+    {
+        depth = BIT_DEPTH_F16;
+    }
+
+    // Make a domain for the composed 1D LUT.
+    Lut1DOpDataRcPtr newDomainLut = MakeLookupDomain(depth);
+
+    // Regardless of what depth is used to build the domain, set the in & out 
+    // to the actual depth so that scaling is done correctly.
+    newDomainLut->setInputBitDepth(lut->getInputBitDepth());
+    newDomainLut->setOutputBitDepth(lut->getInputBitDepth());
+
+    // Change inv style to INV_EXACT to avoid recursion.
+    Lut1DStyleGuard guard(lut);
+
+    Compose(newDomainLut, lut, COMPOSE_RESAMPLE_NO);
+    return newDomainLut;
+}
+
+void Lut1DOpData::initializeFromForward()
+{
+    // This routine is to be called (e.g. in XML reader) once the base forward
+    // Lut1D has been created and then sets up what is needed for the invLut1D.
+
+    // Note that if the original LUT had a half domain, the invLut needs to as
+    // well so that the appropriate evaluation algorithm is called.
+
+    // NB: The file reader must call setOriginalBitDepth since some methods
+    // need to know the original scaling of the LUT.
+    prepareArray();
+}
+
+bool Lut1DOpData::hasExtendedDomain() const
+{
+    // The forward LUT is allowed to have entries outside the outDepth (e.g. a
+    // 10i LUT is allowed to have values on [-20,1050] if it wants).  This is
+    // called an extended range LUT and helps maximize accuracy by allowing
+    // clamping to happen (if necessary) after the interpolation.
+    // The implication is that the inverse LUT needs to evaluate over an
+    // extended domain.  Since this potentially requires a slower rendering
+    // method for the Fast style, this method allows the renderers to determine
+    // if this is necessary.
+
+    // Note that it is the range (output) of the forward LUT that determines
+    // the need for an extended domain on the inverse LUT.  Whether the forward
+    // LUT has a half domain does not matter.  E.g., a Lustre float-conversion
+    // LUT has a half domain but outputs integers within [0,65535] so the
+    // inverse actually wants a normal 16i domain.
+
+    const unsigned long length = getArray().getLength();
+    const unsigned long maxChannels = getArray().getMaxColorComponents();
+    const unsigned long activeChannels = getArray().getNumColorComponents();
+    const Array::Values& values = getArray().getValues();
+
+    // As noted elsewhere, the InBitDepth describes the scaling of the LUT entries.
+    const float normalMin = 0.0f;
+    const float normalMax = GetBitDepthMaxValue(getInputBitDepth());
+
+    unsigned long minInd = 0;
+    unsigned long maxInd = length - 1;
+    if (isInputHalfDomain())
+    {
+        minInd = 64511u;  // last value before -inf
+        maxInd = 31743u;  // last value before +inf
+    }
+
+    // prepareArray has made the LUT either non-increasing or non-decreasing,
+    // so the min and max values will be either the first or last LUT entries.
+    for (unsigned long c = 0; c < activeChannels; ++c)
+    {
+        if (m_componentProperties[c].isIncreasing)
+        {
+            if (values[minInd * maxChannels + c] < normalMin ||
+                values[maxInd * maxChannels + c] > normalMax)
+            {
+                return true;
+            }
+        }
+        else
+        {
+            if (values[minInd * maxChannels + c] > normalMax ||
+                values[maxInd * maxChannels + c] < normalMin)
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+// NB: The half domain includes pos/neg infinity and NaNs.  
+// The prepareArray makes the LUT monotonic to ensure a unique inverse and
+// determines an effective domain to handle flat spots at the ends nicely.
+// It's not clear how the NaN part of the domain should be included in the
+// monotonicity constraints, furthermore there are 2048 NaNs that could each
+// potentially have different values.  For now, the inversion algorithm and
+// the pre-processing ignore the NaN part of the domain.
+
+void Lut1DOpData::prepareArray()
+{
+    // Note: Data allocated for the array is length*getMaxColorComponents().
+    const unsigned long length = getArray().getLength();
+    const unsigned long maxChannels = getArray().getMaxColorComponents();
+    const unsigned long activeChannels = getArray().getNumColorComponents();
+    Array::Values& values = getArray().getValues();
+
+    for (unsigned c = 0; c < activeChannels; ++c)
+    {
+        // Determine if the LUT is overall increasing or decreasing.
+        // The heuristic used is to compare first and last entries.
+        // (Note flat LUTs (arbitrarily) have isIncreasing == false.)
+        unsigned long lowInd = c;
+        unsigned long highInd = (length - 1) * maxChannels + c;
+        if (isInputHalfDomain())
+        {
+            // For half-domain LUTs, I am concerned that customer LUTs may not
+            // correctly populate the whole domain, so using -HALF_MAX and
+            // +HALF_MAX could potentially give unreliable results.
+            // Just using 0 and 1 for now.
+            lowInd = 0u * maxChannels + c;       // 0.0
+            highInd = 15360u * maxChannels + c;  // 15360 == 1.0
+        }
+
+        {
+            m_componentProperties[c].isIncreasing
+                = (values[lowInd] < values[highInd]);
+        }
+
+        // Flatten reversals.
+        // (If the LUT has a reversal, there is not a unique inverse.
+        // Furthermore we require sorted values for the exact eval algorithm.)
+        {
+            bool isIncreasing = m_componentProperties[c].isIncreasing;
+
+            if (!isInputHalfDomain())
+            {
+                float prevValue = values[c];
+                for (unsigned long idx = c + maxChannels;
+                     idx < length * maxChannels;
+                     idx += maxChannels)
+                {
+                    if (isIncreasing != (values[idx] > prevValue))
+                    {
+                        values[idx] = prevValue;
+                    }
+                    else
+                    {
+                        prevValue = values[idx];
+                    }
+                }
+            }
+            else
+            {
+                // Do positive numbers.
+                unsigned long startInd = 0u * maxChannels + c; // 0 == +zero
+                unsigned long endInd = 31744u * maxChannels;   // 31744 == +infinity
+                float prevValue = values[startInd];
+                for (unsigned long idx = startInd + maxChannels;
+                     idx <= endInd;
+                     idx += maxChannels)
+                {
+                    if (isIncreasing != (values[idx] > prevValue))
+                    {
+                        values[idx] = prevValue;
+                    }
+                    else
+                    {
+                        prevValue = values[idx];
+                    }
+                }
+
+                // Do negative numbers.
+                isIncreasing = !isIncreasing;
+                startInd = 32768u * maxChannels + c;      // 32768 == -zero
+                endInd = 64512u * maxChannels;            // 64512 == -infinity
+                prevValue = values[c];  // prev value for -0 is +0 (disallow overlaps)
+                for (unsigned long idx = startInd; idx <= endInd; idx += maxChannels)
+                {
+                    if (isIncreasing != (values[idx] > prevValue))
+                    {
+                        values[idx] = prevValue;
+                    }
+                    else
+                    {
+                        prevValue = values[idx];
+                    }
+                }
+            }
+        }
+
+        // Determine effective domain from the starting/ending flat spots.
+        // (If the LUT begins or ends with a flat spot, the inverse should be
+        // the value nearest the center of the LUT.)
+        // For constant LUTs, the end domain == start domain == 0.
+        {
+            if (!isInputHalfDomain())
+            {
+                unsigned long endDomain = length - 1;
+                const float endValue = values[endDomain * maxChannels + c];
+                while (endDomain > 0
+                    && values[(endDomain - 1) * maxChannels + c] == endValue)
+                {
+                    --endDomain;
+                }
+
+                unsigned long startDomain = 0;
+                const float startValue = values[startDomain * maxChannels + c];
+                // Note that this works for both increasing and decreasing LUTs
+                // since there is no reqmt that startValue < endValue.
+                while (startDomain < endDomain
+                    &&  values[(startDomain + 1) * maxChannels + c] == startValue)
+                {
+                    ++startDomain;
+                }
+
+                m_componentProperties[c].startDomain = startDomain;
+                m_componentProperties[c].endDomain = endDomain;
+            }
+            else
+            {
+                // Question: Should the value for infinity be considered for
+                // interpolation? The advantage is that in theory, if infinity
+                // is mapped to some value by the forward LUT, you could
+                // restore that value to infinity in the inverse.
+                // This does seem to work in INV_EXACT mode (e.g.
+                // CPURendererInvLUT1DHalf_fclut unit test).
+                // TODO: Test to be ported CPURenderer_cases.cpp_inc
+                // The problem is that in INV_FAST mode, there are Infs in the fast
+                // LUT and these seem to make the value for both inf and 65504
+                // a NaN. Limiting the effective domain allows 65504 to invert
+                // correctly.
+                unsigned long endDomain = 31743u;    // +65504 = largest half value < inf
+                const float endValue = values[endDomain * maxChannels + c];
+                while (endDomain > 0
+                    && values[(endDomain - 1) * maxChannels + c] == endValue)
+                {
+                    --endDomain;
+                }
+
+                unsigned long startDomain = 0;       // positive zero
+                const float startValue = values[startDomain * maxChannels + c];
+                // Note that this works for both increasing and decreasing LUTs
+                // since there is no reqmt that startValue < endValue.
+                while (startDomain < endDomain
+                    &&  values[(startDomain + 1) * maxChannels + c] == startValue)
+                {
+                    ++startDomain;
+                }
+
+                m_componentProperties[c].startDomain = startDomain;
+                m_componentProperties[c].endDomain = endDomain;
+
+                // Negative half of domain has its own start/end.
+                unsigned long negEndDomain = 64511u;  // -65504 = last value before neg inf
+                const float negEndValue = values[negEndDomain * maxChannels + c];
+                while (negEndDomain > 32768u     // negative zero
+                    && values[(negEndDomain - 1) * maxChannels + c] == negEndValue)
+                {
+                    --negEndDomain;
+                }
+
+                unsigned long negStartDomain = 32768u; // negative zero
+                const float negStartValue = values[negStartDomain * maxChannels + c];
+                while (negStartDomain < negEndDomain
+                    && values[(negStartDomain + 1) * maxChannels + c] == negStartValue)
+                {
+                    ++negStartDomain;
+                }
+
+                m_componentProperties[c].negStartDomain = negStartDomain;
+                m_componentProperties[c].negEndDomain = negEndDomain;
+            }
+        }
+    }
+
+    if (activeChannels == 1)
+    {
+        m_componentProperties[2] = m_componentProperties[1] = m_componentProperties[0];
+    }
+}
+
+
+
+}
+OCIO_NAMESPACE_EXIT
+
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef OCIO_UNIT_TEST
+
+namespace OCIO = OCIO_NAMESPACE;
+#include "unittest.h"
+
+
+OIIO_ADD_TEST(Lut1DOpData, get_lut_ideal_size)
+{
+    OIIO_CHECK_EQUAL(OCIO::Lut1DOpData::GetLutIdealSize(OCIO::BIT_DEPTH_UINT8), 256);
+    OIIO_CHECK_EQUAL(OCIO::Lut1DOpData::GetLutIdealSize(OCIO::BIT_DEPTH_UINT16), 65536);
+
+    OIIO_CHECK_EQUAL(OCIO::Lut1DOpData::GetLutIdealSize(OCIO::BIT_DEPTH_F16), 65536);
+    OIIO_CHECK_EQUAL(OCIO::Lut1DOpData::GetLutIdealSize(OCIO::BIT_DEPTH_F32), 65536);
+}
+
+OIIO_ADD_TEST(Lut1DOpData, constructor)
+{
+    OCIO::Lut1DOpData lut(2);
+
+    OIIO_CHECK_ASSERT(lut.getType() == OCIO::OpData::Lut1DType);
+    OIIO_CHECK_ASSERT(!lut.isNoOp());
+    OIIO_CHECK_ASSERT(lut.isIdentity());
+    OIIO_CHECK_EQUAL(lut.getArray().getLength(), 2);
+    OIIO_CHECK_EQUAL(lut.getInterpolation(), OCIO::INTERP_LINEAR);
+    OIIO_CHECK_NO_THROW(lut.validate());
+}
+
+OIIO_ADD_TEST(Lut1DOpData, accessors)
+{
+    OCIO::Lut1DOpData l(17);
+    l.setInputBitDepth(OCIO::BIT_DEPTH_UINT10);
+    l.setOutputBitDepth(OCIO::BIT_DEPTH_UINT10);
+    l.setInterpolation(OCIO::INTERP_LINEAR);
+
+    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_LINEAR);
+    OIIO_CHECK_ASSERT(!l.isNoOp());
+    OIIO_CHECK_ASSERT(l.isIdentity());
+    OIIO_CHECK_NO_THROW(l.validate());
+
+    OIIO_CHECK_EQUAL(l.getHueAdjust(), OCIO::Lut1DOpData::HUE_NONE);
+    l.setHueAdjust(OCIO::Lut1DOpData::HUE_DW3);
+    OIIO_CHECK_EQUAL(l.getHueAdjust(), OCIO::Lut1DOpData::HUE_DW3);
+
+    // Note: Hue and Sat adjust do not affect identity status.
+    OIIO_CHECK_ASSERT(l.isIdentity());
+
+    const float back1 = l.getArray()[1];
+    l.getArray()[1] = 1.0f;
+    OIIO_CHECK_ASSERT(!l.isNoOp());
+    OIIO_CHECK_ASSERT(!l.isIdentity());
+    OIIO_CHECK_NO_THROW(l.validate());
+
+    l.setInterpolation(OCIO::INTERP_BEST);
+    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_BEST);
+
+    OIIO_CHECK_EQUAL(l.getArray().getLength(), 17);
+    OIIO_CHECK_EQUAL(l.getArray().getNumValues(), 17 * 3);
+    OIIO_CHECK_EQUAL(l.getArray().getNumColorComponents(), 3);
+
+    l.getArray().resize(65, 3);
+
+    OIIO_CHECK_EQUAL(l.getArray().getLength(), 65);
+    OIIO_CHECK_EQUAL(l.getArray().getNumValues(), 65 * 3);
+    OIIO_CHECK_EQUAL(l.getArray().getNumColorComponents(), 3);
+    OIIO_CHECK_NO_THROW(l.validate());
+}
+
+OIIO_ADD_TEST(Lut1DOpData, identity_bitdepth)
+{
+    OCIO::Lut1DOpData l1(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT8,
+                         "", OCIO::OpData::Descriptions(),
+                         OCIO::INTERP_LINEAR,
+                         OCIO::Lut1DOpData::LUT_STANDARD);
+    OCIO::Lut1DOpData l2(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT10,
+                         "", OCIO::OpData::Descriptions(),
+                         OCIO::INTERP_LINEAR,
+                         OCIO::Lut1DOpData::LUT_STANDARD);
+
+    OIIO_CHECK_ASSERT(!l1.isNoOp());
+    OIIO_CHECK_ASSERT(l1.isIdentity());
+    OIIO_CHECK_NO_THROW(l1.validate());
+
+    OIIO_CHECK_ASSERT(!l2.isNoOp());
+    OIIO_CHECK_ASSERT(l2.isIdentity());
+    OIIO_CHECK_NO_THROW(l2.validate());
+
+    const float coeff
+        = OCIO::GetBitDepthMaxValue(l2.getOutputBitDepth())
+        / OCIO::GetBitDepthMaxValue(l2.getInputBitDepth());
+
+    // To validate the result, compute the expected results
+    // not using the Lut1DOp algorithm.
+    const float error = 1e-6f;
+    for (unsigned long idx = 0; idx<l2.getArray().getLength(); ++idx)
+    {
+        OIIO_CHECK_CLOSE(l1.getArray().getValues()[idx * 3 + 0] * coeff,
+                         l2.getArray().getValues()[idx * 3 + 0],
+                         error);
+
+        OIIO_CHECK_CLOSE(l1.getArray().getValues()[idx * 3 + 1] * coeff,
+                         l2.getArray().getValues()[idx * 3 + 1],
+                         error);
+
+        OIIO_CHECK_CLOSE(l1.getArray().getValues()[idx * 3 + 2] * coeff,
+                         l2.getArray().getValues()[idx * 3 + 2],
+                         error);
+    }
+
+    OCIO::Lut1DOpData l3(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_UINT8,
+                         "", OCIO::OpData::Descriptions(),
+                         OCIO::INTERP_LINEAR,
+                         OCIO::Lut1DOpData::LUT_INPUT_HALF_CODE);
+
+    OIIO_CHECK_ASSERT(l3.isIdentity());
+}
+
+OIIO_ADD_TEST(Lut1DOpData, is_identity)
+{
+    OCIO::Lut1DOpData l1(OCIO::BIT_DEPTH_UINT10, OCIO::BIT_DEPTH_UINT10,
+                         "", OCIO::OpData::Descriptions(),
+                         OCIO::INTERP_LINEAR,
+                         OCIO::Lut1DOpData::LUT_STANDARD);
+
+    OIIO_CHECK_ASSERT(l1.isIdentity());
+
+    // The tolerance will be 1023*1e-5 = 0.01023.
+    const unsigned long lastId = (unsigned long)l1.getArray().getValues().size() - 1;
+    const float first = l1.getArray()[0];
+    const float last = l1.getArray()[lastId];
+
+    l1.getArray()[0] = first + 0.01f;
+    l1.getArray()[lastId] = last + 0.01f;
+    OIIO_CHECK_ASSERT(l1.isIdentity());
+
+    l1.getArray()[0] = first + 0.02f;
+    l1.getArray()[lastId] = last;
+    OIIO_CHECK_ASSERT(!l1.isIdentity());
+
+    l1.getArray()[0] = first;
+    l1.getArray()[lastId] = last + 0.02f;
+    OIIO_CHECK_ASSERT(!l1.isIdentity());
+
+
+    OCIO::Lut1DOpData l2(OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_UINT10,
+                         "", OCIO::OpData::Descriptions(),
+                         OCIO::INTERP_LINEAR,
+                         OCIO::Lut1DOpData::LUT_INPUT_HALF_CODE);
+
+    unsigned long id2 = 31700 * 3;
+    const float first2 = l2.getArray()[0];
+    const float last2 = l2.getArray()[id2];
+
+    // U10 out bit-depth means values are scaled by 1023.f
+    // (float)half(1) - (float)half(0) = 5.96046448e-08f
+    // scaled -> 6.09755516e-5f
+    const float ERROR_0 = 6.09755516e-5f;
+    // (float)half(31701) - (float)half(31700) = 32.0f
+    // scaled -> 32736.0f
+    const float ERROR_31700 = 32736.0f;
+
+    OIIO_CHECK_ASSERT(l2.isIdentity());
+
+    l2.getArray()[0] = first2 + ERROR_0;
+    l2.getArray()[id2] = last2 + ERROR_31700;
+
+    OIIO_CHECK_ASSERT(l2.isIdentity());
+
+    l2.getArray()[0] = first2 + 2 * ERROR_0;
+    l2.getArray()[id2] = last2;
+
+    OIIO_CHECK_ASSERT(!l2.isIdentity());
+
+    l2.getArray()[0] = first2;
+    l2.getArray()[id2] = last2 + 2 * ERROR_31700;
+
+    OIIO_CHECK_ASSERT(!l2.isIdentity());
+}
+
+OIIO_ADD_TEST(Lut1DOpData, clone)
+{
+    OCIO::Lut1DOpData ref(20);
+    ref.getArray()[1] = 0.5f;
+    ref.setHueAdjust(OCIO::Lut1DOpData::HUE_DW3);
+
+    OCIO::Lut1DOpDataRcPtr pClone = ref.clone();
+
+    OIIO_CHECK_ASSERT(!pClone->isNoOp());
+    OIIO_CHECK_ASSERT(!pClone->isIdentity());
+    OIIO_CHECK_NO_THROW(pClone->validate());
+    OIIO_CHECK_ASSERT(pClone->getArray() == ref.getArray());
+    OIIO_CHECK_EQUAL(pClone->getHueAdjust(), OCIO::Lut1DOpData::HUE_DW3);
+}
+
+OIIO_ADD_TEST(Lut1DOpData, output_depth_scaling)
+{
+    OCIO::Lut1DOpData ref(OCIO::BIT_DEPTH_UINT8,
+                          OCIO::BIT_DEPTH_UINT10,
+                          OCIO::Lut1DOpData::LUT_STANDARD);
+
+    // Get the array values and keep them to compare later.
+    const OCIO::Array::Values initialArrValues = ref.getArray().getValues();
+    const OCIO::BitDepth initialBitdepth = ref.getOutputBitDepth();
+
+    const OCIO::BitDepth newBitdepth = OCIO::BIT_DEPTH_UINT16;
+
+    const float factor = OCIO::GetBitDepthMaxValue(newBitdepth)
+                         / OCIO::GetBitDepthMaxValue(initialBitdepth);
+
+    ref.setOutputBitDepth(newBitdepth);
+    // Now we need to make sure that the bitdepth was changed from the overriden
+    // method.
+    OIIO_CHECK_EQUAL(ref.getOutputBitDepth(), newBitdepth);
+
+    // Now we need to check the scaling between the new array and initial array
+    // matches the factor computed above.
+    const OCIO::Array::Values& newArrValues = ref.getArray().getValues();
+
+    // Sanity check first.
+    OIIO_CHECK_EQUAL(initialArrValues.size(), newArrValues.size());
+
+    float expectedValue = 0.0f;
+    const float error = 1e-6f;
+    for (unsigned long i = 0; i < newArrValues.size(); i++)
+    {
+        expectedValue = initialArrValues[i] * factor;
+        OIIO_CHECK_CLOSE(expectedValue, newArrValues[i], error);
+    }
+
+}
+
+OIIO_ADD_TEST(Lut1DOpData, equality_test)
+{
+    OCIO::Lut1DOpData l1(OCIO::BIT_DEPTH_UINT10, OCIO::BIT_DEPTH_UINT10,
+                         "", OCIO::OpData::Descriptions(),
+                         OCIO::INTERP_LINEAR,
+                         OCIO::Lut1DOpData::LUT_STANDARD);
+
+    OCIO::Lut1DOpData l2(OCIO::BIT_DEPTH_UINT10, OCIO::BIT_DEPTH_UINT10,
+                         "", OCIO::OpData::Descriptions(),
+                         OCIO::INTERP_NEAREST,
+                         OCIO::Lut1DOpData::LUT_STANDARD);
+
+    OIIO_CHECK_ASSERT(!(l1 == l2));
+
+    OCIO::Lut1DOpData l3(OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_UINT10,
+                         "", OCIO::OpData::Descriptions(),
+                         OCIO::INTERP_LINEAR,
+                         OCIO::Lut1DOpData::LUT_STANDARD);
+
+    OIIO_CHECK_ASSERT(!(l1 == l3) && !(l3 == l2));
+
+    OCIO::Lut1DOpData l4(OCIO::BIT_DEPTH_UINT10, OCIO::BIT_DEPTH_UINT10,
+                         "", OCIO::OpData::Descriptions(),
+                         OCIO::INTERP_LINEAR,
+                         OCIO::Lut1DOpData::LUT_STANDARD);
+
+    OIIO_CHECK_ASSERT(l1 == l4);
+
+    l1.setHueAdjust(OCIO::Lut1DOpData::HUE_DW3);
+
+    OIIO_CHECK_ASSERT(!(l1 == l4));
+}
+
+OIIO_ADD_TEST(Lut1DOpData, channel)
+{
+    OCIO::Lut1DOpDataRcPtr L1 = std::make_shared<OCIO::Lut1DOpData>(
+        OCIO::BIT_DEPTH_UINT10, OCIO::BIT_DEPTH_UINT10,
+        "", OCIO::OpData::Descriptions(),
+        OCIO::INTERP_LINEAR,
+        OCIO::Lut1DOpData::LUT_STANDARD,
+        17);
+
+    OCIO::ConstLut1DOpDataRcPtr L2 = std::make_shared<OCIO::Lut1DOpData>(
+        OCIO::BIT_DEPTH_UINT10, OCIO::BIT_DEPTH_UINT10,
+        "", OCIO::OpData::Descriptions(),
+        OCIO::INTERP_LINEAR,
+        OCIO::Lut1DOpData::LUT_STANDARD,
+        20);
+
+    // False: identity.
+    OIIO_CHECK_ASSERT(!L1->hasChannelCrosstalk());
+    OIIO_CHECK_ASSERT(L1->mayCompose(L2));
+
+    L1->setHueAdjust(OCIO::Lut1DOpData::HUE_DW3);
+    
+    // True: hue restore is on, it's an identity LUT, but this is not
+    // tested for efficency.
+    OIIO_CHECK_ASSERT(L1->hasChannelCrosstalk());
+    
+    OIIO_CHECK_ASSERT(!L1->mayCompose(L2));
+
+    OCIO::ConstLut1DOpDataRcPtr L1C = L1;
+    OIIO_CHECK_ASSERT(!L2->mayCompose(L1C));
+
+    L1->setHueAdjust(OCIO::Lut1DOpData::HUE_NONE);
+    L1->getArray()[1] = 3.0f;
+    // False: non-identity.
+    OIIO_CHECK_ASSERT(!L1->hasChannelCrosstalk());
+
+    L1->setHueAdjust(OCIO::Lut1DOpData::HUE_DW3);
+    // True: non-identity w/hue restore.
+    OIIO_CHECK_ASSERT(L1->hasChannelCrosstalk());
+}
+
+OIIO_ADD_TEST(Lut1DOpData, interpolation)
+{
+    OCIO::Lut1DOpData l(17);
+    l.setInputBitDepth(OCIO::BIT_DEPTH_F32);
+    l.setOutputBitDepth(OCIO::BIT_DEPTH_F32);
+
+    l.setInterpolation(OCIO::INTERP_LINEAR);
+    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_LINEAR);
+    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OIIO_CHECK_NO_THROW(l.validate());
+
+    l.setInterpolation(OCIO::INTERP_BEST);
+    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_BEST);
+    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OIIO_CHECK_NO_THROW(l.validate());
+
+    l.setInterpolation(OCIO::INTERP_DEFAULT);
+    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_DEFAULT);
+    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OIIO_CHECK_NO_THROW(l.validate());
+
+    // TODO: INTERP_NEAREST is currently implemented as INTERP_LINEAR.
+    l.setInterpolation(OCIO::INTERP_NEAREST);
+    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_NEAREST);
+    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OIIO_CHECK_NO_THROW(l.validate());
+
+    // Invalid interpolation type do not get translated
+    // by getConcreteInterpolation.
+    l.setInterpolation(OCIO::INTERP_UNKNOWN);
+    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_UNKNOWN);
+    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OIIO_CHECK_THROW_WHAT(l.validate(), OCIO::Exception, "does not support interpolation algorithm");
+
+    l.setInterpolation(OCIO::INTERP_TETRAHEDRAL);
+    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_TETRAHEDRAL);
+    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OIIO_CHECK_THROW_WHAT(l.validate(), OCIO::Exception, " does not support interpolation algorithm");
+}
+
+
+OIIO_ADD_TEST(Lut1DOpData, lut_1d_compose)
+{
+    OCIO::Lut1DOpDataRcPtr lut1 =
+        std::make_shared<OCIO::Lut1DOpData>(OCIO::BIT_DEPTH_F32,
+                                            OCIO::BIT_DEPTH_F32,
+                                            OCIO::Lut1DOpData::LUT_STANDARD);
+
+    lut1->getArray().resize(8, 3);
+    float * values = &lut1->getArray().getValues()[0];
+
+    values[0]  = 0.0f;      values[1]  = 0.0f;      values[2]  = 0.002333f;
+    values[3]  = 0.0f;      values[4]  = 0.291341f; values[5]  = 0.015624f;
+    values[6]  = 0.106521f; values[7]  = 0.334331f; values[8]  = 0.462431f;
+    values[9]  = 0.515851f; values[10] = 0.474151f; values[11] = 0.624611f;
+    values[12] = 0.658791f; values[13] = 0.527381f; values[14] = 0.685071f;
+    values[15] = 0.908501f; values[16] = 0.707951f; values[17] = 0.886331f;
+    values[18] = 0.926671f; values[19] = 0.846431f; values[20] = 1.0f;
+    values[21] = 1.0f;      values[22] = 1.0f;      values[23] = 1.0f;
+
+    OCIO::Lut1DOpDataRcPtr lut1Cloned = lut1->clone();
+
+    OCIO::Lut1DOpDataRcPtr lut2 =
+        std::make_shared<OCIO::Lut1DOpData>(OCIO::BIT_DEPTH_F32,
+                                            OCIO::BIT_DEPTH_F32,
+                                            OCIO::Lut1DOpData::LUT_STANDARD);
+
+    lut2->getArray().resize(8, 3);
+    values = &lut2->getArray().getValues()[0];
+
+    values[0]  = 0.0f;        values[1]  = 0.0f;       values[2]  = 0.0023303f;
+    values[3]  = 0.0f;        values[4]  = 0.0029134f; values[5]  = 0.015624f;
+    values[6]  = 0.00010081f; values[7]  = 0.0059806f; values[8]  = 0.023362f;
+    values[9]  = 0.0045628f;  values[10] = 0.024229f;  values[11] = 0.05822f;
+    values[12] = 0.0082598f;  values[13] = 0.033831f;  values[14] = 0.074063f;
+    values[15] = 0.028595f;   values[16] = 0.075003f;  values[17] = 0.13552f;
+    values[18] = 0.69154f;    values[19] = 0.9213f;    values[20] = 1.0f;
+    values[21] = 0.76038f;    values[22] = 1.0f;       values[23] = 1.0f;
+
+    OCIO::ConstLut1DOpDataRcPtr lut2C = lut2;
+
+    {
+        OCIO::Lut1DOpData::Compose(lut1,
+                                   lut2C,
+                                   OCIO::Lut1DOpData::COMPOSE_RESAMPLE_NO);
+
+        values = &lut1->getArray().getValues()[0];
+
+        OIIO_CHECK_EQUAL(lut1->getArray().getLength(), 8);
+
+        OIIO_CHECK_CLOSE(values[0], 0.0f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[1], 0.0f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[2], 0.00254739914f, 1e-6f);
+
+        OIIO_CHECK_CLOSE(values[3], 0.0f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[4], 0.00669934973f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[5], 0.00378420483f, 1e-6f);
+
+        OIIO_CHECK_CLOSE(values[6], 0.0f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[7], 0.0121908365f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[8], 0.0619750582f, 1e-6f);
+
+        OIIO_CHECK_CLOSE(values[9], 0.00682150759f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[10], 0.0272925831f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[11], 0.096942015f, 1e-6f);
+
+        OIIO_CHECK_CLOSE(values[12], 0.0206955168f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[13], 0.0308703855f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[14], 0.12295182f, 1e-6f);
+
+        OIIO_CHECK_CLOSE(values[15], 0.716288447f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[16], 0.0731772855f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[17], 1.0f, 1e-6f);
+
+        OIIO_CHECK_CLOSE(values[18], 0.725044191f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[19], 0.857842028f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[20], 1.0f, 1e-6f);
+    }
+
+    {
+        OCIO::Lut1DOpData::Compose(lut1Cloned,
+                                   lut2C,
+                                   OCIO::Lut1DOpData::COMPOSE_RESAMPLE_INDEPTH);
+
+        values = &lut1Cloned->getArray().getValues()[0];
+
+        OIIO_CHECK_EQUAL(lut1Cloned->getArray().getLength(), 65536);
+
+        OIIO_CHECK_CLOSE(values[0], 0.0f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[1], 0.0f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[2], 0.00254739914f, 1e-6f);
+
+        OIIO_CHECK_CLOSE(values[3], 0.0f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[4], 6.34463504e-07f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[5], 0.00254753046f, 1e-6f);
+
+        OIIO_CHECK_CLOSE(values[6], 0.0f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[7], 1.26915984e-06f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[8], 0.00254766271f, 1e-6f);
+
+        OIIO_CHECK_CLOSE(values[9], 0.0f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[10], 1.90362334e-06f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[11], 0.00254779495f, 1e-6f);
+
+        OIIO_CHECK_CLOSE(values[12], 0.0f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[13], 2.53855251e-06f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[14], 0.0025479272f, 1e-6f);
+
+        OIIO_CHECK_CLOSE(values[15], 0.0f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[16], 3.17324884e-06f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[17], 0.00254805945f, 1e-6f);
+
+        OIIO_CHECK_CLOSE(values[300], 0.0f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[301], 6.3463347e-05f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[302], 0.00256060902f, 1e-6f);
+
+        OIIO_CHECK_CLOSE(values[900], 0.0f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[901], 0.000190390972f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[902], 0.00258703064f, 1e-6f);
+
+        OIIO_CHECK_CLOSE(values[2700], 0.0f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[2701], 0.000571172219f, 1e-6f);
+        OIIO_CHECK_CLOSE(values[2702], 0.00266629551f, 1e-6f);
+    }
+}
+
+OIIO_ADD_TEST(Lut1DOpData, lut_1d_compose_sc)
+{
+    OCIO::Lut1DOpDataRcPtr lut1 =
+        std::make_shared<OCIO::Lut1DOpData>(OCIO::BIT_DEPTH_UINT8,
+                                            OCIO::BIT_DEPTH_UINT8,
+                                            OCIO::Lut1DOpData::LUT_STANDARD);
+
+    lut1->getArray().resize(2, 3);
+    float * values = &lut1->getArray().getValues()[0];
+    values[0] = 64.f;  values[1] = 64.f;   values[2] = 64.f;
+    values[3] = 196.f; values[4] = 196.f;  values[5] = 196.f;
+
+    OCIO::Lut1DOpDataRcPtr lut2 =
+        std::make_shared<OCIO::Lut1DOpData>(OCIO::BIT_DEPTH_UINT8,
+                                            OCIO::BIT_DEPTH_F32,
+                                            OCIO::Lut1DOpData::LUT_STANDARD);
+
+    lut2->getArray().resize(32, 3);
+    values = &lut2->getArray().getValues()[0];
+
+    values[0] = 0.0000000f;   values[1] = 0.0000000f;  values[2] = 0.0023303f;
+    values[3] = 0.0000000f;   values[4] = 0.0001869f;  values[5] = 0.0052544f;
+    values[6] = 0.0000000f;   values[7] = 0.0010572f;  values[8] = 0.0096338f;
+    values[9] = 0.0000000f;  values[10] = 0.0029134f; values[11] = 0.0156240f;
+    values[12] = 0.0001008f; values[13] = 0.0059806f; values[14] = 0.0233620f;
+    values[15] = 0.0007034f; values[16] = 0.0104480f; values[17] = 0.0329680f;
+    values[18] = 0.0021120f; values[19] = 0.0164810f; values[20] = 0.0445540f;
+    values[21] = 0.0045628f; values[22] = 0.0242290f; values[23] = 0.0582200f;
+    values[24] = 0.0082598f; values[25] = 0.0338310f; values[26] = 0.0740630f;
+    values[27] = 0.0133870f; values[28] = 0.0454150f; values[29] = 0.0921710f;
+    values[30] = 0.0201130f; values[31] = 0.0591010f; values[32] = 0.1126300f;
+    values[33] = 0.0285950f; values[34] = 0.0750030f; values[35] = 0.1355200f;
+    values[36] = 0.0389830f; values[37] = 0.0932290f; values[38] = 0.1609100f;
+    values[39] = 0.0514180f; values[40] = 0.1138800f; values[41] = 0.1888800f;
+    values[42] = 0.0660340f; values[43] = 0.1370600f; values[44] = 0.2195000f;
+    values[45] = 0.0829620f; values[46] = 0.1628600f; values[47] = 0.2528300f;
+    values[48] = 0.1023300f; values[49] = 0.1913800f; values[50] = 0.2889500f;
+    values[51] = 0.1242500f; values[52] = 0.2227000f; values[53] = 0.3279000f;
+    values[54] = 0.1488500f; values[55] = 0.2569100f; values[56] = 0.3697600f;
+    values[57] = 0.1762300f; values[58] = 0.2940900f; values[59] = 0.4145900f;
+    values[60] = 0.2065200f; values[61] = 0.3343300f; values[62] = 0.4624300f;
+    values[63] = 0.2398200f; values[64] = 0.3777000f; values[65] = 0.5133400f;
+    values[66] = 0.2762200f; values[67] = 0.4242800f; values[68] = 0.5673900f;
+    values[69] = 0.3158500f; values[70] = 0.4741500f; values[71] = 0.6246100f;
+    values[72] = 0.3587900f; values[73] = 0.5273800f; values[74] = 0.6850700f;
+    values[75] = 0.4051500f; values[76] = 0.5840400f; values[77] = 0.7488100f;
+    values[78] = 0.4550200f; values[79] = 0.6442100f; values[80] = 0.8158800f;
+    values[81] = 0.5085000f; values[82] = 0.7079500f; values[83] = 0.8863300f;
+    values[84] = 0.5656900f; values[85] = 0.7753400f; values[86] = 0.9602100f;
+    values[87] = 0.6266700f; values[88] = 0.8464300f; values[89] = 1.0000000f;
+    values[90] = 0.6915400f; values[91] = 0.9213000f; values[92] = 1.0000000f;
+    values[93] = 0.7603800f; values[94] = 1.0000000f; values[95] = 1.0000000f;
+
+    OCIO::ConstLut1DOpDataRcPtr lut2C = lut2;
+
+    {
+        OCIO::Lut1DOpDataRcPtr lComp = lut1->clone();
+        OIIO_CHECK_NO_THROW(
+            OCIO::Lut1DOpData::Compose(lComp, lut2C, OCIO::Lut1DOpData::COMPOSE_RESAMPLE_NO));
+
+        OIIO_CHECK_EQUAL(lComp->getArray().getLength(), 2);
+        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[0], 0.00744791f, 1e-6f);
+        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[1], 0.03172233f, 1e-6f);
+        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[2], 0.07058375f, 1e-6f);
+        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[3], 0.3513808f, 1e-6f);
+        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[4], 0.51819527f, 1e-6f);
+        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[5], 0.67463773f, 1e-6f);
+    }
+
+    {
+        OCIO::Lut1DOpDataRcPtr lComp = lut1->clone();
+        OIIO_CHECK_NO_THROW(
+            OCIO::Lut1DOpData::Compose(lComp, lut2C, OCIO::Lut1DOpData::COMPOSE_RESAMPLE_INDEPTH));
+
+        OIIO_CHECK_EQUAL(lComp->getArray().getLength(), 256);
+        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[0], 0.00744791f, 1e-6f);
+        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[1], 0.03172233f, 1e-6f);
+        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[2], 0.07058375f, 1e-6f);
+        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[383], 0.28073114f, 1e-6f);
+        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[384], 0.09914176f, 1e-6f);
+        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[385], 0.1866852f, 1e-6f);
+        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[765], 0.3513808f, 1e-6f);
+        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[766], 0.51819527f, 1e-6f);
+        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[767], 0.67463773f, 1e-6f);
+    }
+
+    {
+        OCIO::ConstLut1DOpDataRcPtr lut1C = lut1;
+        OCIO::Lut1DOpDataRcPtr lComp = lut2->clone();
+        OIIO_CHECK_THROW_WHAT(
+            OCIO::Lut1DOpData::Compose(lComp, lut1C, OCIO::Lut1DOpData::COMPOSE_RESAMPLE_NO),
+            OCIO::Exception, "bit-depth mismatch forbids the composition");
+
+    }
+}
+
+namespace
+{
+    const char uid[] = "uid";
+    const OCIO::OpData::Descriptions desc;
+};
+
+// Validate the input and output bit-depths and half domain.
+void checkInverse_bitDepths_domain(
+    const OCIO::BitDepth refInputBitDepth,
+    const OCIO::BitDepth refOutputBitDepth,
+    const OCIO::Interpolation refInterpolationAlgo,
+    const OCIO::Lut1DOpData::HalfFlags refHalfFlags,
+    const OCIO::BitDepth expectedInvInputBitDepth,
+    const OCIO::BitDepth expectedInvOutputBitDepth,
+    const OCIO::Interpolation expectedInvInterpolationAlgo,
+    const OCIO::Lut1DOpData::HalfFlags expectedInvHalfFlags)
+{
+    OCIO::Lut1DOpData refLut1d(
+        refInputBitDepth, refOutputBitDepth,
+        uid, desc,
+        refInterpolationAlgo,
+        refHalfFlags);
+
+    // Get inverse of reference 1D LUT operation.
+    OCIO::Lut1DOpDataRcPtr invLut1d;
+    OIIO_CHECK_NO_THROW(invLut1d = refLut1d.inverse());
+    OIIO_REQUIRE_ASSERT(invLut1d);
+
+    OIIO_CHECK_EQUAL(invLut1d->getInputBitDepth(),
+                     expectedInvInputBitDepth);
+
+    OIIO_CHECK_EQUAL(invLut1d->getOutputBitDepth(),
+                     expectedInvOutputBitDepth);
+
+    OIIO_CHECK_EQUAL(invLut1d->getInterpolation(),
+                     expectedInvInterpolationAlgo);
+
+    OIIO_CHECK_EQUAL(invLut1d->getHalfFlags(),
+                     expectedInvHalfFlags);
+
+    OIIO_CHECK_EQUAL(invLut1d->getHueAdjust(),
+                     OCIO::Lut1DOpData::HUE_NONE);
+}
+
+
+OIIO_ADD_TEST(Lut1DOpData, inverse_bitDepth_domain)
+{
+    checkInverse_bitDepths_domain(
+        // Reference
+        OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_F32,
+        OCIO::INTERP_DEFAULT,
+        OCIO::Lut1DOpData::LUT_STANDARD,
+        // Expected
+        OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_UINT8,
+        OCIO::INTERP_DEFAULT,
+        OCIO::Lut1DOpData::LUT_STANDARD);
+
+    checkInverse_bitDepths_domain(
+        // Reference
+        OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_UINT12,
+        OCIO::INTERP_LINEAR,
+        OCIO::Lut1DOpData::LUT_STANDARD,
+        // Expected
+        OCIO::BIT_DEPTH_UINT12, OCIO::BIT_DEPTH_F16,
+        OCIO::INTERP_LINEAR,
+        OCIO::Lut1DOpData::LUT_STANDARD);
+
+    checkInverse_bitDepths_domain(
+        // Reference
+        OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_F32,
+        OCIO::INTERP_BEST,
+        OCIO::Lut1DOpData::LUT_STANDARD,
+        // Expected
+        OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F16,
+        OCIO::INTERP_BEST,
+        OCIO::Lut1DOpData::LUT_STANDARD);
+
+    checkInverse_bitDepths_domain(
+        // Reference
+        OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_UINT12,
+        OCIO::INTERP_BEST,
+        OCIO::Lut1DOpData::LUT_INPUT_HALF_CODE,
+        // Expected
+        OCIO::BIT_DEPTH_UINT12, OCIO::BIT_DEPTH_F16,
+        OCIO::INTERP_BEST,
+        OCIO::Lut1DOpData::LUT_INPUT_HALF_CODE);
+}
+
+OIIO_ADD_TEST(Lut1DOpData, inverse_hueadjust)
+{
+    OCIO::Lut1DOpData refLut1d(OCIO::BIT_DEPTH_F32,
+                               OCIO::BIT_DEPTH_F32,
+                               uid, desc,
+                               OCIO::INTERP_BEST,
+                               OCIO::Lut1DOpData::LUT_STANDARD);
+
+    refLut1d.setHueAdjust(OCIO::Lut1DOpData::HUE_DW3);
+
+    // Get inverse of reference lut1d operation.
+    OCIO::Lut1DOpDataRcPtr invLut1d;
+    OIIO_CHECK_NO_THROW(invLut1d = refLut1d.inverse());
+    OIIO_REQUIRE_ASSERT(invLut1d);
+
+    OIIO_CHECK_EQUAL(invLut1d->getHueAdjust(),
+                     OCIO::Lut1DOpData::HUE_DW3);
+}
+
+OIIO_ADD_TEST(Lut1DOpData, is_inverse)
+{
+    // Create forward LUT.
+    OCIO::Lut1DOpDataRcPtr L1 = std::make_shared<OCIO::Lut1DOpData>(
+        OCIO::BIT_DEPTH_UINT8,
+        OCIO::BIT_DEPTH_UINT10,
+        uid, desc,
+        OCIO::INTERP_LINEAR,
+        OCIO::Lut1DOpData::LUT_STANDARD,
+        5);
+    
+    // Make it not an identity.
+    OCIO::Array & array = L1->getArray();
+    OCIO::Array::Values & values = array.getValues();
+    values[0] = 20.f;
+    OIIO_CHECK_ASSERT(!L1->isIdentity());
+
+    // Create an inverse LUT with same basics.
+    OCIO::Lut1DOpDataRcPtr L2 = L1->inverse();
+    OIIO_REQUIRE_ASSERT(L2);
+
+    OIIO_CHECK_ASSERT(!(*L1 == *L2));
+
+    OCIO::ConstLut1DOpDataRcPtr L1C = L1;
+    OCIO::ConstLut1DOpDataRcPtr L2C = L2;
+
+    // Check isInverse.
+    OIIO_CHECK_ASSERT(L1->isInverse(L2C));
+    OIIO_CHECK_ASSERT(L2->isInverse(L1C));
+
+    // Arrays are the same if you normalize for the scaling difference.
+    L1->setOutputBitDepth(OCIO::BIT_DEPTH_UINT12);
+    OIIO_CHECK_ASSERT(L1->isInverse(L2C));
+    OIIO_CHECK_ASSERT(L2->isInverse(L1C));
+
+    // Catch the situation where the arrays are the same even though the
+    // bit-depths don't match and hence the arrays effectively aren't the same.
+    L1->setOutputBitDepth(OCIO::BIT_DEPTH_UINT10);  // restore original
+    OIIO_CHECK_ASSERT(L1->isInverse(L2C));
+    L1->OpData::setOutputBitDepth(OCIO::BIT_DEPTH_UINT12);
+    OIIO_CHECK_ASSERT(!L1->isInverse(L2C));
+    OIIO_CHECK_ASSERT(!L2->isInverse(L1C));
+}
+
+void SetLutArray(OCIO::Lut1DOpData & op,
+                 unsigned long dimension,
+                 unsigned long channels,
+                 const float * data)
+{
+    OCIO::Array & refArray = op.getArray();
+    refArray.resize(dimension, channels);
+    // The data allocated for the array is dimension * getMaxColorComponents(),
+    // not dimension * channels.
+
+    const unsigned long maxChannels = refArray.getMaxColorComponents();
+    OCIO::Array::Values & values = refArray.getValues();
+    if (channels == maxChannels)
+    {
+        memcpy(&(values[0]), data, dimension * channels * sizeof(float));
+    }
+    else
+    {
+        // Set the red component, fill other with zero values.
+        for (unsigned long i = 0; i < dimension; ++i)
+        {
+            values[i*maxChannels + 0] = data[i];
+            values[i*maxChannels + 1] = 0.f;
+            values[i*maxChannels + 2] = 0.f;
+        }
+    }
+}
+
+// Validate the overall increase/decrease and effective domain.
+void CheckInverse_IncreasingEffectiveDomain(
+    unsigned long dimension, unsigned long channels, const float* fwdArrayData,
+    bool expIncreasingR, unsigned long expStartDomainR, unsigned long expEndDomainR,
+    bool expIncreasingG, unsigned long expStartDomainG, unsigned long expEndDomainG,
+    bool expIncreasingB, unsigned long expStartDomainB, unsigned long expEndDomainB)
+{
+    OCIO::Lut1DOpData refLut1dOp(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32,
+                                 uid, desc,
+                                 OCIO::INTERP_BEST,
+                                 OCIO::Lut1DOpData::LUT_STANDARD);
+
+    SetLutArray(refLut1dOp, dimension, channels, fwdArrayData);
+
+    OCIO::Lut1DOpDataRcPtr invLut1dOp = refLut1dOp.inverse();
+    OIIO_REQUIRE_ASSERT(invLut1dOp);
+    OIIO_CHECK_NO_THROW(invLut1dOp->finalize());
+
+    const OCIO::Lut1DOpData::ComponentProperties &
+        redProperties = invLut1dOp->getRedProperties();
+
+    const OCIO::Lut1DOpData::ComponentProperties &
+        greenProperties = invLut1dOp->getGreenProperties();
+
+    const OCIO::Lut1DOpData::ComponentProperties &
+        blueProperties = invLut1dOp->getBlueProperties();
+
+    OIIO_CHECK_EQUAL(redProperties.isIncreasing, expIncreasingR);
+    OIIO_CHECK_EQUAL(redProperties.startDomain, expStartDomainR);
+    OIIO_CHECK_EQUAL(redProperties.endDomain, expEndDomainR);
+
+    OIIO_CHECK_EQUAL(greenProperties.isIncreasing, expIncreasingG);
+    OIIO_CHECK_EQUAL(greenProperties.startDomain, expStartDomainG);
+    OIIO_CHECK_EQUAL(greenProperties.endDomain, expEndDomainG);
+
+    OIIO_CHECK_EQUAL(blueProperties.isIncreasing, expIncreasingB);
+    OIIO_CHECK_EQUAL(blueProperties.startDomain, expStartDomainB);
+    OIIO_CHECK_EQUAL(blueProperties.endDomain, expEndDomainB);
+}
+
+OIIO_ADD_TEST(Lut1DOpData, inverse_increasing_effective_domain)
+{
+    {
+        const float fwdData[] = { 0.1f, 0.8f, 0.1f,    // 0
+                                  0.1f, 0.7f, 0.1f,
+                                  0.1f, 0.6f, 0.1f,    // 2
+                                  0.2f, 0.5f, 0.1f,    // 3
+                                  0.3f, 0.4f, 0.2f,
+                                  0.4f, 0.3f, 0.3f,
+                                  0.5f, 0.1f, 0.4f,    // 6
+                                  0.6f, 0.1f, 0.5f,    // 7
+                                  0.7f, 0.1f, 0.5f,
+                                  0.8f, 0.1f, 0.5f };  // 9
+
+        CheckInverse_IncreasingEffectiveDomain(
+            10, 3, fwdData,
+            true,  2, 9,   // increasing, flat [0, 2]
+            false, 0, 6,   // decreasing, flat [6, 9]
+            true,  3, 7);  // increasing, flat [0, 3] and [7, 9]
+    }
+
+    {
+        const float fwdData[] = { 0.3f,    // 0
+                                  0.3f,
+                                  0.3f,    // 2
+                                  0.4f,
+                                  0.5f,
+                                  0.6f,
+                                  0.7f,
+                                  0.8f,    // 7
+                                  0.8f,
+                                  0.8f };  // 9
+
+        CheckInverse_IncreasingEffectiveDomain(
+            10, 1, fwdData,
+            true, 2, 7,   // increasing, flat [0->2] and [7->9]
+            true, 2, 7,
+            true, 2, 7);
+    }
+
+    {
+        const float fwdData[] = { 0.5f,
+                                  0.5f,
+                                  0.5f,
+                                  0.5f,
+                                  0.5f,
+                                  0.5f,
+                                  0.5f,
+                                  0.5f,
+                                  0.5f,
+                                  0.5f };
+
+        CheckInverse_IncreasingEffectiveDomain(
+            10, 1, fwdData,
+            false, 0, 0,
+            false, 0, 0,
+            false, 0, 0);
+    }
+
+    {
+        const float fwdData[] = { 0.8f,     // 0
+                                  0.9f,     // reversal
+                                  0.8f,     // 2
+                                  0.5f,
+                                  0.4f,
+                                  0.3f,
+                                  0.2f,
+                                  0.1f,     // 7
+                                  0.1f,
+                                  0.2f };   // reversal
+
+        CheckInverse_IncreasingEffectiveDomain(
+            10, 1, fwdData,
+            false, 2, 7,
+            false, 2, 7,
+            false, 2, 7);
+    }
+}
+
+// Validate the flatten algorithms.
+void CheckInverse_Flatten(unsigned long dimension,
+                          unsigned long channels,
+                          const float * fwdArrayData,
+                          const float * expInvArrayData)
+{
+    OCIO::Lut1DOpData refLut1dOp(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32,
+                                 uid, desc,
+                                 OCIO::INTERP_BEST,
+                                 OCIO::Lut1DOpData::LUT_STANDARD);
+
+    SetLutArray(refLut1dOp, dimension, channels, fwdArrayData);
+
+    OCIO::Lut1DOpDataRcPtr invLut1dOp = refLut1dOp.inverse();
+    OIIO_REQUIRE_ASSERT(invLut1dOp);
+    invLut1dOp->finalize();
+
+    const OCIO::Array::Values &
+        invValues = invLut1dOp->getArray().getValues();
+
+    for (unsigned long i = 0; i < dimension * channels; ++i)
+    {
+        OIIO_CHECK_EQUAL(invValues[i], expInvArrayData[i]);
+    }
+}
+
+OIIO_ADD_TEST(Lut1DOpData, inverse_flatten_test)
+{
+    {
+        const float fwdData[] = { 0.10f, 0.90f, 0.25f,    // 0
+                                  0.20f, 0.80f, 0.30f,
+                                  0.30f, 0.70f, 0.40f,
+                                  0.40f, 0.60f, 0.50f,
+                                  0.35f, 0.50f, 0.60f,    // 4
+                                  0.30f, 0.55f, 0.50f,    // 5
+                                  0.45f, 0.60f, 0.40f,    // 6
+                                  0.50f, 0.65f, 0.30f,    // 7
+                                  0.60f, 0.45f, 0.20f,    // 8
+                                  0.70f, 0.50f, 0.10f };  // 9
+        // red is increasing, with a reversal [4, 5]
+        // green is decreasing, with reversals [4, 5] and [9]
+        // blue is decreasing, with reversals [0, 8]
+
+        const float expInvData[] = { 0.10f, 0.90f, 0.25f,
+                                     0.20f, 0.80f, 0.25f,
+                                     0.30f, 0.70f, 0.25f,
+                                     0.40f, 0.60f, 0.25f,
+                                     0.40f, 0.50f, 0.25f,
+                                     0.40f, 0.50f, 0.25f,
+                                     0.45f, 0.50f, 0.25f,
+                                     0.50f, 0.50f, 0.25f,
+                                     0.60f, 0.45f, 0.20f,
+                                     0.70f, 0.45f, 0.10f };
+
+        CheckInverse_Flatten(10, 3, fwdData, expInvData);
+    }
+}
+
+void SetLutArrayHalf(const OCIO::Lut1DOpDataRcPtr & op, unsigned long channels)
+{
+    const unsigned long dimension = 65536u;
+    OCIO::Array & refArray = op->getArray();
+    refArray.resize(dimension, channels);
+    // The data allocated for the array is dimension * getMaxColorComponents(),
+    // not dimension * channels.
+
+    const unsigned long maxChannels = refArray.getMaxColorComponents();
+    OCIO::Array::Values & values = refArray.getValues();
+    for (unsigned long j = 0u; j < channels; j++)
+    {
+        for (unsigned long i = 0u; i < 65536u; i++)
+        {
+            float f = OCIO::ConvertHalfBitsToFloat((unsigned short)i);
+            if (j == 0)
+            {
+                if (i < 32768u)
+                    f = 2.f * f - 0.1f;
+                else                            // neg domain overlaps pos with reversal
+                    f = 3.f * f + 0.1f;
+                if (i >= 25000u && i < 32760u)  // flat spot at positive end
+                    f = 10000.f;
+                if (i >= 60000u)                // flat spot at neg end
+                    f = -10000.f;
+                if (i > 15000u && i < 20000u)   // reversal in positive side
+                    f = 0.5f;
+                if (i > 50000u && i < 55000u)   // reversal in negative side
+                    f = -2.f;
+            }
+            else if (j == 1)
+            {
+                if (i < 32768u)                  // decreasing function
+                    f = -0.5f * f + 0.02f;
+                else                            // gap between pos & neg at zero
+                    f = -0.4f * f + 0.05f;
+                if (i >= 25000u && i < 32760u)  // flat spot at positive end
+                    f = -400.f;
+                if (i >= 60000u)                // flat spot at neg end
+                    f = 2000.f;
+                if (i > 15000u && i < 20000u)   // reversal in positive side
+                    f = -0.1f;
+                if (i > 50000u && i < 55000u)   // reversal in negative side
+                    f = 1.4f;
+            }
+            else if (j == 2)
+            {
+                if (i < 32768u)
+                    f = std::pow(f, 1.5f);
+                else
+                    f = -std::pow(-f, 0.9f);
+                if (i <= 11878u || (i >= 32768u && i <= 44646u))  // flat spot around zero
+                    f = -0.01f;
+            }
+            values[i * maxChannels + j] = f;
+        }
+    }
+}
+
+OIIO_ADD_TEST(Lut1DOpData, inverse_half_domain)
+{
+    OCIO::Lut1DOpDataRcPtr refLut1dOp = std::make_shared<OCIO::Lut1DOpData>(
+        OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32,
+        uid, desc,
+        OCIO::INTERP_BEST,
+        OCIO::Lut1DOpData::LUT_INPUT_HALF_CODE);
+
+    SetLutArrayHalf(refLut1dOp, 3u);
+
+    OCIO::Lut1DOpDataRcPtr invLut1dOp = refLut1dOp->inverse();
+    OIIO_REQUIRE_ASSERT(invLut1dOp);
+    invLut1dOp->finalize();
+
+    const OCIO::Lut1DOpData::ComponentProperties &
+        redProperties = invLut1dOp->getRedProperties();
+
+    const OCIO::Lut1DOpData::ComponentProperties &
+        greenProperties = invLut1dOp->getGreenProperties();
+
+    const OCIO::Lut1DOpData::ComponentProperties &
+        blueProperties = invLut1dOp->getBlueProperties();
+
+    const OCIO::Array::Values &
+        invValues = invLut1dOp->getArray().getValues();
+
+    // Check increasing/decreasing and start/end domain.
+    OIIO_CHECK_EQUAL(redProperties.isIncreasing, true);
+    OIIO_CHECK_EQUAL(redProperties.startDomain, 0u);
+    OIIO_CHECK_EQUAL(redProperties.endDomain, 25000u);
+    OIIO_CHECK_EQUAL(redProperties.negStartDomain, 44100u);  // -0.2/3 (flattened to remove overlap)
+    OIIO_CHECK_EQUAL(redProperties.negEndDomain, 60000u);
+
+    OIIO_CHECK_EQUAL(greenProperties.isIncreasing, false);
+    OIIO_CHECK_EQUAL(greenProperties.startDomain, 0u);
+    OIIO_CHECK_EQUAL(greenProperties.endDomain, 25000u);
+    OIIO_CHECK_EQUAL(greenProperties.negStartDomain, 32768u);
+    OIIO_CHECK_EQUAL(greenProperties.negEndDomain, 60000u);
+
+    OIIO_CHECK_EQUAL(blueProperties.isIncreasing, true);
+    OIIO_CHECK_EQUAL(blueProperties.startDomain, 11878u);
+    OIIO_CHECK_EQUAL(blueProperties.endDomain, 31743u);      // see note in invLut1DOp.cpp
+    OIIO_CHECK_EQUAL(blueProperties.negStartDomain, 44646u);
+    OIIO_CHECK_EQUAL(blueProperties.negEndDomain, 64511u);
+
+    // Check reversals are removed.
+    half act, aim;
+    act = invValues[16000 * 3];
+    OIIO_CHECK_EQUAL(act.bits(), 15922);  // halfToFloat(15000) * 2 - 0.1
+    act = invValues[52000 * 3];
+    OIIO_CHECK_EQUAL(act.bits(), 51567);  // halfToFloat(50000) * 3 + 0.1
+    act = invValues[16000 * 3 + 1];
+    OIIO_CHECK_EQUAL(act.bits(), 46662);  // halfToFloat(15000) * -0.5 + 0.02
+    act = invValues[52000 * 3 + 1];
+    OIIO_CHECK_EQUAL(act.bits(), 15885);  // halfToFloat(50000) * -0.4 + 0.05
+
+    bool reversal = false;
+    for (unsigned long i = 1; i < 31745; i++)
+    {
+        if (invValues[i * 3] < invValues[(i - 1) * 3])           // increasing red
+            reversal = true;
+    }
+    OIIO_CHECK_ASSERT(!reversal);
+    // Check no overlap at +0 and -0.
+    OIIO_CHECK_ASSERT(invValues[0] >= invValues[32768 * 3]);
+    reversal = false;
+    for (unsigned long i = 1; i < 31745; i++)
+    {
+        if (invValues[i * 3 + 1] > invValues[(i - 1) * 3 + 1])   // decreasing grn
+            reversal = true;
+    }
+    OIIO_CHECK_ASSERT(!reversal);
+    OIIO_CHECK_ASSERT(invValues[0 + 1] <= invValues[32768 * 3 + 1]);
+    reversal = false;
+    for (unsigned long i = 1; i < 31745; i++)
+    {
+        if (invValues[i * 3 + 2] < invValues[(i - 1) * 3 + 2])   // increasing blu
+            reversal = true;
+    }
+    OIIO_CHECK_ASSERT(!reversal);
+    OIIO_CHECK_ASSERT(invValues[0 + 2] >= invValues[32768 * 3 + 2]);
+}
+
+
+// TODO: Port syncolor test: renderer\test\invLutUtil_test.cpp - GPURendererInvLut1D_LutSize_ExtendedDomain
+// TODO: Port syncolor test: renderer\test\invLutUtil_test.cpp - GPURendererInvLut1D_LutSize_GPUOpt
+// TODO: Port syncolor test: renderer\test\invLutUtil_test.cpp - GPURendererInvLut1D_LutSize_HalfDomain
+// TODO: Port syncolor test: renderer\test\invLutUtil_test.cpp - GPURendererInvLut3D_LutSize
+
+#endif // OCIO_UNIT_TEST
+

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOpData.cpp
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOpData.cpp
@@ -271,7 +271,7 @@ Lut1DOpData::~Lut1DOpData()
 
 Interpolation Lut1DOpData::getConcreteInterpolation() const
 {
-    // TODO: currently INTERP_NEAREST is not implemented Lut1DOpCPU.
+    // TODO: currently INTERP_NEAREST is not implemented in Lut1DOpCPU.
     // This is a regression from OCIO v1.
     // NB: To have the same interpolation support (i.e. same color processing)
     // between the CPU & GPU paths, the 'Nearest' interpolation is implemented

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOpData.h
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOpData.h
@@ -1,0 +1,334 @@
+/*
+Copyright (c) 2018 Autodesk Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef INCLUDED_OCIO_LUT1DOPDATA_H
+#define INCLUDED_OCIO_LUT1DOPDATA_H
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "Op.h"
+#include "ops/OpArray.h"
+
+OCIO_NAMESPACE_ENTER
+{
+class Lut1DOpData;
+typedef OCIO_SHARED_PTR<Lut1DOpData> Lut1DOpDataRcPtr;
+typedef OCIO_SHARED_PTR<const Lut1DOpData> ConstLut1DOpDataRcPtr;
+
+class Lut1DOpData : public OpData
+{
+public:
+
+    // List of flags that describe 1-D LUT index and value encoding.
+    //
+    // 1-D LUT indices and values can either be expressed in standard numeric
+    // encodings or using half float codes.   Half float codes are 16 bit integer
+    // representations of a 16 bit floating point value. See:
+    // http://en.wikipedia.org/wiki/Half-precision_floating-point_format.
+    //
+    enum HalfFlags {
+        LUT_STANDARD = 0x00,         // Indices & values use standard encoding.
+        LUT_INPUT_HALF_CODE = 0x01,  // LUT indices are half float codes.
+        LUT_OUTPUT_HALF_CODE = 0x02, // LUT values are half float codes.
+
+        LUT_INPUT_OUTPUT_HALF_CODE =
+        LUT_INPUT_HALF_CODE
+        | LUT_OUTPUT_HALF_CODE       // Indices and values are half float codes.
+    };
+
+    // Enum to control optional hue restoration algorithm.
+    enum HueAdjust
+    {
+        HUE_NONE = 0, // No adjustment.
+        HUE_DW3       // Algorithm used in ACES Output Transforms through v0.7.
+    };
+
+    // Enumeration of the inverse 1D LUT styles.
+    enum InvStyle
+    {
+        INV_EXACT = 0,  // Exact, but slow, inverse processing.
+        INV_FAST        // Fast, but approximate, inverse processing.
+    };
+
+    // Contains properties needed for inversion of a single channel of a LUT.
+    struct ComponentProperties
+    {
+        ComponentProperties()
+            : isIncreasing(false)
+            , startDomain(0)
+            , endDomain(0)
+            , negStartDomain(0)
+            , negEndDomain(0) {}
+
+        bool isIncreasing;            // Represents the overall increasing state.
+        unsigned long startDomain;    // Is the lowest index such that LUT[start] != LUT[start+1].
+        unsigned long endDomain;      // Is the highest index such that LUT[end-1] != LUT[end].
+        unsigned long negStartDomain; // StartDomain for half-domain negative values.
+        unsigned long negEndDomain;   // EndDomain for half-domain negative values.
+    };
+
+    // Make an identity LUT with a domain suitable for pre-composing
+    // with this LUT so that a lookup may be done rather than interpolation.
+    static Lut1DOpDataRcPtr MakeLookupDomain(BitDepth incomingDepth);
+
+    // Control behavior of 1D LUT composition.
+    enum ComposeMethod
+    {
+        COMPOSE_RESAMPLE_NO = 0,      // Preserve original domain.
+        COMPOSE_RESAMPLE_INDEPTH = 1, // InDepth controls min size.
+        COMPOSE_RESAMPLE_BIG = 2      // Min size is 65536.
+    };
+
+    // Use functional composition to generate a single op that 
+    // approximates the effect of the pair of ops.
+    // A is used as in/out parameter. As input is it the first LUT in the composition,
+    // as output it is the result of the composition.
+    // B is the second LUT to compose and will not be modified.
+    static void Compose(Lut1DOpDataRcPtr & A,
+                        ConstLut1DOpDataRcPtr & B,
+                        ComposeMethod compFlag);
+
+    // Return the size to use for an identity LUT of the specified bit-depth.
+    static unsigned long GetLutIdealSize(BitDepth incomingBitDepth);
+
+    explicit Lut1DOpData(unsigned long dimension);
+    Lut1DOpData(BitDepth inBitDepth, BitDepth outBitDepth, HalfFlags halfFlags);
+
+    Lut1DOpData(BitDepth inBitDepth,
+                BitDepth outBitDepth,
+                const std::string & id,
+                const Descriptions & descriptions,
+                Interpolation interpolation,
+                HalfFlags halfFlags);
+
+    Lut1DOpData(BitDepth inBitDepth,
+                BitDepth outBitDepth,
+                const std::string & id,
+                const Descriptions & descriptions,
+                Interpolation interpolation,
+                HalfFlags halfFlags,
+                unsigned long dimension);
+
+    virtual ~Lut1DOpData();
+
+    inline Interpolation getInterpolation() const { return m_interpolation; }
+
+    // Get the interpolation algorithm that has to be used.
+    // INTERP_BEST and INTERP_DEFAULT are translated to what should be used.
+    Interpolation getConcreteInterpolation() const;
+
+    void setInterpolation(Interpolation algo);
+
+    TransformDirection getDirection() const { return m_direction; }
+
+    inline InvStyle getInvStyle() const { return m_invStyle; }
+
+    void setInvStyle(InvStyle style);
+
+    Type getType() const override { return Lut1DType; }
+
+    bool isNoOp() const override;
+
+    bool isIdentity() const override;
+
+    bool hasChannelCrosstalk() const override;
+
+    void setOutputBitDepth(BitDepth out) override;
+    void setInputBitDepth(BitDepth in) override;
+
+    // The file readers should call this to record the original scaling of the LUT values.
+    void setFileBitDepth(BitDepth depth)
+    {
+        m_fileBitDepth = depth;
+    }
+
+    void finalize() override;
+
+    // Check if the LUT is using half code indices as its domain.
+    // Return returns true if this LUT requires half code indices as input.
+    static inline bool IsInputHalfDomain(HalfFlags halfFlags)
+    {
+        return ((halfFlags & LUT_INPUT_HALF_CODE) ==
+                LUT_INPUT_HALF_CODE);
+    }
+    inline bool isInputHalfDomain() const
+    {
+        return IsInputHalfDomain(m_halfFlags);
+    }
+
+    // Note: this function is used by the xml reader to build the op and is
+    //       not intended for other use.
+    void setInputHalfDomain(bool isHalfDomain);
+
+    // Note: this function is used by the xml reader to build the op and is
+    //       not intended for other use.
+    void setOutputRawHalfs(bool isRawHalfs);
+
+    inline bool isOutputRawHalfs() const {
+        return ((m_halfFlags & LUT_OUTPUT_HALF_CODE) ==
+                LUT_OUTPUT_HALF_CODE);
+    }
+
+    inline HalfFlags getHalfFlags() const { return m_halfFlags; }
+
+    inline HueAdjust getHueAdjust() const { return m_hueAdjust; }
+
+    void setHueAdjust(HueAdjust algo);
+
+    // Get an array containing the LUT elements.
+    // The elements are stored as a vector [r0,g0,b0, r1,g1,b1, r2,g2,b2, ...].
+    inline const Array & getArray() const { return m_array; }
+
+    // Get an array containing the LUT elements.
+    // The elements are stored as a vector [r0,g0,b0, r1,g1,b1, r2,g2,b2, ...].
+    inline Array & getArray() { return m_array; }
+
+    void validate() const override;
+
+    virtual Lut1DOpDataRcPtr clone() const;
+
+    virtual Lut1DOpDataRcPtr inverse() const;
+
+    bool isInverse(ConstLut1DOpDataRcPtr & lut) const;
+
+    bool mayCompose(ConstLut1DOpDataRcPtr & B) const;
+
+    // Return true if this Lut1DOp applies the same LUT 
+    // to each of r, g, and b.
+    inline bool hasSingleLut() const
+    {
+        return (m_array.getNumColorComponents() == 1);
+    }
+
+    // Determine if the LUT has an appropriate domain to allow
+    // lookup rather than interpolation.
+    bool mayLookup(BitDepth incomingDepth) const;
+
+    bool operator==(const OpData & other) const;
+
+    OpDataRcPtr getIdentityReplacement() const;
+
+    // Make a forward Lut1DOpData that approximates the exact inverse
+    // Lut1DOpData to be used for the fast rendering style.
+    // LUT has to be inverse or the function will throw.
+    static Lut1DOpDataRcPtr MakeFastLut1DFromInverse(ConstLut1DOpDataRcPtr & lut, bool forGPU);
+
+    inline const ComponentProperties & getRedProperties() const
+    {
+        return m_componentProperties[0];
+    }
+
+    inline const ComponentProperties & getGreenProperties() const
+    {
+        return m_componentProperties[1];
+    }
+
+    inline const ComponentProperties & getBlueProperties() const
+    {
+        return m_componentProperties[2];
+    }
+
+private:
+    static bool IsInverse(const Lut1DOpData * lutfwd,
+                          const Lut1DOpData * lutinv);
+
+    Lut1DOpData() = delete;
+
+    // Test core parts of LUTs for equality.
+    bool haveEqualBasics(const Lut1DOpData & lut) const;
+
+    // For inverse LUT.
+
+    // Determine if the inverse LUT needs to handle values outside
+    // the normal domain: e.g. [0,1023] for 10i or [0.,1.] for 16f.
+    // (This is true if the forward LUT had an extended range.)
+    bool hasExtendedDomain() const;
+    void initializeFromForward();
+    // Make the array monotonic and prepare params for the renderer.
+    void prepareArray();
+
+    class Lut3by1DArray : public Array
+    {
+    public:
+        Lut3by1DArray(BitDepth  inBitDepth,
+                      BitDepth  outBitDepth,
+                      HalfFlags halfFlags);
+
+        Lut3by1DArray(BitDepth  outBitDepth,
+                      HalfFlags halfFlags,
+                      unsigned long length);
+
+        ~Lut3by1DArray();
+
+        bool isIdentity(HalfFlags halfFlags, BitDepth outBitDepth) const;
+
+        unsigned long getNumValues() const override;
+
+        void scale(float scaleFactor);
+
+    protected:
+        // Fill the LUT 1D with appropriate default values 
+        // representing an identity LUT.
+        void fill(HalfFlags halfFlags, BitDepth outBitDepth);
+
+    public:
+        // Default copy constructor and assignation operator are fine.
+        Lut3by1DArray() = default;
+        Lut3by1DArray(const Lut3by1DArray &) = default;
+        Lut3by1DArray & operator= (const Lut3by1DArray &) = default;
+    };
+
+    // Get the LUT length that would allow a look-up for inputBitDepth.
+    // - halfFlags except if the LUT has a half domain, always return 65536
+    static unsigned long GetLutIdealSize(BitDepth inputBitDepth,
+                                         HalfFlags halfFlags);
+
+    Interpolation       m_interpolation;
+    Lut3by1DArray       m_array;
+    HalfFlags           m_halfFlags;
+    HueAdjust           m_hueAdjust;
+                        
+    TransformDirection  m_direction;
+
+    // Members for inverse LUT.
+    InvStyle            m_invStyle;
+
+    ComponentProperties m_componentProperties[3];
+
+    // The original LUT scaling from the file.
+    // Must be set by the file reader.
+    // Note: This is hopefully only needed temporarily.
+    //       Used in MakeFastLut1DFromInverse.
+    BitDepth            m_fileBitDepth;
+
+};
+
+}
+OCIO_NAMESPACE_EXIT
+
+#endif

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOpGPU.cpp
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOpGPU.cpp
@@ -1,0 +1,409 @@
+/*
+Copyright (c) 2018 Autodesk Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <algorithm>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "GpuShaderUtils.h"
+#include "MathUtils.h"
+#include "ops/Lut1D/Lut1DOpGPU.h"
+
+OCIO_NAMESPACE_ENTER
+{
+
+namespace
+{
+void PadLutChannels(unsigned long width,
+                    unsigned long height,
+                    const std::vector<float> & channel,
+                    std::vector<float> & chn)
+{
+    const unsigned long currWidth = (unsigned long)(channel.size() / 3);
+
+    if (height>1)
+    {
+        // Fill the texture values.
+        //
+        // Make the last texel of a given row the same as the first texel 
+        // of its next row.  This will preserve the continuity along row breaks 
+        // as long as the lookup position used by the sampler is based on (width-1) 
+        // to account for the 1 texel padding at the end of each row.
+        unsigned long leftover = currWidth;
+
+        const unsigned long step = width - 1;
+        for (unsigned long i = 0; i < (currWidth - step); i += step)
+        {
+            chn.insert(chn.end(), &channel[3 * i], &channel[3 * (i + step)]);
+
+            chn.push_back(channel[3 * (i + step) + 0]);
+            chn.push_back(channel[3 * (i + step) + 1]);
+            chn.push_back(channel[3 * (i + step) + 2]);
+            leftover -= step;
+        }
+
+        // If there are still texels to fill, add them to the texture data.
+        if (leftover > 0)
+        {
+            chn.insert(chn.end(),
+                       &channel[3 * (currWidth - leftover)],
+                       &channel[3 * (currWidth - 1)]);
+
+            chn.push_back(channel[3 * (currWidth - 1) + 0]);
+            chn.push_back(channel[3 * (currWidth - 1) + 1]);
+            chn.push_back(channel[3 * (currWidth - 1) + 2]);
+        }
+    }
+    else
+    {
+        chn = channel;
+    }
+
+    // Pad the remaining of the texture with the last LUT entry.
+    // Note: GPU Textures are expected a size of width*height.
+
+    unsigned long missingEntries = width*height - (chn.size() / 3);
+    for (unsigned long idx = 0; idx < missingEntries; ++idx)
+    {
+        chn.push_back(channel[3 * (currWidth - 1) + 0]);
+        chn.push_back(channel[3 * (currWidth - 1) + 1]);
+        chn.push_back(channel[3 * (currWidth - 1) + 2]);
+    }
+}
+}
+
+void GetLut1DGPUShaderProgram(GpuShaderDescRcPtr & shaderDesc,
+                              ConstLut1DOpDataRcPtr & lutData)
+{
+    const unsigned long defaultMaxWidth = shaderDesc->getTextureMaxWidth();
+
+    const unsigned long length = lutData->getArray().getLength();
+    const unsigned long width = std::min(length, defaultMaxWidth);
+    const unsigned long height = (length / defaultMaxWidth) + 1;
+
+    // Adjust LUT texture to allow for correct 2d linear interpolation, if needed.
+
+    std::vector<float> values;
+    PadLutChannels(width, height, lutData->getArray().getValues(), values);
+
+    // Register the RGB LUT
+
+    std::ostringstream resName;
+    resName << shaderDesc->getResourcePrefix()
+            << std::string("lut1d_")
+            << shaderDesc->getNumTextures();
+
+    const std::string name(resName.str());
+    
+    shaderDesc->addTexture(GpuShaderText::getSamplerName(name).c_str(),
+                           lutData->getCacheID().c_str(),
+                           width, height,
+                           GpuShaderDesc::TEXTURE_RGB_CHANNEL,
+                           lutData->getConcreteInterpolation(),
+                           &values[0]);
+
+    // Add the LUT code to the OCIO shader program.
+
+    if (height > 1 || lutData->isInputHalfDomain())
+    {
+        // In case the 1D LUT length exceeds the 1D texture maximum length
+        // a 2D texture is used.
+
+        {
+            GpuShaderText ss(shaderDesc->getLanguage());
+            ss.declareTex2D(name);
+            shaderDesc->addToDeclareShaderCode(ss.string().c_str());
+        }
+
+        {
+            GpuShaderText ss(shaderDesc->getLanguage());
+
+            ss.newLine() << ss.vec2fKeyword() << " " << name << "_computePos(float f)";
+            ss.newLine() << "{";
+            ss.indent();
+
+            if (lutData->isInputHalfDomain())
+            {
+                static const float NEG_MIN_EXP = 15.0f;
+                static const float EXP_SCALE = 1024.0f;
+                static const float HALF_DENRM_MAX = 6.09755515e-05f;  // e.g. 2^-14 - 2^-24
+
+                ss.newLine() << "float dep;";
+                ss.newLine() << "float abs_f = abs(f);";
+                ss.newLine() << "if (abs_f > " << (float)HALF_NRM_MIN << ")";
+                ss.newLine() << "{";
+                ss.indent();
+                ss.declareVec3f("fComp", NEG_MIN_EXP, NEG_MIN_EXP, NEG_MIN_EXP);
+                ss.newLine() << "float absarr = min( abs_f, " << (float)HALF_MAX << ");";
+                // Compute the exponent, scaled [-14,15].
+                ss.newLine() << "fComp.x = floor( log2( absarr ) );";
+                // Lower is the greatest power of 2 <= f.
+                ss.newLine() << "float lower = pow( 2.0, fComp.x );";
+                // Compute the mantissa (scaled [0-1]).
+                ss.newLine() << "fComp.y = ( absarr - lower ) / lower;";
+                // The dot product recombines the parts into a raw half without the sign component:
+                //   dep = [ exponent + mantissa + NEG_MIN_EXP] * scale
+                ss.declareVec3f("scale", EXP_SCALE, EXP_SCALE, EXP_SCALE);
+                ss.newLine() << "dep = dot( fComp, scale );";
+                ss.dedent();
+                ss.newLine() << "}";
+                ss.newLine() << "else";
+                ss.newLine() << "{";
+                ss.indent();
+                // Extract bits from denormalized values
+                ss.newLine() << "dep = abs_f * 1023.0 / " << HALF_DENRM_MAX << ";";
+                ss.dedent();
+                ss.newLine() << "}";
+
+                // Adjust position for negative values
+                ss.newLine() << "dep += step(f, 0.0) * 32768.0;";
+
+                // At this point 'dep' contains the raw half
+                // Note: Raw halfs for NaN floats cannot be computed using
+                //       floating-point operations.
+                ss.newLine() << ss.vec2fDecl("retVal") << ";";
+                ss.newLine() << "retVal.y = floor(dep / " << float(width - 1) << ");";       // floor( dep / (width-1) ))
+                ss.newLine() << "retVal.x = dep - retVal.y * " << float(width - 1) << ";";   // dep - retVal.y * (width-1)
+
+                ss.newLine() << "retVal.x = (retVal.x + 0.5) / " << float(width) << ";";   // (retVal.x + 0.5) / width;
+                ss.newLine() << "retVal.y = (retVal.y + 0.5) / " << float(height) << ";";  // (retVal.x + 0.5) / height;
+            }
+            else
+            {
+                // Need min() to protect against f > 1 causing a bogus x value.
+                // min( f, 1.) * (dim - 1)
+                ss.newLine() << "float dep = min(f, 1.0) * " << float(length - 1) << ";";
+
+                ss.newLine() << ss.vec2fDecl("retVal") << ";";
+                // float(int( dep / (width-1) ))
+                ss.newLine() << "retVal.y = float(int(dep / " << float(width - 1) << "));";
+                // dep - retVal.y * (width-1)
+                ss.newLine() << "retVal.x = dep - retVal.y * " << float(width - 1) << ";";
+
+                // (retVal.x + 0.5) / width;
+                ss.newLine() << "retVal.x = (retVal.x + 0.5) / " << float(width) << ";";
+                // (retVal.x + 0.5) / height;
+                ss.newLine() << "retVal.y = (retVal.y + 0.5) / " << float(height) << ";";
+            }
+
+            ss.newLine() << "return retVal;";
+            ss.dedent();
+            ss.newLine() << "}";
+
+            shaderDesc->addToHelperShaderCode(ss.string().c_str());
+        }
+    }
+    else
+    {
+        GpuShaderText ss(shaderDesc->getLanguage());
+        ss.declareTex1D(name);
+        shaderDesc->addToDeclareShaderCode(ss.string().c_str());
+    }
+
+    GpuShaderText ss(shaderDesc->getLanguage());
+    ss.indent();
+
+    ss.newLine() << "";
+    ss.newLine() << "// Add a LUT 1D processing for " << name;
+    ss.newLine() << "";
+
+    ss.newLine() << "{";
+    ss.indent();
+
+    if (lutData->getHueAdjust() == Lut1DOpData::HUE_DW3)
+    {
+        ss.newLine() << "// Add the pre hue adjustment";
+        ss.newLine() << ss.vec3fDecl("maxval")
+                        << " = max(" << shaderDesc->getPixelName() << ".rgb, max("
+                        << shaderDesc->getPixelName() << ".gbr, " << shaderDesc->getPixelName() << ".brg));";
+        ss.newLine() << ss.vec3fDecl("minval")
+                        << " = min(" << shaderDesc->getPixelName() << ".rgb, min("
+                        << shaderDesc->getPixelName() << ".gbr, " << shaderDesc->getPixelName() << ".brg));";
+        ss.newLine() << "float oldChroma = max(1e-8, maxval.r - minval.r);";
+        ss.newLine() << ss.vec3fDecl("delta") << " = " << shaderDesc->getPixelName() << ".rgb - minval;";
+        ss.newLine() << "";
+    }
+
+    if (height > 1 || lutData->isInputHalfDomain())
+    {
+        const std::string str = name + "_computePos(" + shaderDesc->getPixelName();
+
+        ss.newLine() << shaderDesc->getPixelName() << ".r = " << ss.sampleTex2D(name, str + ".r)") << ".r;";
+        ss.newLine() << shaderDesc->getPixelName() << ".g = " << ss.sampleTex2D(name, str + ".g)") << ".g;";
+        ss.newLine() << shaderDesc->getPixelName() << ".b = " << ss.sampleTex2D(name, str + ".b)") << ".b;";
+    }
+    else
+    {
+        const float dim = (float)lutData->getArray().getLength();
+
+        ss.newLine() << ss.vec3fDecl(name + "_coords")
+                        << " = (" << shaderDesc->getPixelName() << ".rgb * "
+                        << ss.vec3fConst(dim - 1)
+                        << " + " << ss.vec3fConst(0.5f) << " ) / "
+                        << ss.vec3fConst(dim) << ";";
+
+        ss.newLine() << shaderDesc->getPixelName() << ".r = "
+                        << ss.sampleTex1D(name, name + "_coords.r") << ".r;";
+        ss.newLine() << shaderDesc->getPixelName() << ".g = "
+                        << ss.sampleTex1D(name, name + "_coords.g") << ".g;";
+        ss.newLine() << shaderDesc->getPixelName() << ".b = "
+                        << ss.sampleTex1D(name, name + "_coords.b") << ".b;";
+    }
+
+    if (lutData->getHueAdjust() == Lut1DOpData::HUE_DW3)
+    {
+        ss.newLine() << "";
+        ss.newLine() << "// Add the post hue adjustment";
+        ss.newLine() << ss.vec3fDecl("maxval2") << " = max(" << shaderDesc->getPixelName()
+                        << ".rgb, max(" << shaderDesc->getPixelName() << ".gbr, "
+                        << shaderDesc->getPixelName() << ".brg));";
+        ss.newLine() << ss.vec3fDecl("minval2") << " = min(" << shaderDesc->getPixelName()
+                        << ".rgb, min(" << shaderDesc->getPixelName() << ".gbr, "
+                        << shaderDesc->getPixelName() << ".brg));";
+        ss.newLine() << "float newChroma = maxval2.r - minval2.r;";
+        ss.newLine() << shaderDesc->getPixelName()
+                        << ".rgb = minval2.r + delta * newChroma / oldChroma;";
+    }
+
+    ss.dedent();
+    ss.newLine() << "}";
+
+    shaderDesc->addToFunctionShaderCode(ss.string().c_str());
+
+}
+
+
+}
+OCIO_NAMESPACE_EXIT
+
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef OCIO_UNIT_TEST
+
+namespace OCIO = OCIO_NAMESPACE;
+#include "unittest.h"
+
+OIIO_ADD_TEST(Lut1DOp, pad_lut_one_dimension)
+{
+    const unsigned width = 6;
+
+    // Create a channel multi row and smaller than the expected texture size.
+
+    std::vector<float> channel;
+    channel.resize((width - 2) * 3);
+
+    // Fill the channel.
+
+    for (unsigned idx = 0; idx<channel.size() / 3; ++idx)
+    {
+        channel[3*idx] = float(idx);
+        channel[3*idx + 1] = float(idx) + 0.1f;
+        channel[3*idx + 2] = float(idx) + 0.2f;
+    }
+
+    // Pad the texture values.
+
+    std::vector<float> chn;
+    OIIO_CHECK_NO_THROW(OCIO::PadLutChannels(width, 1, channel, chn));
+
+    // Check the values.
+
+    const float res[18] = { 0.0f, 0.1f, 0.2f, 1.0f, 1.1f, 1.2f,
+                            2.0f, 2.1f, 2.2f, 3.0f, 3.1f, 3.2f,
+                            3.0f, 3.1f, 3.2f, 3.0f, 3.1f, 3.2f };
+    OIIO_CHECK_EQUAL(chn.size(), 18);
+    for (unsigned idx = 0; idx<chn.size(); ++idx)
+    {
+        OIIO_CHECK_EQUAL(chn[idx], res[idx]);
+    }
+}
+
+OIIO_ADD_TEST(Lut1DOp, pad_lut_two_dimension_1)
+{
+    const unsigned width = 4;
+    const unsigned height = 3;
+
+    std::vector<float> channel;
+    channel.resize((height * width - 4) * 3);
+
+    for (unsigned idx = 0; idx<channel.size() / 3; ++idx)
+    {
+        channel[3 * idx] = float(idx);
+        channel[3 * idx + 1] = float(idx) + 0.1f;
+        channel[3 * idx + 2] = float(idx) + 0.2f;
+    }
+
+    std::vector<float> chn;
+    OIIO_CHECK_NO_THROW(OCIO::PadLutChannels(width, height, channel, chn));
+
+    const float res[] = {
+        0.0f, 0.1f, 0.2f, 1.0f, 1.1f, 1.2f, 2.0f, 2.1f, 2.2f, 3.0f, 3.1f, 3.2f,
+        3.0f, 3.1f, 3.2f, 4.0f, 4.1f, 4.2f, 5.0f, 5.1f, 5.2f, 6.0f, 6.1f, 6.2f, 
+        6.0f, 6.1f, 6.2f, 7.0f, 7.1f, 7.2f, 7.0f, 7.1f, 7.2f, 7.0f, 7.1f, 7.2f };
+    OIIO_CHECK_EQUAL(chn.size(), 36);
+    for (unsigned idx = 0; idx<chn.size(); ++idx)
+    {
+        OIIO_CHECK_EQUAL(chn[idx], res[idx]);
+    }
+}
+
+OIIO_ADD_TEST(Lut1DOp, pad_lut_two_dimension_2)
+{
+    const unsigned width = 4;
+    const unsigned height = 3;
+
+    std::vector<float> channel;
+    channel.resize((height * width - 3) * 3);
+
+    for (unsigned idx = 0; idx<channel.size() / 3; ++idx)
+    {
+        channel[3 * idx] = float(idx);
+        channel[3 * idx + 1] = float(idx) + 0.1f;
+        channel[3 * idx + 2] = float(idx) + 0.2f;
+    }
+
+    // Special case where size%(width-1) = 0
+    std::vector<float> chn;
+    OIIO_CHECK_NO_THROW(OCIO::PadLutChannels(width, height, channel, chn));
+
+    // Check the values
+
+    const float res[] = {
+        0.0f, 0.1f, 0.2f, 1.0f, 1.1f, 1.2f, 2.0f, 2.1f, 2.2f, 3.0f, 3.1f, 3.2f,
+        3.0f, 3.1f, 3.2f, 4.0f, 4.1f, 4.2f, 5.0f, 5.1f, 5.2f, 6.0f, 6.1f, 6.2f,
+        6.0f, 6.1f, 6.2f, 7.0f, 7.1f, 7.2f, 8.0f, 8.1f, 8.2f, 8.0f, 8.1f, 8.2f };
+    
+    OIIO_CHECK_EQUAL(chn.size(), 36);
+
+    for (unsigned idx = 0; idx<chn.size(); ++idx)
+    {
+        OIIO_CHECK_EQUAL(chn[idx], res[idx]);
+    }
+}
+
+#endif

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOpGPU.cpp
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOpGPU.cpp
@@ -87,7 +87,7 @@ void PadLutChannels(unsigned long width,
     // Pad the remaining of the texture with the last LUT entry.
     // Note: GPU Textures are expected a size of width*height.
 
-    unsigned long missingEntries = width*height - (chn.size() / 3);
+    unsigned long missingEntries = width*height - ((unsigned long)chn.size() / 3);
     for (unsigned long idx = 0; idx < missingEntries; ++idx)
     {
         chn.push_back(channel[3 * (currWidth - 1) + 0]);

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOpGPU.h
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOpGPU.h
@@ -1,0 +1,52 @@
+/*
+Copyright (c) 2018 Autodesk Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+#ifndef INCLUDED_OCIO_LUT1D_GPU
+#define INCLUDED_OCIO_LUT1D_GPU
+
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "GpuShaderUtils.h"
+#include "ops/Lut1D/Lut1DOpData.h"
+
+
+OCIO_NAMESPACE_ENTER
+{
+
+void GetLut1DGPUShaderProgram(GpuShaderDescRcPtr & shaderDesc,
+                              ConstLut1DOpDataRcPtr & lutData);
+
+}
+OCIO_NAMESPACE_EXIT
+
+
+#endif
+
+

--- a/src/OpenColorIO/ops/Lut3D/Lut3DOpCPU.cpp
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOpCPU.cpp
@@ -1962,7 +1962,7 @@ OpCPURcPtr GetLut3DRenderer(ConstLut3DOpDataRcPtr & lut)
             // Render with a Lut3D renderer.
             return GetForwardLut3DRenderer(newLut);
         }
-        else  // EXACT
+        else  // INV_EXACT
         {
             return std::make_shared<InvLut3DRenderer>(lut);
         }

--- a/src/OpenColorIO/ops/Lut3D/Lut3DOpCPU.cpp
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOpCPU.cpp
@@ -1962,7 +1962,7 @@ OpCPURcPtr GetLut3DRenderer(ConstLut3DOpDataRcPtr & lut)
             // Render with a Lut3D renderer.
             return GetForwardLut3DRenderer(newLut);
         }
-        else  // INV_EXACT
+        else  // EXACT
         {
             return std::make_shared<InvLut3DRenderer>(lut);
         }

--- a/src/OpenColorIO/ops/Lut3D/Lut3DOpData.cpp
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOpData.cpp
@@ -71,8 +71,13 @@ Lut3DOpDataRcPtr MakeFastLut3DFromInverse(ConstLut3DOpDataRcPtr & lut)
 {
     if (lut->getDirection() != TRANSFORM_DIR_INVERSE)
     {
-        throw Exception("MakeFastLut3DFromInverse expects an inverse LUT");
+        throw Exception("MakeFastLut3DFromInverse expect an inverse LUT");
     }
+
+    // The composition needs to use the EXACT renderer.
+    // (Also avoids infinite loop.)
+    // So temporarily set the style to EXACT.
+    Lut3DStyleGuard guard(lut);
 
     // Make a domain for the composed Lut3D.
     // TODO: Using a large number like 48 here is better for accuracy, 
@@ -85,21 +90,17 @@ Lut3DOpDataRcPtr MakeFastLut3DFromInverse(ConstLut3DOpDataRcPtr & lut)
     newDomain->setInputBitDepth(lut->getInputBitDepth());
     newDomain->setOutputBitDepth(lut->getInputBitDepth());
 
-    // The composition needs to use the INV_EXACT renderer.
-    // (Also avoids infinite loop.)
-    // So temporarily set the style to INV_EXACT.
-    Lut3DStyleGuard guard(lut);
-
+    ConstLut3DOpDataRcPtr constNewDomain = newDomain;
     // Compose the LUT newDomain with our inverse LUT (using INV_EXACT style).
-    Lut3DOpData::Compose(newDomain, lut);
+    Lut3DOpDataRcPtr newLut(Lut3DOpData::Compose(constNewDomain, lut));
 
-    // The INV_EXACT inversion style computes an inverse to the tetrahedral
+    // The EXACT inversion style computes an inverse to the tetrahedral
     // style of forward evalutation.
     // TODO: Although this seems like the "correct" thing to do, it does
     // not seem to help accuracy (and is slower).  To investigate ...
     //newLut->setInterpolation(INTERP_TETRAHEDRAL);
 
-    return newDomain;
+    return newLut;
 }
 
 const unsigned long Lut3DOpData::maxSupportedLength = 129;
@@ -114,8 +115,8 @@ const unsigned long Lut3DOpData::maxSupportedLength = 129;
 // needs to render values through the ops.  In some cases the domain of
 // the first op is sufficient, in other cases we need to create a new more
 // finely sampled domain to try and make the result less lossy.
-void Lut3DOpData::Compose(Lut3DOpDataRcPtr & A,
-                          ConstLut3DOpDataRcPtr & B)
+Lut3DOpDataRcPtr Lut3DOpData::Compose(ConstLut3DOpDataRcPtr & A,
+                                      ConstLut3DOpDataRcPtr & B)
 {
     // TODO: Composition of LUTs is a potentially lossy operation.
     // We try to be safe by making the result at least as big as either A or B
@@ -162,7 +163,8 @@ void Lut3DOpData::Compose(Lut3DOpDataRcPtr & A,
                                                min_sz);
 
         // Interpolate through both LUTs in this case (resample).
-        CreateLut3DOp(ops, A, TRANSFORM_DIR_FORWARD);
+        Lut3DOpDataRcPtr clonedA = A->clone();
+        CreateLut3DOp(ops, clonedA, TRANSFORM_DIR_FORWARD);
     }
 
     // TODO: Would like to not require a clone simply to prevent the delete
@@ -178,19 +180,19 @@ void Lut3DOpData::Compose(Lut3DOpDataRcPtr & A,
     OpData::Descriptions newDesc = A->getDescriptions();
     newDesc += B->getDescriptions();
     // TODO: May want to revisit metadata propagation.
-    A = std::make_shared<Lut3DOpData>(A->getInputBitDepth(),
-                                      B->getOutputBitDepth(),
-                                      A->getId() + B->getId(),
-                                      newDesc,
-                                      A->getInterpolation(),
-                                      2);  // we replace it anyway
+    Lut3DOpDataRcPtr result = std::make_shared<Lut3DOpData>(A->getInputBitDepth(),
+                                                            B->getOutputBitDepth(),
+                                                            A->getId() + B->getId(),
+                                                            newDesc,
+                                                            A->getInterpolation(),
+                                                            2);  // we replace it anyway
 
     const Array::Values& inValues = domain->getArray().getValues();
     const long gridSize = domain->getArray().getLength();
     const long numPixels = gridSize * gridSize * gridSize;
 
-    A->getArray().resize(gridSize, 3);
-    Array::Values& outValues = A->getArray().getValues();
+    result->getArray().resize(gridSize, 3);
+    Array::Values& outValues = result->getArray().getValues();
 
     EvalTransform((const float*)(&inValues[0]),
                   (float*)(&outValues[0]),
@@ -198,6 +200,8 @@ void Lut3DOpData::Compose(Lut3DOpDataRcPtr & A,
                   ops);
 
     // TODO: Code to handle dynamic properties should go here.
+
+    return result;
 }
 
 Lut3DOpData::Lut3DArray::Lut3DArray(long length,
@@ -592,28 +596,6 @@ Lut3DOpDataRcPtr Lut3DOpData::inverse() const
     return invLut;
 }
 
-namespace
-{
-const char* GetInvStyleName(Lut3DOpData::InvStyle invStyle)
-{
-    switch (invStyle)
-    {
-    case Lut3DOpData::INV_EXACT:
-    {
-        return "exact";
-        break;
-    }
-    case Lut3DOpData::INV_FAST:
-    {
-        return "fast";
-        break;
-    }
-    }
-
-    throw Exception("3D LUT has an invalid inverse style.");
-}
-}
-
 void Lut3DOpData::finalize()
 {
     AutoMutex lock(m_mutex);
@@ -632,8 +614,7 @@ void Lut3DOpData::finalize()
     cacheIDStream << InterpolationToString(m_interpolation) << " ";
     cacheIDStream << TransformDirectionToString(m_direction) << " ";
     cacheIDStream << BitDepthToString(getInputBitDepth()) << " ";
-    cacheIDStream << BitDepthToString(getOutputBitDepth()) << " ";
-    cacheIDStream << GetInvStyleName(m_invStyle);
+    cacheIDStream << BitDepthToString(getOutputBitDepth());
 
     m_cacheID = cacheIDStream.str();
 }
@@ -988,8 +969,8 @@ OIIO_ADD_TEST(OpDataLut3D, ComposeTest)
     OIIO_REQUIRE_ASSERT(lutData0);
     OIIO_REQUIRE_ASSERT(lutData1);
 
-    OCIO::Lut3DOpDataRcPtr composed = lutData0->clone();
-    OCIO::Lut3DOpData::Compose(composed, lutData1);
+    OCIO::Lut3DOpDataRcPtr composed =
+        OCIO::Lut3DOpData::Compose(lutData0, lutData1);
 
     OIIO_CHECK_EQUAL(composed->getArray().getLength(), (unsigned long)32);
     OIIO_CHECK_EQUAL(composed->getArray().getNumColorComponents(),

--- a/src/OpenColorIO/ops/Lut3D/Lut3DOpData.cpp
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOpData.cpp
@@ -71,13 +71,8 @@ Lut3DOpDataRcPtr MakeFastLut3DFromInverse(ConstLut3DOpDataRcPtr & lut)
 {
     if (lut->getDirection() != TRANSFORM_DIR_INVERSE)
     {
-        throw Exception("MakeFastLut3DFromInverse expect an inverse LUT");
+        throw Exception("MakeFastLut3DFromInverse expectS an inverse LUT");
     }
-
-    // The composition needs to use the EXACT renderer.
-    // (Also avoids infinite loop.)
-    // So temporarily set the style to EXACT.
-    Lut3DStyleGuard guard(lut);
 
     // Make a domain for the composed Lut3D.
     // TODO: Using a large number like 48 here is better for accuracy, 
@@ -90,68 +85,24 @@ Lut3DOpDataRcPtr MakeFastLut3DFromInverse(ConstLut3DOpDataRcPtr & lut)
     newDomain->setInputBitDepth(lut->getInputBitDepth());
     newDomain->setOutputBitDepth(lut->getInputBitDepth());
 
-    ConstLut3DOpDataRcPtr constNewDomain = newDomain;
-    // Compose the LUT newDomain with our inverse LUT (using INV_EXACT style).
-    Lut3DOpDataRcPtr newLut(Lut3DOpData::Compose(constNewDomain, lut));
+    // The composition needs to use the INV_EXACT renderer.
+    // (Also avoids infinite loop.)
+    // So temporarily set the style to INV_EXACT.
+    Lut3DStyleGuard guard(lut);
 
-    // The EXACT inversion style computes an inverse to the tetrahedral
+    // Compose the LUT newDomain with our inverse LUT (using INV_EXACT style).
+    Lut3DOpData::Compose(newDomain, lut);
+
+    // The INV_EXACT inversion style computes an inverse to the tetrahedral
     // style of forward evalutation.
     // TODO: Although this seems like the "correct" thing to do, it does
     // not seem to help accuracy (and is slower).  To investigate ...
     //newLut->setInterpolation(INTERP_TETRAHEDRAL);
 
-    return newLut;
+    return newDomain;
 }
 
 const unsigned long Lut3DOpData::maxSupportedLength = 129;
-
-namespace
-{
-void EvalTransform(const float * in,
-                   float * out,
-                   long numPixels,
-                   OpRcPtrVec & ops)
-{
-    std::vector<float> tmp(numPixels * 4);
-
-    // Render the LUT entries (domain) through the ops.
-
-    const float * values = in;
-    for (long idx = 0; idx<numPixels; ++idx)
-    {
-        tmp[4 * idx + 0] = values[0];
-        tmp[4 * idx + 1] = values[1];
-        tmp[4 * idx + 2] = values[2];
-        tmp[4 * idx + 3] = 1.0f;
-
-        values += 3;
-    }
-
-    // NB: We assume finalize will set the bit-depth at each op interface
-    // to 32f so there is never any quantization to integer.
-    // Furthermore, to avoid improper recursion we must never call
-    // the renderer with an integer input depth.
-    // TODO: Currently the OCIO finalize is hard-coded to 32f.
-    //       When that changes we need to update this to request 32f input
-    //       and output bit depths.
-    FinalizeOpVec(ops);
-
-    for (OpRcPtrVec::size_type i = 0, size = ops.size(); i<size; ++i)
-    {
-        ops[i]->apply(&tmp[0], numPixels);
-    }
-
-    float * result = out;
-    for (long idx = 0; idx<numPixels; ++idx)
-    {
-        result[0] = tmp[4 * idx + 0];
-        result[1] = tmp[4 * idx + 1];
-        result[2] = tmp[4 * idx + 2];
-
-        result += 3;
-    }
-}
-}
 
 // Functional composition is a concept from mathematics where two functions
 // are combined into a single function.  This idea may be applied to ops
@@ -163,8 +114,8 @@ void EvalTransform(const float * in,
 // needs to render values through the ops.  In some cases the domain of
 // the first op is sufficient, in other cases we need to create a new more
 // finely sampled domain to try and make the result less lossy.
-Lut3DOpDataRcPtr Lut3DOpData::Compose(ConstLut3DOpDataRcPtr & A,
-                                      ConstLut3DOpDataRcPtr & B)
+void Lut3DOpData::Compose(Lut3DOpDataRcPtr & A,
+                          ConstLut3DOpDataRcPtr & B)
 {
     // TODO: Composition of LUTs is a potentially lossy operation.
     // We try to be safe by making the result at least as big as either A or B
@@ -211,8 +162,7 @@ Lut3DOpDataRcPtr Lut3DOpData::Compose(ConstLut3DOpDataRcPtr & A,
                                                min_sz);
 
         // Interpolate through both LUTs in this case (resample).
-        Lut3DOpDataRcPtr clonedA = A->clone();
-        CreateLut3DOp(ops, clonedA, TRANSFORM_DIR_FORWARD);
+        CreateLut3DOp(ops, A, TRANSFORM_DIR_FORWARD);
     }
 
     // TODO: Would like to not require a clone simply to prevent the delete
@@ -228,19 +178,19 @@ Lut3DOpDataRcPtr Lut3DOpData::Compose(ConstLut3DOpDataRcPtr & A,
     OpData::Descriptions newDesc = A->getDescriptions();
     newDesc += B->getDescriptions();
     // TODO: May want to revisit metadata propagation.
-    Lut3DOpDataRcPtr result = std::make_shared<Lut3DOpData>(A->getInputBitDepth(),
-                                                            B->getOutputBitDepth(),
-                                                            A->getId() + B->getId(),
-                                                            newDesc,
-                                                            A->getInterpolation(),
-                                                            2);  // we replace it anyway
+    A = std::make_shared<Lut3DOpData>(A->getInputBitDepth(),
+                                      B->getOutputBitDepth(),
+                                      A->getId() + B->getId(),
+                                      newDesc,
+                                      A->getInterpolation(),
+                                      2);  // we replace it anyway
 
     const Array::Values& inValues = domain->getArray().getValues();
     const long gridSize = domain->getArray().getLength();
     const long numPixels = gridSize * gridSize * gridSize;
 
-    result->getArray().resize(gridSize, 3);
-    Array::Values& outValues = result->getArray().getValues();
+    A->getArray().resize(gridSize, 3);
+    Array::Values& outValues = A->getArray().getValues();
 
     EvalTransform((const float*)(&inValues[0]),
                   (float*)(&outValues[0]),
@@ -248,8 +198,6 @@ Lut3DOpDataRcPtr Lut3DOpData::Compose(ConstLut3DOpDataRcPtr & A,
                   ops);
 
     // TODO: Code to handle dynamic properties should go here.
-
-    return result;
 }
 
 Lut3DOpData::Lut3DArray::Lut3DArray(long length,
@@ -644,6 +592,28 @@ Lut3DOpDataRcPtr Lut3DOpData::inverse() const
     return invLut;
 }
 
+namespace
+{
+const char* GetInvStyleName(Lut3DOpData::InvStyle invStyle)
+{
+    switch (invStyle)
+    {
+    case Lut3DOpData::INV_EXACT:
+    {
+        return "exact";
+        break;
+    }
+    case Lut3DOpData::INV_FAST:
+    {
+        return "fast";
+        break;
+    }
+    }
+
+    throw Exception("3D LUT has an invalid inverse style.");
+}
+}
+
 void Lut3DOpData::finalize()
 {
     AutoMutex lock(m_mutex);
@@ -662,7 +632,8 @@ void Lut3DOpData::finalize()
     cacheIDStream << InterpolationToString(m_interpolation) << " ";
     cacheIDStream << TransformDirectionToString(m_direction) << " ";
     cacheIDStream << BitDepthToString(getInputBitDepth()) << " ";
-    cacheIDStream << BitDepthToString(getOutputBitDepth());
+    cacheIDStream << BitDepthToString(getOutputBitDepth()) << " ";
+    cacheIDStream << GetInvStyleName(m_invStyle);
 
     m_cacheID = cacheIDStream.str();
 }
@@ -1017,8 +988,8 @@ OIIO_ADD_TEST(OpDataLut3D, ComposeTest)
     OIIO_REQUIRE_ASSERT(lutData0);
     OIIO_REQUIRE_ASSERT(lutData1);
 
-    OCIO::Lut3DOpDataRcPtr composed =
-        OCIO::Lut3DOpData::Compose(lutData0, lutData1);
+    OCIO::Lut3DOpDataRcPtr composed = lutData0->clone();
+    OCIO::Lut3DOpData::Compose(composed, lutData1);
 
     OIIO_CHECK_EQUAL(composed->getArray().getLength(), (unsigned long)32);
     OIIO_CHECK_EQUAL(composed->getArray().getNumColorComponents(),

--- a/src/OpenColorIO/ops/Lut3D/Lut3DOpData.cpp
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOpData.cpp
@@ -71,7 +71,7 @@ Lut3DOpDataRcPtr MakeFastLut3DFromInverse(ConstLut3DOpDataRcPtr & lut)
 {
     if (lut->getDirection() != TRANSFORM_DIR_INVERSE)
     {
-        throw Exception("MakeFastLut3DFromInverse expectS an inverse LUT");
+        throw Exception("MakeFastLut3DFromInverse expects an inverse LUT");
     }
 
     // Make a domain for the composed Lut3D.

--- a/src/OpenColorIO/ops/Lut3D/Lut3DOpData.h
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOpData.h
@@ -66,8 +66,8 @@ public:
 
     // Use functional composition to generate a single op that 
     // approximates the effect of the pair of ops.
-    static Lut3DOpDataRcPtr Compose(ConstLut3DOpDataRcPtr & A,
-                                    ConstLut3DOpDataRcPtr & B);
+    static void Compose(Lut3DOpDataRcPtr & A,
+                        ConstLut3DOpDataRcPtr & B);
 
 public:
     // The gridSize parameter is the length of the cube axis.

--- a/src/OpenColorIO/ops/Lut3D/Lut3DOpData.h
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOpData.h
@@ -66,8 +66,8 @@ public:
 
     // Use functional composition to generate a single op that 
     // approximates the effect of the pair of ops.
-    static void Compose(Lut3DOpDataRcPtr & A,
-                        ConstLut3DOpDataRcPtr & B);
+    static Lut3DOpDataRcPtr Compose(ConstLut3DOpDataRcPtr & A,
+                                    ConstLut3DOpDataRcPtr & B);
 
 public:
     // The gridSize parameter is the length of the cube axis.

--- a/src/OpenColorIO/ops/NoOp/NoOps.cpp
+++ b/src/OpenColorIO/ops/NoOp/NoOps.cpp
@@ -482,7 +482,7 @@ void CreateGenericScaleOp(OpRcPtrVec & ops)
 void CreateGenericLutOp(OpRcPtrVec & ops)
 {
     // Make a LUT that squares the input
-    Lut1DOpDataRcPtr lut = Lut1DOpData::Create();
+    Lut1DRcPtr lut = Lut1D::Create();
     {
         lut->from_min[0] = 0.0f;
         lut->from_min[1] = 0.0f;

--- a/src/OpenColorIO/ops/OpArray.h
+++ b/src/OpenColorIO/ops/OpArray.h
@@ -29,6 +29,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef INCLUDED_OCIO_OPARRAY_H
 #define INCLUDED_OCIO_OPARRAY_H
 
+#include <sstream>
 #include <vector>
 
 #include <OpenColorIO/OpenColorIO.h>
@@ -71,9 +72,27 @@ public:
     // length and number of components.
     virtual unsigned long getNumValues() const = 0;
 
+    void setLength(unsigned length)
+    {
+        if (m_length != length)
+        {
+            m_length = length;
+            m_data.resize(getNumValues());
+        }
+    }
+
     unsigned long getLength() const
     {
         return m_length;
+    }
+
+    void setMaxColorComponents()
+    {
+        if (m_numColorComponents != getMaxColorComponents())
+        {
+            m_numColorComponents = getMaxColorComponents();
+            m_data.resize(getNumValues());
+        }
     }
 
     unsigned long getNumColorComponents() const
@@ -86,12 +105,12 @@ public:
         return 3;
     }
 
-    const Values& getValues() const
+    inline const Values& getValues() const
     {
         return m_data;
     }
 
-    Values& getValues()
+    inline Values& getValues()
     {
         return m_data;
     }
@@ -122,8 +141,10 @@ public:
         // that this matches the number of values that were actually set.
         if (m_data.size() != getNumValues())
         {
-            throw Exception("Array content does not have the expected number "
-                "of values.");
+            std::ostringstream os;
+            os << "Array contains: " << m_data.size() << " values, ";
+            os << "but " << getNumValues() << " are expected.";
+            throw Exception(os.str().c_str());
         }
     }
 

--- a/src/OpenColorIO/ops/Range/RangeOps.cpp
+++ b/src/OpenColorIO/ops/Range/RangeOps.cpp
@@ -38,10 +38,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "RangeOpCPU.h"
 #include "RangeOps.h"
 
-
-// TODO: To be removed when ilmbase library will be in
-#define HALF_MAX    65504.0
-
 OCIO_NAMESPACE_ENTER
 {
 

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -20,6 +20,7 @@ function(add_ocio_test NAME SOURCES PRIVATE_INCLUDES)
 			oiio_unittest
 			unittest_data
 			libexpat
+			ilmbase
 	)
 	if(PRIVATE_INCLUDES)
 		target_include_directories(${TEST_BINARY}
@@ -102,6 +103,9 @@ set(SOURCES
 	ops/Exponent/ExponentOps.cpp
 	ops/Log/LogOps.cpp
 	ops/Lut1D/Lut1DOp.cpp
+	ops/Lut1D/Lut1DOpCPU.cpp
+	ops/Lut1D/Lut1DOpData.cpp
+	ops/Lut1D/Lut1DOpGPU.cpp
 	ops/Lut3D/Lut3DOp.cpp
 	ops/Lut3D/Lut3DOpCPU.cpp
 	ops/Lut3D/Lut3DOpData.cpp

--- a/tests/gpu/Lut1DOp_test.cpp
+++ b/tests/gpu/Lut1DOp_test.cpp
@@ -86,8 +86,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, lut1d_1_small_legacy_shader)
 
     test.setContext(file->createEditableCopy(), shaderDesc);
 
-    // TODO: Investigate why the test needs such a threshold
-    test.setErrorThreshold(3e-3f);
+    test.setErrorThreshold(1e-6f);
 }
 
 
@@ -101,8 +100,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, lut1d_1_small_inverse_legacy_shader)
 
     test.setContext(file->createEditableCopy(), shaderDesc);
 
-    // TODO: Investigate why the test needs such a threshold
-    test.setErrorThreshold(1e-2f);
+    test.setErrorThreshold(1e-6f);
 }
 
 
@@ -113,7 +111,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, lut1d_1_small_generic_shader)
     OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
 
     test.setContext(file->createEditableCopy(), shaderDesc);
-    test.setErrorThreshold(1e-4f);
+    test.setErrorThreshold(1e-6f);
 }
 
 
@@ -125,7 +123,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, lut1d_1_small_inverse_generic_shader)
     OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
 
     test.setContext(file->createEditableCopy(), shaderDesc);
-    test.setErrorThreshold(1e-4f);
+    test.setErrorThreshold(1e-6f);
 }
 
 
@@ -137,7 +135,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, lut1d_2_legacy_shader)
         = OCIO::GpuShaderDesc::CreateLegacyShaderDesc(2*LUT3D_EDGE_SIZE);
 
     test.setContext(file->createEditableCopy(), shaderDesc);
-    test.setErrorThreshold(5e-4f);
+    test.setErrorThreshold(2e-4f);
 }
 
 
@@ -150,7 +148,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, lut1d_2_inverse_legacy_shader)
         = OCIO::GpuShaderDesc::CreateLegacyShaderDesc(2*LUT3D_EDGE_SIZE);
 
     test.setContext(file->createEditableCopy(), shaderDesc);
-    test.setErrorThreshold(5e-4f);
+    test.setErrorThreshold(2e-4f);
 }
 
 
@@ -162,7 +160,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, lut1d_2_generic_shader)
         = OCIO::GpuShaderDesc::CreateShaderDesc();
 
     test.setContext(file->createEditableCopy(), shaderDesc);
-    test.setErrorThreshold(1e-4f);
+    test.setErrorThreshold(1e-6f);
 }
 
 
@@ -175,7 +173,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, lut1d_2_inverse_generic_shader)
         = OCIO::GpuShaderDesc::CreateShaderDesc();
 
     test.setContext(file->createEditableCopy(), shaderDesc);
-    test.setErrorThreshold(5e-4f);
+    test.setErrorThreshold(1e-4f);
 }
 
 
@@ -187,7 +185,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, lut1d_3_big_legacy_shader)
         = OCIO::GpuShaderDesc::CreateLegacyShaderDesc(2*LUT3D_EDGE_SIZE);
 
     test.setContext(file->createEditableCopy(), shaderDesc);
-    test.setErrorThreshold(1e-4f);
+    test.setErrorThreshold(1e-6f);
 }
 
 
@@ -200,7 +198,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, lut1d_3_big_inverse_legacy_shader)
         = OCIO::GpuShaderDesc::CreateLegacyShaderDesc(2*LUT3D_EDGE_SIZE);
 
     test.setContext(file->createEditableCopy(), shaderDesc);
-    test.setErrorThreshold(1e-4f);
+    test.setErrorThreshold(1e-6f);
 }
 
 
@@ -211,7 +209,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, lut1d_3_big_generic_shader)
     OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
 
     test.setContext(file->createEditableCopy(), shaderDesc);
-    test.setErrorThreshold(1e-4f);
+    test.setErrorThreshold(1e-6f);
 }
 
 
@@ -223,7 +221,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, lut1d_3_big_inverse_generic_shader)
     OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
 
     test.setContext(file->createEditableCopy(), shaderDesc);
-    test.setErrorThreshold(1e-4f);
+    test.setErrorThreshold(1e-6f);
 }
 
 
@@ -235,7 +233,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, lut1d_3_big_nearest_generic_shader)
     OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
 
     test.setContext(file->createEditableCopy(), shaderDesc);
-    test.setErrorThreshold(1e-4f);
+    test.setErrorThreshold(1e-6f);
 }
 
 
@@ -247,8 +245,10 @@ OCIO_ADD_GPU_TEST(Lut1DOp, scale_lut1d_4_legacy_shader)
         = OCIO::GpuShaderDesc::CreateLegacyShaderDesc(2*LUT3D_EDGE_SIZE);
 
     test.setContext(file->createEditableCopy(), shaderDesc);
+    // lut1d_4.spi1d has values outside [0, 1]. Legacy shader is baking ops
+    // into a 3D LUT and would clamp outside of [0, 1].
     test.setWideRange(false);
-    test.setErrorThreshold(1e-3f);
+    test.setErrorThreshold(2e-4f);
 }
 
 
@@ -262,7 +262,7 @@ OCIO_ADD_GPU_TEST(Lut1DOp, scale_lut1d_4_inverse_legacy_shader)
 
     test.setContext(file->createEditableCopy(), shaderDesc);
     test.setWideRange(false);
-    test.setErrorThreshold(1e-4f);
+    test.setErrorThreshold(5e-5f);
 }
 
 
@@ -273,11 +273,9 @@ OCIO_ADD_GPU_TEST(Lut1DOp, scale_lut1d_4_generic_shader)
     OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
 
     test.setContext(file->createEditableCopy(), shaderDesc);
+    // TODO: Should be smaller.
     test.setErrorThreshold(1e-4f);
 }
-
-/*
-    TODO: Uncomment when the 1D LUT inverse is fully working.
 
 OCIO_ADD_GPU_TEST(Lut1DOp, scale_lut1d_4_inverse_generic_shader)
 {
@@ -287,9 +285,9 @@ OCIO_ADD_GPU_TEST(Lut1DOp, scale_lut1d_4_inverse_generic_shader)
     OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
 
     test.setContext(file->createEditableCopy(), shaderDesc);
-    test.setErrorThreshold(1e-4f);
+    test.setErrorThreshold(1e-6f);
 }
-*/
+
 
 OCIO_ADD_GPU_TEST(Lut1DOp, not_linear_lut1d_5_generic_shader)
 {
@@ -298,12 +296,10 @@ OCIO_ADD_GPU_TEST(Lut1DOp, not_linear_lut1d_5_generic_shader)
     OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
 
     test.setContext(file->createEditableCopy(), shaderDesc);
+    // TODO: Should be smaller.
     test.setErrorThreshold(1e-3f);
-    test.setRelativeComparison(true);
+    test.setRelativeComparison(true); // LUT contains values up to 64
 }
-
-/*
-    TODO: Uncomment when the 1D LUT inverse is fully working.
 
 OCIO_ADD_GPU_TEST(Lut1DOp, not_linear_lut1d_5_inverse_generic_shader)
 {
@@ -313,6 +309,25 @@ OCIO_ADD_GPU_TEST(Lut1DOp, not_linear_lut1d_5_inverse_generic_shader)
     OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GpuShaderDesc::CreateShaderDesc();
 
     test.setContext(file->createEditableCopy(), shaderDesc);
-    test.setErrorThreshold(1e-4f);
+    test.setErrorThreshold(1e-6f);
 }
-*/
+
+
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererLut1D_8i_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererLut1D_16i_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererLut1D_16f_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererLut1D_16f_half_domain_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererLut1D_32f_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererLut1DTooManyTextures_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererLut1D_File1_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererLut1D_too_small
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererLut1D_half_domain_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererLut1D_File2_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererLut1D_hue_adjust_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererLut1D_half_domain_hue_adjust_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererInvLut1D_File1_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererInvLut1D_File2_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererInvLut1DHalf_File1_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - GPURendererInvLut1DHalf_HueAdjust_File1_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - lut1d_half_domain_special_values_test
+// TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc - lut1d_normal_domain_special_values_test

--- a/tests/gpu/Lut3DOp_test.cpp
+++ b/tests/gpu/Lut3DOp_test.cpp
@@ -333,6 +333,8 @@ OCIO_ADD_GPU_TEST(Lut3DOp, 3dlut_file_spi3d_tetra)
     test.setErrorThreshold(1e-6f);
 }
 
+#if defined(NDEBUG) || !defined(WIN32)
+// TODO: 3D LUT inversion might be very slow in debug on windows.
 OCIO_ADD_GPU_TEST(Lut3DOp, inv3dlut_file_spi3d_linear)
 {
     // The test uses the FAST style of inverse on both CPU and GPU.
@@ -360,6 +362,7 @@ OCIO_ADD_GPU_TEST(Lut3DOp, inv3dlut_file_spi3d_tetra)
     test.setContext(file->createEditableCopy(), shaderDesc);
     test.setErrorThreshold(1.2e-3f);
 }
+#endif
 
 OCIO_ADD_GPU_TEST(Lut3DOp, 3dlut_file_spi3d_bizarre_linear)
 {
@@ -385,6 +388,7 @@ OCIO_ADD_GPU_TEST(Lut3DOp, 3dlut_file_spi3d_bizarre_tetra)
     test.setErrorThreshold(1e-6f);
 }
 
+#if defined(NDEBUG) || !defined(WIN32)
 OCIO_ADD_GPU_TEST(Lut3DOp, inv3dlut_file_spi3d_bizarre_linear)
 {
     OCIO::FileTransformRcPtr file = GetFileTransform("lut3d_bizarre.spi3d");
@@ -407,7 +411,7 @@ OCIO_ADD_GPU_TEST(Lut3DOp, inv3dlut_file_spi3d_bizarre_tetra)
     test.setContext(file->createEditableCopy(), shaderDesc);
     test.setErrorThreshold(3e-4f);
 }
-
+#endif
 
 // TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc GPURendererLut3D_File2_test
 // TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc GPURendererLut3D_File3_test

--- a/tests/gpu/Lut3DOp_test.cpp
+++ b/tests/gpu/Lut3DOp_test.cpp
@@ -333,8 +333,6 @@ OCIO_ADD_GPU_TEST(Lut3DOp, 3dlut_file_spi3d_tetra)
     test.setErrorThreshold(1e-6f);
 }
 
-#if defined(NDEBUG) || !defined(WIN32)
-// TODO: 3D LUT inversion might be very slow in debug on windows.
 OCIO_ADD_GPU_TEST(Lut3DOp, inv3dlut_file_spi3d_linear)
 {
     // The test uses the FAST style of inverse on both CPU and GPU.
@@ -362,7 +360,6 @@ OCIO_ADD_GPU_TEST(Lut3DOp, inv3dlut_file_spi3d_tetra)
     test.setContext(file->createEditableCopy(), shaderDesc);
     test.setErrorThreshold(1.2e-3f);
 }
-#endif
 
 OCIO_ADD_GPU_TEST(Lut3DOp, 3dlut_file_spi3d_bizarre_linear)
 {
@@ -388,7 +385,6 @@ OCIO_ADD_GPU_TEST(Lut3DOp, 3dlut_file_spi3d_bizarre_tetra)
     test.setErrorThreshold(1e-6f);
 }
 
-#if defined(NDEBUG) || !defined(WIN32)
 OCIO_ADD_GPU_TEST(Lut3DOp, inv3dlut_file_spi3d_bizarre_linear)
 {
     OCIO::FileTransformRcPtr file = GetFileTransform("lut3d_bizarre.spi3d");
@@ -411,7 +407,7 @@ OCIO_ADD_GPU_TEST(Lut3DOp, inv3dlut_file_spi3d_bizarre_tetra)
     test.setContext(file->createEditableCopy(), shaderDesc);
     test.setErrorThreshold(3e-4f);
 }
-#endif
+
 
 // TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc GPURendererLut3D_File2_test
 // TODO: Port syncolor test: renderer\test\GPURenderer_cases.cpp_inc GPURendererLut3D_File3_test


### PR DESCRIPTION
This PR contains upgrades to the Lut1D that speeds up inversion and sets the foundation for further improvements.  This PR is related to several upcoming PRs and is a Work in Progress.  As previously mentioned we are also planning on adding support for integer pixel buffers for the apply method.  This PR contains some code paths in Lut1DOpCPU.cpp that will not do anything until the bit-depth PR arrives and it will be substantially refactored at that time.  We are also adding support for CLF reading and until that arrives we cannot add some of the SynColor unit tests.

This PR keeps the original Lut1D struct from OCIO v1, which is used in the file format readers.  However in a future PR those will be switched over to using the new Lut1DOpData class and the original struct will be removed.  The code for determining if a LUT is a no-op/identity is changing somewhat as part of this and the new algorithm is in this PR but will not actually be used in the file readers until the upcoming PR.

Apologies for the incomplete aspects of this review.  We are trying to keep the PRs smaller but this implies the complete picture will not be clear until all the branches are in place.