### PR TITLE
Adsk Contrib - Add Category support to Color Spaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,9 @@
 matrix:
   include:
     - os: linux
-      dist: xenial
       language: cpp
       compiler: clang
     - os: linux
-      dist: xenial
       language: cpp
       compiler: gcc
     - os: osx
@@ -31,6 +29,10 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       sudo apt-get update -qq;
       sudo apt-get install -y -qq freeglut3-dev libglew-dev libxmu-dev libxi-dev;
+      mkdir ${TRAVIS_BUILD_DIR}/_cmake;
+      wget https://cmake.org/files/v3.12/cmake-3.12.2-Linux-x86_64.sh;
+      sh cmake-3.12.2-Linux-x86_64.sh -- --skip-license --prefix=${TRAVIS_BUILD_DIR}/_cmake;
+      export PATH="${TRAVIS_BUILD_DIR}/_cmake/bin:$PATH";
     fi
   # OSX ones
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@
 matrix:
   include:
     - os: linux
+      dist: xenial
       language: cpp
       compiler: clang
     - os: linux
+      dist: xenial
       language: cpp
       compiler: gcc
     - os: osx
@@ -29,10 +31,6 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       sudo apt-get update -qq;
       sudo apt-get install -y -qq freeglut3-dev libglew-dev libxmu-dev libxi-dev;
-      mkdir ${TRAVIS_BUILD_DIR}/_cmake;
-      wget https://cmake.org/files/v3.12/cmake-3.12.2-Linux-x86_64.sh;
-      sh cmake-3.12.2-Linux-x86_64.sh -- --skip-license --prefix=${TRAVIS_BUILD_DIR}/_cmake;
-      export PATH="${TRAVIS_BUILD_DIR}/_cmake/bin:$PATH";
     fi
   # OSX ones
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -304,30 +304,52 @@ OCIO_NAMESPACE_ENTER
         // 
         // ColorSpaces
         // ^^^^^^^^^^^
-        
+
+        //!cpp:function:: Get all color spaces having a specific category
+        //                in the order they appear in the config file.
+        //
+        // .. note::
+        //    If the category is null or empty, the method returns 
+        //    all the color spaces like :cpp:func:`Config::getNumColorSpaces` 
+        //    and :cpp:func:`Config::getColorSpaceNameByIndex` do.
+        //
+        // .. note::
+        //    It's worth noticing that the method returns a copy of the 
+        //    selected color spaces decoupling the result from the config. 
+        //    Hence, any changes on the config do not affect the existing 
+        //    color space sets, and vice-versa.
+        //
+        ColorSpaceSetRcPtr getColorSpaces(const char * category) const;
+
         //!cpp:function::
         int getNumColorSpaces() const;
-        //!cpp:function:: This will null if an invalid index is specified
+        //!cpp:function:: Will be null for invalid index.
         const char * getColorSpaceNameByIndex(int index) const;
         
         //!rst::
         // .. note::
         //    These fcns all accept either a color space OR role name.
-        //    (Colorspace names take precedence over roles.)
+        //    (Color space names take precedence over roles.)
         
-        //!cpp:function:: This will return null if the specified name is not
-        // found.
+        //!cpp:function:: Will return null if the name is not found.
         ConstColorSpaceRcPtr getColorSpace(const char * name) const;
-        //!cpp:function::
+        //!cpp:function:: Will return -1 if the name is not found.
         int getIndexForColorSpace(const char * name) const;
         
-        //!cpp:function::
+        //!cpp:function:: Add a color space to the configuration.
         // .. note::
         //    If another color space is already registered with the same name,
         //    this will overwrite it. This stores a copy of the specified
         //    color space.
+        // .. note::
+        //    Adding a color space to a Config does not affect any ColorSpaceSets 
+        //    that have already been created.
         void addColorSpace(const ConstColorSpaceRcPtr & cs);
-        //!cpp:function::
+
+        //!cpp:function:: Remove all the color spaces from the configuration.
+        // .. note::
+        //    Removing color spaces from a Config does not affect 
+        //    any ColorSpaceSets that have already been created.
         void clearColorSpaces();
         
         //!cpp:function:: Given the specified string, get the longest,
@@ -605,7 +627,39 @@ OCIO_NAMESPACE_ENTER
         BitDepth getBitDepth() const;
         //!cpp:function::
         void setBitDepth(BitDepth bitDepth);
-        
+
+        ///////////////////////////////////////////////////////////////////////////
+        //!rst::
+        // Categories
+        // ^^^^^^^^^^
+        // A category is used to allow applications to filter the list of color spaces 
+        // they display in menus based on what that color space is used for.
+        //
+        // Here is an example config entry that could appear under a ColorSpace:
+        // categories: [input, rendering]
+        //
+        // The example contains two categories: 'input' and 'rendering'. 
+        // Category strings are not case-sensitive and the order is not significant.
+        // There is no limit imposed on length or number. Although users may add 
+        // their own categories, the strings will typically come from a fixed set 
+        // listed in the documentation (similar to roles).
+
+        //!cpp:function:: Return true if the category is present.
+        bool hasCategory(const char * category) const;
+        //!cpp:function:: Add a single category.
+        // .. note:: Will do nothing if the category already exists.
+        void addCategory(const char * category);
+        //!cpp:function:: Remove a category.
+        // .. note:: Will do nothing if the category is missing.
+        void removeCategory(const char * category);
+        //!cpp:function:: Get the number of categories.
+        int getNumCategories() const;
+        //!cpp:function:: Return the category name using its index
+        // .. note:: Will be null if the index is invalid.
+        const char * getCategory(int index) const;
+        // Clear all the categories.
+        void clearCategories();
+
         ///////////////////////////////////////////////////////////////////////////
         //!rst::
         // Data
@@ -693,9 +747,105 @@ OCIO_NAMESPACE_ENTER
     
     
     
