### PR TITLE
Adsk Contrib - Fix Windows command line build

### DIFF
--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -1,4 +1,10 @@
 find_package(PythonInterp 2.7 REQUIRED)
 
-add_test(test_python ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/OpenColorIOTestSuite.py ${CMAKE_BINARY_DIR} ${CMAKE_BUILD_TYPE})
+set(BUILD_TYPE "")
+if (MSVC_IDE)
+    # Note: By default Microsoft Visual Studio editor happens the build type to the build directory.
+    set(BUILD_TYPE ${CMAKE_BUILD_TYPE})
+endif()
+
+add_test(test_python ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/OpenColorIOTestSuite.py ${CMAKE_BINARY_DIR} ${BUILD_TYPE})
 

--- a/tests/python/OpenColorIOTestSuite.py
+++ b/tests/python/OpenColorIOTestSuite.py
@@ -1,14 +1,17 @@
 import unittest, os, sys
 
 build_location = sys.argv[1]
-build_type = sys.argv[2]
 
 opencolorio_dir = os.path.join(build_location, "src", "OpenColorIO")
 pyopencolorio_dir = os.path.join(build_location, "src", "bindings", "python")
+
 if os.name == 'nt':
     # On Windows we must append the build type to the build dirs and add the main library to PATH
-    opencolorio_dir = os.path.join(opencolorio_dir, build_type)
-    pyopencolorio_dir = os.path.join(pyopencolorio_dir, build_type)
+    # Note: Only when compiling within Microsoft Visual Studio editor i.e. not on command line.
+    if len(sys.argv)==3:
+        opencolorio_dir = os.path.join(opencolorio_dir, sys.argv[2])
+        pyopencolorio_dir = os.path.join(pyopencolorio_dir, sys.argv[2])
+
     os.environ['PATH'] = "{0};{1}".format(opencolorio_dir, os.environ.get('PATH',""))
 elif sys.platform == 'darwin':
     # On OSX we must add the main library location to DYLD_LIBRARY_PATH


### PR DESCRIPTION
The Windows Python Binding unit tests failed because of the difference between running from Microsoft Visual Studio and from a console (i.e. Vc++ using ninja for example). The expected output directory is not the same as Microsoft Visual Studio happens the build type by default.