### PR TITLE
Adsk Contrib - Fix some Windows & Linux compilation warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,16 @@ option(OCIO_USE_SSE "Specify whether to enable SSE CPU performance optimizations
 option(OCIO_INLINES_HIDDEN "Specify whether to build with -fvisibility-inlines-hidden" ${UNIX})
 
 ###############################################################################
+# Platform dependent compilation flags
+
+set(PLATFORM_COMPILE_FLAGS "")
+if(MSVC)
+	# Because our Exceptions derive from std::runtime_error we can safely disable this warning
+	set(PLATFORM_COMPILE_FLAGS "/wd4275")
+endif()
+
+
+###############################################################################
 # External linking
 
 option(USE_EXTERNAL_YAML "Use system installed yaml-cpp library." OFF)

--- a/src/OpenColorIO/CMakeLists.txt
+++ b/src/OpenColorIO/CMakeLists.txt
@@ -120,10 +120,9 @@ if(WIN32)
 			XML_STATIC
 	)
 endif()
-if(MSVC)
-	# Because our Exceptions derive from std::runtime_error we can safely disable this warning
-	set_target_properties(OpenColorIO PROPERTIES COMPILE_FLAGS "/wd4275")
-endif()
+
+set_target_properties(OpenColorIO PROPERTIES 
+	COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 
 set_target_properties(OpenColorIO PROPERTIES
     VERSION ${OpenColorIO_VERSION}

--- a/src/OpenColorIO/fileformats/FileFormatSpi3D.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpi3D.cpp
@@ -32,6 +32,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenColorIO/OpenColorIO.h>
 
 #include "ops/Lut3D/Lut3DOp.h"
+#include "Platform.h"
 #include "pystring/pystring.h"
 #include "transforms/FileTransform.h"
 

--- a/src/OpenColorIO/ops/Lut3D/Lut3DOpData.cpp
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOpData.cpp
@@ -575,7 +575,7 @@ bool Lut3DOpData::operator==(const OpData & other) const
         return false;
     }
 
-    if (!OpData::operator==(*lop))
+    if (!OpData::operator==(other))
     {
         return false;
     }

--- a/src/OpenColorIO/ops/Lut3D/Lut3DOpData.h
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOpData.h
@@ -128,7 +128,7 @@ public:
 
     Lut3DOpDataRcPtr inverse() const;
 
-    bool operator==(const OpData& other) const;
+    bool operator==(const OpData& other) const override;
 
     void finalize() override;
 

--- a/src/apps/ociobakelut/CMakeLists.txt
+++ b/src/apps/ociobakelut/CMakeLists.txt
@@ -12,6 +12,9 @@ if(NOT BUILD_SHARED_LIBS)
     )
 endif()
 
+set_target_properties(ociobakelut PROPERTIES 
+    COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
+
 target_link_libraries(ociobakelut PRIVATE OpenColorIO lcms2 apputils)
 
 install(TARGETS ociobakelut

--- a/src/apps/ociocheck/CMakeLists.txt
+++ b/src/apps/ociocheck/CMakeLists.txt
@@ -11,6 +11,9 @@ if(NOT BUILD_SHARED_LIBS)
     )
 endif()
 
+set_target_properties(ociocheck PROPERTIES 
+    COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
+
 target_link_libraries(ociocheck PRIVATE OpenColorIO apputils)
 
 install(TARGETS ociocheck

--- a/src/apps/ocioconvert/CMakeLists.txt
+++ b/src/apps/ocioconvert/CMakeLists.txt
@@ -14,6 +14,9 @@ if(NOT BUILD_SHARED_LIBS)
     )
 endif()
 
+set_target_properties(ocioconvert PROPERTIES 
+	COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
+
 target_include_directories(ocioconvert 
 	SYSTEM
 	PRIVATE

--- a/src/apps/ociodisplay/CMakeLists.txt
+++ b/src/apps/ociodisplay/CMakeLists.txt
@@ -14,6 +14,9 @@ if(NOT BUILD_SHARED_LIBS)
     )
 endif()
 
+set_target_properties(ociodisplay PROPERTIES 
+	COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
+
 target_include_directories(ociodisplay 
 	SYSTEM
 	PRIVATE

--- a/src/apps/ociolutimage/CMakeLists.txt
+++ b/src/apps/ociolutimage/CMakeLists.txt
@@ -11,6 +11,9 @@ if(NOT BUILD_SHARED_LIBS)
     )
 endif()
 
+set_target_properties(ociolutimage PROPERTIES 
+    COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
+
 target_link_libraries(ociolutimage
 	PRIVATE
 		apputils

--- a/src/bindings/python/CMakeLists.txt
+++ b/src/bindings/python/CMakeLists.txt
@@ -50,11 +50,10 @@ if(WIN32)
 	set_target_properties(PyOpenColorIO PROPERTIES
 		SUFFIX ".pyd"
 	)
-	# Because our Exceptions derive from std::runtime_error we can safely disable this warning
-	set_target_properties(PyOpenColorIO PROPERTIES
-		COMPILE_FLAGS "/wd4275"
-	)
 endif()
+
+set_target_properties(PyOpenColorIO PROPERTIES 
+	COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 
 if(NOT BUILD_SHARED_LIBS)
     target_compile_definitions(PyOpenColorIO

--- a/src/utils/openglbuilder/CMakeLists.txt
+++ b/src/utils/openglbuilder/CMakeLists.txt
@@ -15,6 +15,9 @@ if(NOT BUILD_SHARED_LIBS)
     )
 endif()
 
+set_target_properties(openglbuilder PROPERTIES 
+    COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
+
 target_include_directories(openglbuilder
 	PUBLIC
 		${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/utils/pystring/CMakeLists.txt
+++ b/src/utils/pystring/CMakeLists.txt
@@ -4,5 +4,7 @@ set(SOURCES
 
 add_library(pystring STATIC ${SOURCES})
 set_target_properties(pystring PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(pystring PROPERTIES 
+    COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 target_include_directories(pystring PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(pystring public_api)

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -41,10 +41,9 @@ function(add_ocio_test NAME SOURCES PRIVATE_INCLUDES)
 				XML_STATIC
 		)
 	endif(WIN32)
-	if(MSVC)
-		# Because our Exceptions derive from std::runtime_error we can safely disable this warning
-		set_target_properties(${TEST_BINARY} PROPERTIES COMPILE_FLAGS "/wd4275")
-	endif(MSVC)
+	set_target_properties(${TEST_BINARY} PROPERTIES 
+		COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
+
 	add_test(${TEST_NAME} ${TEST_BINARY})
 endfunction(add_ocio_test)
 

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -30,6 +30,9 @@ if(NOT BUILD_SHARED_LIBS)
 	)
 endif()
 
+set_target_properties(test_gpu_exec PROPERTIES 
+	COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
+
 target_link_libraries(test_gpu_exec
 	PRIVATE
 		OpenColorIO


### PR DESCRIPTION
While investigating the Linux build break for #648 (i.e. compiling with gcc 4.8), I discovered warnings with gcc 5.4. So I fixed them, and took the opportunity to also fix the Windows "std::exception" warning.