-    
-    
-    
+    ///////////////////////////////////////////////////////////////////////////
+    //!rst:: .. _colorspaceset_section:
+    // 
+    // ColorSpaceSet
+    // *************
+    // The *ColorSpaceSet* is a set of color spaces (i.e. no color space duplication) 
+    // which could be the result of :cpp:func:`Config::getColorSpaces`
+    // or built from scratch.
+    // 
+    // .. note::
+    //    The color spaces are decoupled from the config. ones i.e. any 
+    //    changes to the set itself or to its color spaces do not affect the 
+    //    original color spaces from the configuration.  If needed, 
+    //    use :cpp:func:`Config::addColorSpace` to update the configuration.
+
+    //!cpp:class::
+    class OCIOEXPORT ColorSpaceSet
+    {
+    public:
+        //!cpp:function:: Create an empty set of color spaces.
+        static ColorSpaceSetRcPtr Create();
+
+        //!cpp:function:: Create a set containing a copy of all the color spaces.
+        ColorSpaceSetRcPtr createEditableCopy() const;
+
+        //!cpp:function:: Return true if the two sets are equal.
+        // .. note:: The comparison is done on the color space names (not a deep comparison).
+        bool operator==(const ColorSpaceSet & css) const;
+        //!cpp:function:: Return true if the two sets are different.
+        bool operator!=(const ColorSpaceSet & css) const;
+
+        //!cpp:function:: Return the number of color spaces.
+        int getNumColorSpaces() const;
+        //!cpp:function:: Return the color space name using its index.
+        // This will be null if an invalid index is specified.
+        const char * getColorSpaceNameByIndex(int index) const;
+        //!cpp:function:: Return the color space using its index.
+        // This will be empty if an invalid index is specified.
+        ConstColorSpaceRcPtr getColorSpaceByIndex(int index) const;
+
+        //!rst::
+        // .. note::
+        //    These fcns only accept color space names (i.e. no role name).
+
+        //!cpp:function:: Will return null if the name is not found.
+        ConstColorSpaceRcPtr getColorSpace(const char * name) const;
+        //!cpp:function:: Will return -1 if the name is not found.
+        int getIndexForColorSpace(const char * name) const;
+
+        //!cpp:function:: Add color space(s).
+        // .. note::
+        //    If another color space is already registered with the same name,
+        //    this will overwrite it. This stores a copy of the specified
+        //    color space(s).
+        void addColorSpace(const ConstColorSpaceRcPtr & cs);
+        void addColorSpaces(const ConstColorSpaceSetRcPtr & cs);
+
+        //!cpp:function:: Remove color space(s) using color space names (i.e. no role name).
+        // .. note:: The removal of a missing color space does nothing.
+        void removeColorSpace(const char * name);
+        void removeColorSpaces(const ConstColorSpaceSetRcPtr & cs);
+
+        //!cpp:function:: Clear all color spaces.
+        void clearColorSpaces();
+
+    private:
+        ColorSpaceSet();
+        ~ColorSpaceSet();
+        
+        ColorSpaceSet(const ColorSpaceSet &);
+        ColorSpaceSet & operator= (const ColorSpaceSet &);
+        
+        static void deleter(ColorSpaceSet * c);
+        
+        class Impl;
+        friend class Impl;
+        Impl * m_impl;
+        Impl * getImpl() { return m_impl; }
+        const Impl * getImpl() const { return m_impl; }
+    };
+
+
+    // .. note::
+    //    All these fcns provide some operations on two color space sets 
+    //    where the result contains copied color spaces and no duplicates.
+
+    //!cpp:function:: Perform the union of two sets.
+    ConstColorSpaceSetRcPtr operator||(const ConstColorSpaceSetRcPtr & lcss, 
+                                       const ConstColorSpaceSetRcPtr & rcss);
+    //!cpp:function:: Perform the intersection of two sets.
+    ConstColorSpaceSetRcPtr operator&&(const ConstColorSpaceSetRcPtr & lcss, 
+                                       const ConstColorSpaceSetRcPtr & rcss);
+    //!cpp:function:: Perform the difference of two sets.
+    ConstColorSpaceSetRcPtr operator-(const ConstColorSpaceSetRcPtr & lcss, 
+                                      const ConstColorSpaceSetRcPtr & rcss);
+
+
+
+
     ///////////////////////////////////////////////////////////////////////////
     //!rst:: .. _look_section:
     // 

--- a/include/OpenColorIO/OpenColorIO.h
+++ b/include/OpenColorIO/OpenColorIO.h
@@ -757,7 +757,7 @@ OCIO_NAMESPACE_ENTER
     // or built from scratch.
     // 
     // .. note::
-    //    The color spaces are decoupled from the config. ones i.e. any 
+    //    The color spaces are decoupled from the config ones, i.e., any 
     //    changes to the set itself or to its color spaces do not affect the 
     //    original color spaces from the configuration.  If needed, 
     //    use :cpp:func:`Config::addColorSpace` to update the configuration.

--- a/include/OpenColorIO/OpenColorTypes.h
+++ b/include/OpenColorIO/OpenColorTypes.h
@@ -63,7 +63,13 @@ OCIO_NAMESPACE_ENTER
     typedef OCIO_SHARED_PTR<const ColorSpace> ConstColorSpaceRcPtr;
     //!cpp:type::
     typedef OCIO_SHARED_PTR<ColorSpace> ColorSpaceRcPtr;
-    
+
+    class OCIOEXPORT ColorSpaceSet;
+    //!cpp:type::
+    typedef OCIO_SHARED_PTR<const ColorSpaceSet> ConstColorSpaceSetRcPtr;
+    //!cpp:type::
+    typedef OCIO_SHARED_PTR<ColorSpaceSet> ColorSpaceSetRcPtr;
+
     class OCIOEXPORT Look;
     //!cpp:type::
     typedef OCIO_SHARED_PTR<const Look> ConstLookRcPtr;

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
 	BitDepthUtils.cpp
 	Caching.cpp
 	ColorSpace.cpp
+	ColorSpaceSet.cpp
 	Config.cpp
 	Context.cpp
 	Display.cpp

--- a/src/OpenColorIO/ColorSpace.cpp
+++ b/src/OpenColorIO/ColorSpace.cpp
@@ -220,7 +220,7 @@ OCIO_NAMESPACE_ENTER
 
     void ColorSpace::removeCategory(const char * category)
     {
-        auto itr = getImpl()->findCategory(category);
+        Impl::Categories::const_iterator itr = getImpl()->findCategory(category);
 
         if(itr!=getImpl()->categories_.end())
         {

--- a/src/OpenColorIO/ColorSpace.cpp
+++ b/src/OpenColorIO/ColorSpace.cpp
@@ -32,6 +32,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <OpenColorIO/OpenColorIO.h>
 
+#include "pystring/pystring.h"
+
+
 OCIO_NAMESPACE_ENTER
 {
     ColorSpaceRcPtr ColorSpace::Create()
@@ -64,6 +67,9 @@ OCIO_NAMESPACE_ENTER
         
         bool toRefSpecified_;
         bool fromRefSpecified_;
+
+        typedef std::vector<std::string> Categories;
+        Categories categories_;
         
         Impl() :
             bitDepth_(BIT_DEPTH_UNKNOWN),
@@ -99,9 +105,30 @@ OCIO_NAMESPACE_ENTER
 
                 toRefSpecified_ = rhs.toRefSpecified_;
                 fromRefSpecified_ = rhs.fromRefSpecified_;
+
+                categories_ = rhs.categories_;
             }
             return *this;
         }
+
+        Categories::const_iterator findCategory(const char * category) const
+        {
+            if(!category || !*category) return categories_.end();
+
+            // NB: Categories are not case-sensitive and whitespace is stripped.
+            const std::string ref(pystring::strip(pystring::lower(category)));
+
+            for(auto itr = categories_.begin(); itr!=categories_.end(); ++itr)
+            {
+                if(pystring::strip(pystring::lower(*itr))==ref)
+                {
+                    return itr;
+                }
+            }
+
+            return categories_.end();
+        }
+
     };
     
     
@@ -175,7 +202,49 @@ OCIO_NAMESPACE_ENTER
     {
         getImpl()->bitDepth_ = bitDepth;
     }
