### PR TITLE
Adsk Contrib - Remove the cmake HOMEPAGE_URL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.10)
 
 project(OpenColorIO 
 	VERSION 2.0.0
-	HOMEPAGE_URL http://opencolorio.org/
 	LANGUAGES CXX C)
 
 # "dev" for master or "" for any official release


### PR DESCRIPTION
As the cmake version 3.10 does not support it (i.e. support started with 3.12), I removed it from the project definition.

Refer to issue #654 