-    
+
+    bool ColorSpace::hasCategory(const char * category) const
+    {
+        return getImpl()->findCategory(category)
+            != getImpl()->categories_.end();
+    }
+
+    void ColorSpace::addCategory(const char * category)
+    {
+        if(getImpl()->findCategory(category) 
+            == getImpl()->categories_.end())
+        {
+            getImpl()->categories_.push_back(pystring::strip(category));
+        }
+    }
+
+    void ColorSpace::removeCategory(const char * category)
+    {
+        auto itr = getImpl()->findCategory(category);
+
+        if(itr!=getImpl()->categories_.end())
+        {
+            getImpl()->categories_.erase(itr);
+        }
+    }
+
+    int ColorSpace::getNumCategories() const
+    {
+        return static_cast<int>(getImpl()->categories_.size());
+    }
+
+    const char * ColorSpace::getCategory(int index) const
+    {
+        if(index<0 || index>=getImpl()->categories_.size()) return nullptr;
+
+        return getImpl()->categories_[index].c_str();
+    }
+
+    void ColorSpace::clearCategories()
+    {
+        getImpl()->categories_.clear();
+    }
+
     bool ColorSpace::isData() const
     {
         return getImpl()->isData_;
@@ -285,3 +354,52 @@ OCIO_NAMESPACE_ENTER
     }
 }
 OCIO_NAMESPACE_EXIT
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef OCIO_UNIT_TEST
+
+namespace OCIO = OCIO_NAMESPACE;
+#include "unittest.h"
+
+OIIO_ADD_TEST(ColorSpace, category)
+{
+    OCIO::ColorSpaceRcPtr cs = OCIO::ColorSpace::Create();
+    OIIO_CHECK_EQUAL(cs->getNumCategories(), 0);
+
+    OIIO_CHECK_ASSERT(!cs->hasCategory("linear"));
+    OIIO_CHECK_ASSERT(!cs->hasCategory("rendering"));
+    OIIO_CHECK_ASSERT(!cs->hasCategory("log"));
+
+    OIIO_CHECK_NO_THROW(cs->addCategory("linear"));
+    OIIO_CHECK_NO_THROW(cs->addCategory("rendering"));
+    OIIO_CHECK_EQUAL(cs->getNumCategories(), 2);
+
+    OIIO_CHECK_ASSERT(cs->hasCategory("linear"));
+    OIIO_CHECK_ASSERT(cs->hasCategory("rendering"));
+    OIIO_CHECK_ASSERT(!cs->hasCategory("log"));
+
+    OIIO_CHECK_EQUAL(std::string(cs->getCategory(0)), std::string("linear"));
+    OIIO_CHECK_EQUAL(std::string(cs->getCategory(1)), std::string("rendering"));
+    // Check with an invalid index.
+    OIIO_CHECK_NO_THROW(cs->getCategory(2));
+    OIIO_CHECK_ASSERT(cs->getCategory(2) == nullptr);
+
+    OIIO_CHECK_NO_THROW(cs->removeCategory("linear"));
+    OIIO_CHECK_EQUAL(cs->getNumCategories(), 1);
+    OIIO_CHECK_ASSERT(!cs->hasCategory("linear"));
+    OIIO_CHECK_ASSERT(cs->hasCategory("rendering"));
+    OIIO_CHECK_ASSERT(!cs->hasCategory("log"));
+
+    // Remove a category not in the color space.
+    OIIO_CHECK_NO_THROW(cs->removeCategory("log"));
+    OIIO_CHECK_EQUAL(cs->getNumCategories(), 1);
+    OIIO_CHECK_ASSERT(cs->hasCategory("rendering"));
+
+    OIIO_CHECK_NO_THROW(cs->clearCategories());
+    OIIO_CHECK_EQUAL(cs->getNumCategories(), 0);
+}
+
+#endif // OCIO_UNIT_TEST

--- a/src/OpenColorIO/ColorSpace.cpp
+++ b/src/OpenColorIO/ColorSpace.cpp
@@ -129,6 +129,24 @@ OCIO_NAMESPACE_ENTER
             return categories_.end();
         }
 
+        void removeCategory(const char * category)
+        {
+            if(!category || !*category) return;
+
+            // NB: Categories are not case-sensitive and whitespace is stripped.
+            const std::string ref(pystring::strip(pystring::lower(category)));
+
+            for(auto itr = categories_.begin(); itr!=categories_.end(); ++itr)
+            {
+                if(pystring::strip(pystring::lower(*itr))==ref)
+                {
+                    categories_.erase(itr);
+                    return;
+                }
+            }
+
+            return;
+        }
     };
     
     
@@ -220,12 +238,7 @@ OCIO_NAMESPACE_ENTER
 
     void ColorSpace::removeCategory(const char * category)
     {
-        Impl::Categories::const_iterator itr = getImpl()->findCategory(category);
-
-        if(itr!=getImpl()->categories_.end())
-        {
-            getImpl()->categories_.erase(itr);
-        }
+        getImpl()->removeCategory(category);
     }
 
     int ColorSpace::getNumCategories() const

--- a/src/OpenColorIO/ColorSpaceSet.cpp
+++ b/src/OpenColorIO/ColorSpaceSet.cpp
@@ -170,7 +170,7 @@ public:
         const std::string name = pystring::lower(csName);
         if(name.empty()) return;
 
-        for(auto itr = m_colorSpaces.cbegin(); itr != m_colorSpaces.cend(); ++itr)
+        for(auto itr = m_colorSpaces.begin(); itr != m_colorSpaces.end(); ++itr)
         {
             if(pystring::lower((*itr)->getName())==name)
             {

--- a/src/OpenColorIO/ColorSpaceSet.cpp
+++ b/src/OpenColorIO/ColorSpaceSet.cpp
@@ -1,0 +1,659 @@
+/*
+Copyright (c) 2018 Autodesk Inc., et al.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+* Neither the name of Sony Pictures Imageworks nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <sstream>
+
+#include <OpenColorIO/OpenColorIO.h>
+
+#include "PrivateTypes.h"
+#include "pystring/pystring.h"
+
+
+OCIO_NAMESPACE_ENTER
+{
+    
+class ColorSpaceSet::Impl
+{
+public:
+    Impl() { }
+    ~Impl() { }
+    
+    Impl & operator= (const Impl & rhs)
+    {
+        if(this!=&rhs)
+        {
+            clear();
+
+            for(auto & cs: rhs.m_colorSpaces)
+            {
+                m_colorSpaces.push_back(cs->createEditableCopy());
+            }
+        }
+        return *this;
+    }
+
+    bool operator== (const Impl & rhs)
+    {
+        if(this==&rhs) return true;
+
+        if(m_colorSpaces.size()!=rhs.m_colorSpaces.size())
+        {
+            return false;
+        }
+
+        for(auto & cs : m_colorSpaces)
+        {
+            // NB: Only the names are compared.
+            if(-1==rhs.getIndex(cs->getName()))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    int size() const 
+    { 
+        return static_cast<int>(m_colorSpaces.size()); 
+    }
+
+    ConstColorSpaceRcPtr get(int index) const 
+    {
+        if(index<0 || index>=size())
+        {
+            return ColorSpaceRcPtr();
+        }
+
+        return m_colorSpaces[index];
+    }
+
+    const char * getName(int index) const 
+    {
+        if(index<0 || index>=size())
+        {
+            return nullptr;
+        }
+
+        return m_colorSpaces[index]->getName();
+    }
+
+    ConstColorSpaceRcPtr getByName(const char * csName) const 
+    {
+        if(csName && *csName)
+        {
+            const std::string str = pystring::lower(csName);
+            for(auto & cs: m_colorSpaces)
+            {
+                if(pystring::lower(cs->getName())==str)
+                {
+                    return cs;
+                }
+            }
+        }
+        return ColorSpaceRcPtr();
+    }
+
+    int getIndex(const char * csName) const 
+    {
+        if(csName && *csName)
+        {
+            const std::string str = pystring::lower(csName);
+            for(size_t idx = 0; idx<m_colorSpaces.size(); ++idx)
+            {
+                if(pystring::lower(m_colorSpaces[idx]->getName())==str)
+                {
+                    return static_cast<int>(idx);
+                }
+            }
+        }
+
+        return -1;
+    }
+
+    void add(const ConstColorSpaceRcPtr & cs)
+    {
+        const std::string csName = pystring::lower(cs->getName());
+        if(csName.empty())
+        {
+            throw Exception("Cannot add a color space with an empty name.");
+        }
+
+        for(auto & entry: m_colorSpaces)
+        {
+            if(pystring::lower(entry->getName())==csName)
+            {
+                // The color space replaces the existing one.
+                entry = cs->createEditableCopy();
+                return;
+            }
+        }
+
+        m_colorSpaces.push_back(cs->createEditableCopy());
+    }
+
+    void add(const Impl & rhs)
+    {
+        for(auto & cs : rhs.m_colorSpaces)
+        {
+            add(cs);
+        }
+    }
+
+    void remove(const char * csName)
+    {
+        const std::string name = pystring::lower(csName);
+        if(name.empty()) return;
+
+        for(auto itr = m_colorSpaces.cbegin(); itr != m_colorSpaces.cend(); ++itr)
+        {
+            if(pystring::lower((*itr)->getName())==name)
+            {
+                m_colorSpaces.erase(itr);
+                return;
+            }
+        }
+    }
+
+    void remove(const Impl & rhs)
+    {
+        for(auto & cs : rhs.m_colorSpaces)
+        {
+            remove(cs->getName());
+        }
+    }
+
+    void clear()
+    {
+        m_colorSpaces.clear();
+    }
+
+private:
+    typedef std::vector<ColorSpaceRcPtr> ColorSpaceVec;
+    ColorSpaceVec m_colorSpaces;
+};
+
+
+///////////////////////////////////////////////////////////////////////////
+
+ColorSpaceSetRcPtr ColorSpaceSet::Create()
+{
+    return ColorSpaceSetRcPtr(new ColorSpaceSet(), &deleter);
+}
+
+void ColorSpaceSet::deleter(ColorSpaceSet* c)
+{
+    delete c;
+}
+
+
+///////////////////////////////////////////////////////////////////////////
+
+
+
+ColorSpaceSet::ColorSpaceSet()
+    :   m_impl(new ColorSpaceSet::Impl)
+{
+}
+
+ColorSpaceSet::~ColorSpaceSet()
+{
+    delete m_impl;
+    m_impl = nullptr;
+}
+    
+ColorSpaceSetRcPtr ColorSpaceSet::createEditableCopy() const
+{
+    ColorSpaceSetRcPtr css = ColorSpaceSet::Create();
+    *css->m_impl = *m_impl;
+    return css;
+}
+
+bool ColorSpaceSet::operator==(const ColorSpaceSet & css) const
+{
+    return *m_impl == *css.m_impl;
+}
+
+bool ColorSpaceSet::operator!=(const ColorSpaceSet & css) const
+{
+    return !( *m_impl == *css.m_impl );
+}
+
+int ColorSpaceSet::getNumColorSpaces() const
+{
+    return m_impl->size();    
+}
+
+const char * ColorSpaceSet::getColorSpaceNameByIndex(int index) const
+{
+    return m_impl->getName(index);
+}
+
+ConstColorSpaceRcPtr ColorSpaceSet::getColorSpaceByIndex(int index) const
+{
+    return m_impl->get(index);
+}
+
+ConstColorSpaceRcPtr ColorSpaceSet::getColorSpace(const char * name) const
+{
+    return m_impl->getByName(name);
+}
+
+int ColorSpaceSet::getIndexForColorSpace(const char * name) const
+{
+    return m_impl->getIndex(name);
+}
+
+void ColorSpaceSet::addColorSpace(const ConstColorSpaceRcPtr & cs)
+{
+    return m_impl->add(cs);
+}
+
+void ColorSpaceSet::addColorSpaces(const ConstColorSpaceSetRcPtr & css)
+{
+    return m_impl->add(*css->m_impl);
+}
+
+void ColorSpaceSet::removeColorSpace(const char * name)
+{
+    return m_impl->remove(name);
+}
+
+void ColorSpaceSet::removeColorSpaces(const ConstColorSpaceSetRcPtr & css)
+{
+    return m_impl->remove(*css->m_impl);
+}
+
+void ColorSpaceSet::clearColorSpaces()
+{
+    m_impl->clear();
+}
+
+ConstColorSpaceSetRcPtr operator||(const ConstColorSpaceSetRcPtr & lcss, 
+                                   const ConstColorSpaceSetRcPtr & rcss)
+{
+    ColorSpaceSetRcPtr css = lcss->createEditableCopy();
+    css->addColorSpaces(rcss);
+    return css;    
+}
+
+ConstColorSpaceSetRcPtr operator&&(const ConstColorSpaceSetRcPtr & lcss, 
+                                   const ConstColorSpaceSetRcPtr & rcss)
+{
+    ColorSpaceSetRcPtr css = ColorSpaceSet::Create();
+
+    for(int idx=0; idx<rcss->getNumColorSpaces(); ++idx)
+    {
+        ConstColorSpaceRcPtr tmp = rcss->getColorSpaceByIndex(idx);
+        if(-1!=lcss->getIndexForColorSpace(tmp->getName()))
+        {
+            css->addColorSpace(tmp);
+        }
+    }
+
+    return css;
+}
+
+ConstColorSpaceSetRcPtr operator-(const ConstColorSpaceSetRcPtr & lcss, 
+                                  const ConstColorSpaceSetRcPtr & rcss)
+{
+    ColorSpaceSetRcPtr css = ColorSpaceSet::Create();
+
+    for(int idx=0; idx<lcss->getNumColorSpaces(); ++idx)
+    {
+        ConstColorSpaceRcPtr tmp = lcss->getColorSpaceByIndex(idx);
+
+        if(-1==rcss->getIndexForColorSpace(tmp->getName()))
+        {
+            css->addColorSpace(tmp);
+        }
+    }
+
+    return css;
+}
+
+}
+OCIO_NAMESPACE_EXIT
+
+
+
+
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef OCIO_UNIT_TEST
+
+namespace OCIO = OCIO_NAMESPACE;
+#include "unittest.h"
+
+OIIO_ADD_TEST(ColorSpaceSet, basic)
+{
+    OCIO::ConfigRcPtr config = OCIO::Config::Create();
+
+    OCIO::ConstColorSpaceSetRcPtr css1;
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces(nullptr));
+    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 0);
+
+    // No category.
+
+    OCIO::ColorSpaceRcPtr cs1 = OCIO::ColorSpace::Create();
+    cs1->setName("cs1");
+    OIIO_CHECK_ASSERT(!cs1->hasCategory("linear"));
+    OIIO_CHECK_ASSERT(!cs1->hasCategory("rendering"));
+    OIIO_CHECK_ASSERT(!cs1->hasCategory("log"));
+
+    // Having categories to filter with.
+
+    OCIO::ColorSpaceRcPtr cs2 = OCIO::ColorSpace::Create();
+    cs2->setName("cs2");
+    cs2->addCategory("linear");
+    cs2->addCategory("rendering");
+    OIIO_CHECK_ASSERT(cs2->hasCategory("linear"));
+    OIIO_CHECK_ASSERT(cs2->hasCategory("rendering"));
+    OIIO_CHECK_ASSERT(!cs2->hasCategory("log"));
+
+    OIIO_CHECK_NO_THROW(cs2->addCategory("log"));
+    OIIO_CHECK_ASSERT(cs2->hasCategory("log"));
+    OIIO_CHECK_NO_THROW(cs2->removeCategory("log"));
+    OIIO_CHECK_ASSERT(!cs2->hasCategory("log"));
+
+    // Update config.
+
+    OIIO_CHECK_NO_THROW(config->addColorSpace(cs1));
+    OIIO_CHECK_NO_THROW(config->addColorSpace(cs2));
+
+    // Search some color spaces based on criteria.
+
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces(nullptr));
+    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 2);
+    OIIO_CHECK_EQUAL(config->getNumColorSpaces(), 2);
+
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces(""));
+    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 2);
+
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("log"));
+    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 0);
+
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("linear"));
+    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 1);
+    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs2"));
+
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("LinEar"));
+    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 1);
+    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs2"));
+
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces(" LinEar "));
+    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 1);
+    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs2"));
+    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceByIndex(0)->getName()), std::string("cs2"));
+
+    // Test some faulty requests.
+
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("lin ear"));
+    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 0);
+
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("[linear]"));
+    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 0);
+
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("linear log"));
+    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 0);
+
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("linearlog"));
+    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 0);
+
+    // Empty the config.
+
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("linear"));
+    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 1);
+
+    OIIO_CHECK_NO_THROW(config->clearColorSpaces());
+    OIIO_CHECK_EQUAL(config->getNumColorSpaces(), 0);
+    // But existing sets are preserved.
+    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 1);
+
+    OCIO::ConstColorSpaceSetRcPtr css2;
+    OIIO_CHECK_NO_THROW(css2 = config->getColorSpaces(nullptr));
+    OIIO_CHECK_EQUAL(css2->getNumColorSpaces(), 0);
+}
+
+OIIO_ADD_TEST(ColorSpaceSet, decoupled_sets)
+{
+    OCIO::ConfigRcPtr config = OCIO::Config::Create();
+
+    OCIO::ColorSpaceRcPtr cs1 = OCIO::ColorSpace::Create();
+    cs1->setName("cs1");
+    OIIO_CHECK_NO_THROW(cs1->addCategory("linear"));
+    OIIO_CHECK_ASSERT(cs1->hasCategory("linear"));
+    OIIO_CHECK_NO_THROW(config->addColorSpace(cs1));
+
+    OCIO::ConstColorSpaceSetRcPtr css1;
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces(nullptr));
+    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 1);
+    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs1"));
+
+    OCIO::ConstColorSpaceSetRcPtr css2;
+    OIIO_CHECK_NO_THROW(css2 = config->getColorSpaces("linear"));
+    OIIO_CHECK_EQUAL(css2->getNumColorSpaces(), 1);
+    OIIO_CHECK_EQUAL(std::string(css2->getColorSpaceNameByIndex(0)), std::string("cs1"));
+
+    // Change the original color space.
+
+    cs1->setName("new_cs1");
+
+    // Check that color spaces in existing sets are not changed.
+    OIIO_CHECK_EQUAL(std::string(config->getColorSpaceNameByIndex(0)), std::string("cs1"));
+
+    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 1);
+    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs1"));
+
+    OIIO_CHECK_EQUAL(css2->getNumColorSpaces(), 1);
+    OIIO_CHECK_EQUAL(std::string(css2->getColorSpaceNameByIndex(0)), std::string("cs1"));
+
+    // Change the color space from the config instance.
+
+    OIIO_CHECK_ASSERT(!cs1->isData());
+    config->clearColorSpaces();
+    config->addColorSpace(cs1);
+    cs1->setIsData(true);
+
+    OIIO_CHECK_EQUAL(std::string(cs1->getName()), std::string("new_cs1"));
+    OIIO_CHECK_ASSERT(cs1->isData());
+    OIIO_CHECK_EQUAL(std::string(config->getColorSpaceNameByIndex(0)), std::string("new_cs1"));
+    // NB: ColorSpace would need to be re-added to the config to reflect the change to isData.
+    OIIO_CHECK_ASSERT(!config->getColorSpace("new_cs1")->isData());
+
+    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 1);
+    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OIIO_CHECK_ASSERT(!css1->getColorSpace("cs1")->isData());
+
+    OIIO_CHECK_EQUAL(css2->getNumColorSpaces(), 1);
+    OIIO_CHECK_EQUAL(std::string(css2->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OIIO_CHECK_ASSERT(!css2->getColorSpace("cs1")->isData());
+}
+
+OIIO_ADD_TEST(ColorSpaceSet, order_validation)
+{
+    OCIO::ConfigRcPtr config = OCIO::Config::Create();
+
+    OCIO::ConstColorSpaceSetRcPtr css1;
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces(nullptr));
+    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 0);
+
+    // Create some color spaces.
+
+    OCIO::ColorSpaceRcPtr cs1 = OCIO::ColorSpace::Create();
+    cs1->setName("cs1");
+    cs1->addCategory("linear");
+    cs1->addCategory("rendering");
+
+    OCIO::ColorSpaceRcPtr cs2 = OCIO::ColorSpace::Create();
+    cs2->setName("cs2");
+    cs2->addCategory("rendering");
+    cs2->addCategory("linear");
+
+    OCIO::ColorSpaceRcPtr cs3 = OCIO::ColorSpace::Create();
+    cs3->setName("cs3");
+    cs3->addCategory("rendering");
+
+    // Add the color spaces.
+
+    OIIO_CHECK_NO_THROW(config->addColorSpace(cs1));
+    OIIO_CHECK_NO_THROW(config->addColorSpace(cs2));
+    OIIO_CHECK_NO_THROW(config->addColorSpace(cs3));
+
+    // Check the color space order for the category "linear".
+
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("linear"));
+    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 2);
+
+    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(1)), std::string("cs2"));
+
+    // Check the color space order for the category "rendering".
+
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("rendering"));
+    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 3);
+
+    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(1)), std::string("cs2"));
+    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(2)), std::string("cs3"));
+}
+
+OIIO_ADD_TEST(ColorSpaceSet, operations_on_set)
+{
+    OCIO::ConfigRcPtr config = OCIO::Config::Create();
+
+    // No category.
+
+    OCIO::ColorSpaceRcPtr cs1 = OCIO::ColorSpace::Create();
+    cs1->setName("cs1");
+    OIIO_CHECK_NO_THROW(config->addColorSpace(cs1));
+
+    // Having categories to filter with.
+
+    OCIO::ColorSpaceRcPtr cs2 = OCIO::ColorSpace::Create();
+    cs2->setName("cs2");
+    cs2->addCategory("linear");
+    cs2->addCategory("rendering");
+    OIIO_CHECK_NO_THROW(config->addColorSpace(cs2));
+
+    OCIO::ColorSpaceRcPtr cs3 = OCIO::ColorSpace::Create();
+    cs3->setName("cs3");
+    cs3->addCategory("log");
+    cs3->addCategory("rendering");
+    OIIO_CHECK_NO_THROW(config->addColorSpace(cs3));
+
+
+    // Recap. of the existing color spaces:
+    // cs1  -> name="cs1" i.e. no category
+    // cs2  -> name="cs2", categories=[rendering, linear]
+    // cs3  -> name="cs3", categories=[rendering, log]
+
+
+    OCIO::ConstColorSpaceSetRcPtr css1;
+    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces(nullptr));
+    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 3);
+
+    OCIO::ConstColorSpaceSetRcPtr css2;
+    OIIO_CHECK_NO_THROW(css2 = config->getColorSpaces("linear"));
+    OIIO_CHECK_EQUAL(css2->getNumColorSpaces(), 1);
+    OIIO_CHECK_EQUAL(std::string(css2->getColorSpaceNameByIndex(0)), std::string("cs2"));
+
+    OCIO::ConstColorSpaceSetRcPtr css3;
+    OIIO_CHECK_NO_THROW(css3 = config->getColorSpaces("log"));
+    OIIO_CHECK_EQUAL(css3->getNumColorSpaces(), 1);
+    OIIO_CHECK_EQUAL(std::string(css3->getColorSpaceNameByIndex(0)), std::string("cs3"));
+
+
+    // Recap. of the existing color space sets:
+    // ccs1 -> {cs1, cs2, cs3}
+    // ccs2 -> {cs2}
+    // css3 -> {cs3}
+
+
+    // Test the union.
+
+    OCIO::ConstColorSpaceSetRcPtr css4 = css2 || css3;
+    OIIO_CHECK_EQUAL(css4->getNumColorSpaces(), 2); // {cs2, cs3}
+
+    css4 = css1 || css2;
+    OIIO_CHECK_EQUAL(css4->getNumColorSpaces(), 3); // no duplication i.e. all color spaces
+
+    // Test the intersection.
+
+    css4 = css2 && css3;
+    OIIO_CHECK_EQUAL(css4->getNumColorSpaces(), 0);
+
+    css4 = css2 && css1;
+    OIIO_REQUIRE_EQUAL(css4->getNumColorSpaces(), 1); // {cs2}
+    OIIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(0)), std::string("cs2"));
+    OIIO_CHECK_EQUAL(std::string(css4->getColorSpaceByIndex(0)->getName()), std::string("cs2"));
+
+    // Test the difference.
+
+    css4 = css1 - css3;
+    OIIO_REQUIRE_EQUAL(css4->getNumColorSpaces(), 2); // {cs1, cs2}
+    OIIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OIIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(1)), std::string("cs2"));
+
+    css4 = css1 - css2;
+    OIIO_REQUIRE_EQUAL(css4->getNumColorSpaces(), 2); // {cs1, cs3}
+    OIIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OIIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(1)), std::string("cs3"));
+
+    // Test with several embedded operations.
+
+    css4 = css1 - (css2 || css3);
+    OIIO_REQUIRE_EQUAL(css4->getNumColorSpaces(), 1); // {cs1}
+    OIIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(0)), std::string("cs1"));
+
+    OCIO::ColorSpaceSetRcPtr css5;
+    OIIO_CHECK_NO_THROW(css5 = config->getColorSpaces("rendering"));
+    OIIO_CHECK_EQUAL(css5->getNumColorSpaces(), 2); // {cs2, cs3}
+    // Manipulate the result with few tests.
+    OIIO_CHECK_NO_THROW(css5->addColorSpace(cs1));
+    OIIO_CHECK_EQUAL(css5->getNumColorSpaces(), 3); // {cs1, cs2, cs3}
+    OIIO_CHECK_NO_THROW(css5->removeColorSpace("cs2"));
+    OIIO_CHECK_NO_THROW(css5->removeColorSpace("cs1"));
+    OIIO_CHECK_EQUAL(css5->getNumColorSpaces(), 1);
+    OIIO_CHECK_EQUAL(std::string(css5->getColorSpaceNameByIndex(0)), std::string("cs3"));
+    OIIO_CHECK_NO_THROW(css5->clearColorSpaces());
+    OIIO_CHECK_EQUAL(css5->getNumColorSpaces(), 0);
+
+    OIIO_CHECK_NO_THROW(css5 = config->getColorSpaces("rendering"));
+    OIIO_REQUIRE_EQUAL(css5->getNumColorSpaces(), 2); // {cs2, cs3}
+    OIIO_CHECK_EQUAL(std::string(css5->getColorSpaceNameByIndex(0)), std::string("cs2"));
+    OIIO_CHECK_EQUAL(std::string(css5->getColorSpaceNameByIndex(1)), std::string("cs3"));
+
+    css4 = (css1  - css5)  // ( {cs1, cs2, cs3} - {cs2, cs3} ) --> {cs1}
+           && 
+           (css2 || css3); // ( {cs2} || {cs3} )               --> {cs2, cs3}
+
+    OIIO_CHECK_EQUAL(css4->getNumColorSpaces(), 0);
+}
+
+#endif // OCIO_UNIT_TEST

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -206,23 +206,11 @@ OCIO_NAMESPACE_ENTER
     
     
     bool FindColorSpaceIndex(int * index,
-                             const ColorSpaceVec & colorspaces,
+                             const ColorSpaceSetRcPtr & colorspaces,
                              const std::string & csname)
     {
-        if(csname.empty()) return false;
-        
-        const std::string csnamelower = pystring::lower(csname);
-
-        for(unsigned int i = 0; i < colorspaces.size(); ++i)
-        {
-            if(csnamelower == pystring::lower(colorspaces[i]->getName()))
-            {
-                if(index) *index = i;
-                return true;
-            }
-        }
-        
-        return false;
+        *index = colorspaces->getIndexForColorSpace(csname.c_str());
+        return *index!=-1;
     }
         
     } // namespace
@@ -238,7 +226,8 @@ OCIO_NAMESPACE_ENTER
         StringMap env_;
         ContextRcPtr context_;
         std::string description_;
-        ColorSpaceVec colorspaces_;
+        ColorSpaceSetRcPtr colorspaces_;
+
         StringMap roles_;
         LookVec looksList_;
         
@@ -270,7 +259,8 @@ OCIO_NAMESPACE_ENTER
             minorVersion_(0),
             context_(Context::Create()),
             strictParsing_(true),
-            sanity_(SANITY_UNKNOWN)
+            sanity_(SANITY_UNKNOWN),
+            colorspaces_(ColorSpaceSet::Create())
         {
             std::string activeDisplays;
             Platform::Getenv(OCIO_ACTIVE_DISPLAYS_ENVVAR, activeDisplays);
@@ -303,13 +293,7 @@ OCIO_NAMESPACE_ENTER
                 description_ = rhs.description_;
                 
                 // Deep copy the colorspaces
-                colorspaces_.clear();
-                colorspaces_.reserve(rhs.colorspaces_.size());
-                for(unsigned int i=0; i<rhs.colorspaces_.size(); ++i)
-                {
-                    colorspaces_.push_back(
-                        rhs.colorspaces_[i]->createEditableCopy());
-                }
+                colorspaces_ = rhs.colorspaces_;
                 
                 // Deep copy the looks
                 looksList_.clear();
@@ -476,9 +460,9 @@ OCIO_NAMESPACE_ENTER
         StringSet existingColorSpaces;
         
         // Confirm all ColorSpaces are valid
-        for(unsigned int i=0; i<getImpl()->colorspaces_.size(); ++i)
+        for(int i=0; i<getImpl()->colorspaces_->getNumColorSpaces(); ++i)
         {
-            if(!getImpl()->colorspaces_[i])
+            if(!getImpl()->colorspaces_->getColorSpaceByIndex(i))
             {
                 std::ostringstream os;
                 os << "Config failed sanitycheck. ";
@@ -487,7 +471,7 @@ OCIO_NAMESPACE_ENTER
                 throw Exception(getImpl()->sanitytext_.c_str());
             }
             
-            const char * name = getImpl()->colorspaces_[i]->getName();
+            const char * name = getImpl()->colorspaces_->getColorSpaceByIndex(i)->getName();
             if(!name || strlen(name) == 0)
             {
                 std::ostringstream os;
@@ -510,14 +494,14 @@ OCIO_NAMESPACE_ENTER
             }
 
             ConstTransformRcPtr toTrans 
-                = getImpl()->colorspaces_[i]->getTransform(COLORSPACE_DIR_TO_REFERENCE);
+                = getImpl()->colorspaces_->getColorSpaceByIndex(i)->getTransform(COLORSPACE_DIR_TO_REFERENCE);
             if (toTrans)
             {
                 toTrans->validate();
             }
 
             ConstTransformRcPtr fromTrans 
-                = getImpl()->colorspaces_[i]->getTransform(COLORSPACE_DIR_FROM_REFERENCE);
+                = getImpl()->colorspaces_->getColorSpaceByIndex(i)->getTransform(COLORSPACE_DIR_FROM_REFERENCE);
             if (fromTrans)
             {
                 fromTrans->validate();
@@ -842,30 +826,41 @@ OCIO_NAMESPACE_ENTER
     
     ///////////////////////////////////////////////////////////////////////////
     
+    ColorSpaceSetRcPtr Config::getColorSpaces(const char * category) const
+    {
+        ColorSpaceSetRcPtr res = ColorSpaceSet::Create();
+
+        for(int i=0; i<getImpl()->colorspaces_->getNumColorSpaces(); ++i)
+        {
+            ConstColorSpaceRcPtr cs = getImpl()->colorspaces_->getColorSpaceByIndex(i);
+            if(!category || !*category || cs->hasCategory(category))
+            {
+                res->addColorSpace(cs);
+            }
+        }
+
+        return res;
+    }
+
     int Config::getNumColorSpaces() const
     {
-        return static_cast<int>(getImpl()->colorspaces_.size());
+        return getImpl()->colorspaces_->getNumColorSpaces();
     }
     
     const char * Config::getColorSpaceNameByIndex(int index) const
     {
-        if(index<0 || index >= (int)getImpl()->colorspaces_.size())
-        {
-            return "";
-        }
-        
-        return getImpl()->colorspaces_[index]->getName();
+        return getImpl()->colorspaces_->getColorSpaceNameByIndex(index);
     }
     
     ConstColorSpaceRcPtr Config::getColorSpace(const char * name) const
     {
         int index = getIndexForColorSpace(name);
-        if(index<0 || index >= (int)getImpl()->colorspaces_.size())
+        if(index<0 || index >= (int)getImpl()->colorspaces_->getNumColorSpaces())
         {
             return ColorSpaceRcPtr();
         }
         
-        return getImpl()->colorspaces_[index];
+        return getImpl()->colorspaces_->getColorSpaceByIndex(index);
     }
     
     int Config::getIndexForColorSpace(const char * name) const
@@ -901,23 +896,7 @@ OCIO_NAMESPACE_ENTER
     
     void Config::addColorSpace(const ConstColorSpaceRcPtr & original)
     {
-        ColorSpaceRcPtr cs = original->createEditableCopy();
-        
-        std::string name = cs->getName();
-        if(name.empty())
-            throw Exception("Cannot addColorSpace with an empty name.");
-        
-        // Check to see if the colorspace already exists
-        int csindex = -1;
-        if( FindColorSpaceIndex(&csindex, getImpl()->colorspaces_, name) )
-        {
-            getImpl()->colorspaces_[csindex] = cs;
-        }
-        else
-        {
-            // Otherwise, add it
-            getImpl()->colorspaces_.push_back( cs );
-        }
+        getImpl()->colorspaces_->addColorSpace(original);
         
         AutoMutex lock(getImpl()->cacheidMutex_);
         getImpl()->resetCacheIDs();
@@ -925,7 +904,10 @@ OCIO_NAMESPACE_ENTER
     
     void Config::clearColorSpaces()
     {
-        getImpl()->colorspaces_.clear();
+        getImpl()->colorspaces_->clearColorSpaces();
+        
+        AutoMutex lock(getImpl()->cacheidMutex_);
+        getImpl()->resetCacheIDs();
     }
     
     
@@ -949,9 +931,9 @@ OCIO_NAMESPACE_ENTER
         int rightMostColorSpaceIndex = -1;
         
         // Find the right-most occcurance within the string for each colorspace.
-        for (unsigned int i=0; i<getImpl()->colorspaces_.size(); ++i)
+        for (int i=0; i<getImpl()->colorspaces_->getNumColorSpaces(); ++i)
         {
-            std::string csname = pystring::lower(getImpl()->colorspaces_[i]->getName());
+            std::string csname = pystring::lower(getImpl()->colorspaces_->getColorSpaceNameByIndex(i));
             
             // find right-most extension matched in filename
             int colorspacePos = pystring::rfind(fullstr, csname);
@@ -975,7 +957,7 @@ OCIO_NAMESPACE_ENTER
         
         if(rightMostColorSpaceIndex>=0)
         {
-            return getImpl()->colorspaces_[rightMostColorSpaceIndex]->getName();
+            return getImpl()->colorspaces_->getColorSpaceNameByIndex(rightMostColorSpaceIndex);
         }
         
         if(!getImpl()->strictParsing_)
@@ -989,7 +971,7 @@ OCIO_NAMESPACE_ENTER
                 {
                     // This is necessary to not return a reference to
                     // a local variable.
-                    return getImpl()->colorspaces_[csindex]->getName();
+                    return getImpl()->colorspaces_->getColorSpaceNameByIndex(csindex);
                 }
             }
         }
@@ -1591,12 +1573,18 @@ OCIO_NAMESPACE_ENTER
     void Config::Impl::getAllIntenalTransforms(ConstTransformVec & transformVec) const
     {
         // Grab all transforms from the ColorSpaces
-        for(unsigned int i=0; i<colorspaces_.size(); ++i)
+        for(int i=0; i<colorspaces_->getNumColorSpaces(); ++i)
         {
-            if(colorspaces_[i]->getTransform(COLORSPACE_DIR_TO_REFERENCE))
-                transformVec.push_back(colorspaces_[i]->getTransform(COLORSPACE_DIR_TO_REFERENCE));
-            if(colorspaces_[i]->getTransform(COLORSPACE_DIR_FROM_REFERENCE))
-                transformVec.push_back(colorspaces_[i]->getTransform(COLORSPACE_DIR_FROM_REFERENCE));
+            if(colorspaces_->getColorSpaceByIndex(i)->getTransform(COLORSPACE_DIR_TO_REFERENCE))
+            {
+                transformVec.push_back(
+                    colorspaces_->getColorSpaceByIndex(i)->getTransform(COLORSPACE_DIR_TO_REFERENCE));
+            }
+            if(colorspaces_->getColorSpaceByIndex(i)->getTransform(COLORSPACE_DIR_FROM_REFERENCE))
+            {
+                transformVec.push_back(
+                    colorspaces_->getColorSpaceByIndex(i)->getTransform(COLORSPACE_DIR_FROM_REFERENCE));
+            }
         }
         
         // Grab all transforms from the Looks
@@ -2582,7 +2570,90 @@ OIIO_ADD_TEST(Config, range_serialization)
                               OCIO::Exception,
                               "Loading the OCIO profile failed");
     }
+}
 
+OIIO_ADD_TEST(Config, categories)
+{
+    static const std::string MY_OCIO_CONFIG =
+        "ocio_profile_version: 1\n"
+        "\n"
+        "search_path: luts\n"
+        "strictparsing: true\n"
+        "luma: [0.2126, 0.7152, 0.0722]\n"
+        "\n"
+        "roles:\n"
+        "  default: raw1\n"
+        "  scene_linear: raw1\n"
+        "\n"
+        "displays:\n"
+        "  sRGB:\n"
+        "    - !<View> {name: Raw, colorspace: raw1}\n"
+        "\n"
+        "active_displays: []\n"
+        "active_views: []\n"
+        "\n"
+        "colorspaces:\n"
+        "  - !<ColorSpace>\n"
+        "    name: raw1\n"
+        "    family: \"\"\n"
+        "    equalitygroup: \"\"\n"
+        "    bitdepth: unknown\n"
+        "    isdata: false\n"
+        "    categories: [rendering, linear]\n"
+        "    allocation: uniform\n"
+        "    allocationvars: [-0.125, 1.125]\n"
+        "\n"
+        "  - !<ColorSpace>\n"
+        "    name: raw2\n"
+        "    family: \"\"\n"
+        "    equalitygroup: \"\"\n"
+        "    bitdepth: unknown\n"
+        "    isdata: false\n"
+        "    categories: [rendering]\n"
+        "    allocation: uniform\n"
+        "    allocationvars: [-0.125, 1.125]\n";
+
+    std::istringstream is;
+    is.str(MY_OCIO_CONFIG);
+
+    OCIO::ConstConfigRcPtr config;
+    OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OIIO_CHECK_NO_THROW(config->sanityCheck());
+
+    // Test the serialization & deserialization.
+
+    std::stringstream ss;
+    ss << *config.get();
+    OIIO_CHECK_EQUAL(ss.str(), MY_OCIO_CONFIG);
+
+    // Test the config content.
+
+    OCIO::ColorSpaceSetRcPtr css = config->getColorSpaces(nullptr);
+    OIIO_CHECK_EQUAL(css->getNumColorSpaces(), 2);
+    OCIO::ConstColorSpaceRcPtr cs = css->getColorSpaceByIndex(0);
+    OIIO_CHECK_EQUAL(cs->getNumCategories(), 2);
+    OIIO_CHECK_EQUAL(std::string(cs->getCategory(0)), std::string("rendering"));
+    OIIO_CHECK_EQUAL(std::string(cs->getCategory(1)), std::string("linear"));
+
+    css = config->getColorSpaces("linear");
+    OIIO_CHECK_EQUAL(css->getNumColorSpaces(), 1);
+    cs = css->getColorSpaceByIndex(0);
+    OIIO_CHECK_EQUAL(cs->getNumCategories(), 2);
+    OIIO_CHECK_EQUAL(std::string(cs->getCategory(0)), std::string("rendering"));
+    OIIO_CHECK_EQUAL(std::string(cs->getCategory(1)), std::string("linear"));
+
+    css = config->getColorSpaces("rendering");
+    OIIO_CHECK_EQUAL(css->getNumColorSpaces(), 2);
+
+    OIIO_CHECK_EQUAL(config->getNumColorSpaces(), 2);
+    OIIO_CHECK_EQUAL(std::string(config->getColorSpaceNameByIndex(0)), std::string("raw1"));
+    OIIO_CHECK_EQUAL(std::string(config->getColorSpaceNameByIndex(1)), std::string("raw2"));
+    OIIO_CHECK_EQUAL(config->getIndexForColorSpace("raw1"), 0);
+    OIIO_CHECK_EQUAL(config->getIndexForColorSpace("raw2"), 1);
+    cs = config->getColorSpace("raw1");
+    OIIO_CHECK_EQUAL(std::string(cs->getName()), std::string("raw1"));
+    cs = config->getColorSpace("raw2");
+    OIIO_CHECK_EQUAL(std::string(cs->getName()), std::string("raw2"));
 }
 
 #endif // OCIO_UNIT_TEST

--- a/src/OpenColorIO/OCIOYaml.cpp
+++ b/src/OpenColorIO/OCIOYaml.cpp
@@ -1387,6 +1387,15 @@ OCIO_NAMESPACE_ENTER
                     load(second, boolval);
                     cs->setIsData(boolval);
                 }
+                else if(key == "categories")
+                {
+                    std::vector<std::string> categories;
+                    load(second, categories);
+                    for(auto name : categories)
+                    {
+                        cs->addCategory(name.c_str());
+                    }
+                }
                 else if(key == "allocation")
                 {
                     Allocation val;
@@ -1435,7 +1444,18 @@ OCIO_NAMESPACE_ENTER
                 out << YAML::Value << YAML::Literal << cs->getDescription();
             }
             out << YAML::Key << "isdata" << YAML::Value << cs->isData();
-            
+
+            if(cs->getNumCategories() > 0)
+            {
+                std::vector<std::string> categories;
+                for(int idx=0; idx<cs->getNumCategories(); ++idx)
+                {
+                    categories.push_back(cs->getCategory(idx));
+                }
+                out << YAML::Key << "categories";
+                out << YAML::Flow << YAML::Value << categories;
+            }
+
             out << YAML::Key << "allocation" << YAML::Value;
             save(out, cs->getAllocation());
             if(cs->getAllocationNumVars() > 0)

--- a/src/OpenColorIO/PrivateTypes.h
+++ b/src/OpenColorIO/PrivateTypes.h
@@ -45,7 +45,6 @@ OCIO_NAMESPACE_ENTER
     typedef std::set<std::string> StringSet;
     
     typedef std::vector<ConstTransformRcPtr> ConstTransformVec;
-    typedef std::vector<ColorSpaceRcPtr> ColorSpaceVec;
     typedef std::vector<LookRcPtr> LookVec;
     
     typedef std::vector<TransformDirection> TransformDirectionVec;

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -57,6 +57,7 @@ set(SOURCES
 	BitDepthUtils.cpp
 	Caching.cpp
 	ColorSpace.cpp
+	ColorSpaceSet.cpp
 	Config.cpp
 	Context.cpp
 	Display.cpp


### PR DESCRIPTION
Please refer to #623 to have the complete explanation, and #627 for the first API proposal.

Here is the full implementation of the 'categories' support for Color Spaces. One could first have a look to the unit tests in the file ColorSpaceSet.cpp to have examples on how to use this new mechanism.

Note: To limit the size of the review, the Python bindings are planned for another pull request.