### PR TITLE
Adsk Contrib - Fix some gcc/clang warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,9 @@ option(OCIO_BUILD_GPU_TESTS "Specify whether to build gpu unittests" ON)
 option(OCIO_BUILD_PYTHON "Specify whether to build python bindings" ON)
 option(OCIO_BUILD_JAVA "Specify whether to build java bindings" OFF)
 
+option(OCIO_WARNING_AS_ERROR "Set build error level for CI testing" OFF)
+
+
 ###############################################################################
 # Optimisation / internal linking preferences
 
@@ -42,11 +45,21 @@ option(OCIO_INLINES_HIDDEN "Specify whether to build with -fvisibility-inlines-h
 # Platform dependent compilation flags
 
 set(PLATFORM_COMPILE_FLAGS "")
+
 if(MSVC)
 	# Because our Exceptions derive from std::runtime_error we can safely disable this warning
-	set(PLATFORM_COMPILE_FLAGS "/wd4275")
+	set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} /wd4275")
+else()
+	#TODO: Fix warnings before enabling the flag.
+	#set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -Wall")
 endif()
 
+if(OCIO_WARNING_AS_ERROR)
+	# Windows compilation has many tricky warnings, difficult to fix.
+	if(NOT MSVC)
+		set(PLATFORM_COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS} -Werror")
+	endif()
+endif()
 
 ###############################################################################
 # External linking

--- a/src/OpenColorIO/ColorSpace.cpp
+++ b/src/OpenColorIO/ColorSpace.cpp
@@ -248,7 +248,7 @@ OCIO_NAMESPACE_ENTER
 
     const char * ColorSpace::getCategory(int index) const
     {
-        if(index<0 || index>=getImpl()->categories_.size()) return nullptr;
+        if(index<0 || index>=(int)getImpl()->categories_.size()) return nullptr;
 
         return getImpl()->categories_[index].c_str();
     }

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -258,9 +258,9 @@ OCIO_NAMESPACE_ENTER
             majorVersion_(FirstSupportedMajorVersion_),
             minorVersion_(0),
             context_(Context::Create()),
+            colorspaces_(ColorSpaceSet::Create()),
             strictParsing_(true),
-            sanity_(SANITY_UNKNOWN),
-            colorspaces_(ColorSpaceSet::Create())
+            sanity_(SANITY_UNKNOWN)
         {
             std::string activeDisplays;
             Platform::Getenv(OCIO_ACTIVE_DISPLAYS_ENVVAR, activeDisplays);

--- a/src/OpenColorIO/GpuShader.h
+++ b/src/OpenColorIO/GpuShader.h
@@ -56,14 +56,14 @@ public:
     //
     unsigned getNum3DTextures() const override;
     void add3DTexture(const char * name, const char * id, unsigned edgelen, 
-                      Interpolation interpolation, const float * values);
+                      Interpolation interpolation, const float * values) override;
     void get3DTexture(unsigned index, const char *& name, 
                       const char *& id, unsigned & edgelen, 
                       Interpolation & interpolation) const override;
     void get3DTextureValues(unsigned index, const float *& value) const override;
 
     // Get the complete shader text
-    const char * getShaderText() const;
+    const char * getShaderText() const override;
 
     // Get the corresponding cache identifier
     virtual const char * getCacheID() const override;
@@ -87,8 +87,8 @@ public:
 
 protected:
 
-    unsigned getTextureMaxWidth() const;
-    void setTextureMaxWidth(unsigned maxWidth);
+    unsigned getTextureMaxWidth() const override;
+    void setTextureMaxWidth(unsigned maxWidth) override;
 
     // Uniforms are not used by the legacy shader builder
     //
@@ -141,8 +141,8 @@ class GenericGpuShaderDesc : public GpuShaderDesc
 public:
     static GpuShaderDescRcPtr Create();
 
-    unsigned getTextureMaxWidth() const;
-    void setTextureMaxWidth(unsigned maxWidth);
+    unsigned getTextureMaxWidth() const override;
+    void setTextureMaxWidth(unsigned maxWidth) override;
 
     // Accessors to the uniforms
     //
@@ -152,7 +152,7 @@ public:
 
     // Accessors to the 1D & 2D textures built from 1D LUT
     //
-    unsigned getNumTextures() const;
+    unsigned getNumTextures() const override;
     void addTexture(const char * name, const char * id, unsigned width, unsigned height,
                     TextureType channel, Interpolation interpolation, const float * values) override;
     void getTexture(unsigned index, const char *& name, const char *& id, 
@@ -171,7 +171,7 @@ public:
     void get3DTextureValues(unsigned index, const float *& value) const override;
 
     // Get the complete shader text
-    const char * getShaderText() const;
+    const char * getShaderText() const override;
 
     // Get the corresponding cache identifier
     virtual const char * getCacheID() const override;

--- a/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
@@ -274,7 +274,7 @@ OCIO_NAMESPACE_ENTER
             // Start the parsing of one element
             static void StartElementHandler(void *userData,
                 const XML_Char *name,
-                const XML_Char **atts)
+                const XML_Char ** /*atts*/)
             {
                 XMLParserHelper * pImpl = (XMLParserHelper*)userData;
 

--- a/src/OpenColorIO/fileformats/cdl/CDLReaderHelper.cpp
+++ b/src/OpenColorIO/fileformats/cdl/CDLReaderHelper.cpp
@@ -167,7 +167,7 @@ void XmlReaderColorCorrectionElt::setCDLTransformList(CDLTransformVecRcPtr pTran
     m_transformList = pTransformList;
 }
 
-void XmlReaderColorCorrectionElt::appendDescription(const std::string& desc)
+void XmlReaderColorCorrectionElt::appendDescription(const std::string& /*desc*/)
 {
     // TODO: OCIO only keeps the description on the SOP
     //m_transform->setDescription(desc.c_str());
@@ -255,7 +255,7 @@ XmlReaderSOPValueElt::~XmlReaderSOPValueElt()
 {
 }
 
-void XmlReaderSOPValueElt::start(const char **atts)
+void XmlReaderSOPValueElt::start(const char ** /*atts*/)
 {
     m_contentData = "";
 }
@@ -611,7 +611,7 @@ void XmlReaderSOPValueElt::end()
     }
 }
 
-void XmlReaderSOPValueElt::setRawData(const char* str, size_t len, unsigned int xmlLine)
+void XmlReaderSOPValueElt::setRawData(const char* str, size_t len, unsigned int /*xmlLine*/)
 {
     m_contentData += std::string(str, len) + " ";
 }

--- a/src/OpenColorIO/fileformats/cdl/CDLReaderHelper.h
+++ b/src/OpenColorIO/fileformats/cdl/CDLReaderHelper.h
@@ -266,13 +266,13 @@ class XmlReaderDummyElt : public XmlReaderPlainElt
         {
         }
 
-        void appendDescription(const std::string& desc)
+        void appendDescription(const std::string& /*desc*/)
         {
         }
 
         const std::string& getIdentifier() const;
 
-        void start(const char **atts)
+        void start(const char ** /*atts*/)
         {
         }
 
@@ -299,7 +299,7 @@ public:
 
     const std::string& getIdentifier() const;
 
-    void start(const char **atts)
+    void start(const char ** /*atts*/)
     {
     }
 
@@ -307,7 +307,7 @@ public:
     {
     }
 
-    void setRawData(const char* str, size_t len, unsigned xmlLine)
+    void setRawData(const char* str, size_t len, unsigned /*xmlLine*/)
     {
         m_rawData.push_back(std::string(str, len));
     }
@@ -340,7 +340,7 @@ public:
     {
     }
 
-    void start(const char **atts)
+    void start(const char ** /*atts*/)
     {
         m_description.resize(0);
         m_changed = false;
@@ -348,7 +348,7 @@ public:
 
     void end();
 
-    void setRawData(const char* str, size_t len, unsigned xmlLine)
+    void setRawData(const char* str, size_t len, unsigned /*xmlLine*/)
     {
         // keep adding to the string
         m_description += std::string(str, len);
@@ -394,7 +394,7 @@ public:
         return getName();
     }
 
-    void appendDescription(const std::string& desc)
+    void appendDescription(const std::string& /*desc*/)
     {
     }
 
@@ -417,7 +417,7 @@ public:
     {
     }
 
-    void start(const char **atts) {}
+    void start(const char ** /*atts*/) {}
 
     void end() {}
 
@@ -463,7 +463,7 @@ public:
     {
     }
 
-    virtual void start(const char **atts)
+    virtual void start(const char ** /*atts*/)
     {
     }
 
@@ -497,7 +497,7 @@ public:
     {
     }
 
-    void start(const char **atts)
+    void start(const char ** /*atts*/)
     {
     }
 
@@ -574,7 +574,7 @@ public:
     {
     }
 
-    void start(const char **atts)
+    void start(const char ** /*atts*/)
     {
         m_isSlopeInit = m_isOffsetInit = m_isPowerInit = false;
     }
@@ -653,7 +653,7 @@ public:
     {
     }
 
-    void start(const char **atts)
+    void start(const char ** /*atts*/)
     {
     }
 

--- a/src/OpenColorIO/ops/CDL/CDLOps.cpp
+++ b/src/OpenColorIO/ops/CDL/CDLOps.cpp
@@ -208,7 +208,7 @@ bool CDLOp::canCombineWith(ConstOpRcPtr & /*op*/) const
     return false;
 }
 
-void CDLOp::combineWith(OpRcPtrVec & ops, ConstOpRcPtr & secondOp) const
+void CDLOp::combineWith(OpRcPtrVec & /*ops*/, ConstOpRcPtr & secondOp) const
 {
     if(!canCombineWith(secondOp))
     {

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOpData.cpp
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOpData.cpp
@@ -495,7 +495,7 @@ unsigned long Lut1DOpData::GetLutIdealSize(BitDepth inputBitDepth,
     // However note that if the inputBitDepth is, e.g. 10i, this might not be
     // the number of entries required for a look-up.
 
-    unsigned long size = HALF_DOMAIN_REQUIRED_ENTRIES;
+    const unsigned long size = HALF_DOMAIN_REQUIRED_ENTRIES;
 
     if (Lut1DOpData::IsInputHalfDomain(halfFlags))
     {
@@ -723,7 +723,7 @@ void Lut1DOpData::finalize()
     cacheIDStream << InterpolationToString(m_interpolation) << " ";
     cacheIDStream << BitDepthToString(getInputBitDepth()) << " ";
     cacheIDStream << BitDepthToString(getOutputBitDepth()) << " ";
-    cacheIDStream << isInputHalfDomain()?"half domain ":"standard domain ";
+    cacheIDStream << (isInputHalfDomain() ? "half domain " : "standard domain ");
     cacheIDStream << GetHueAdjustName(m_hueAdjust) << " ";
     cacheIDStream << GetInvStyleName(m_invStyle);
 
@@ -1335,7 +1335,6 @@ OIIO_ADD_TEST(Lut1DOpData, accessors)
     // Note: Hue and Sat adjust do not affect identity status.
     OIIO_CHECK_ASSERT(l.isIdentity());
 
-    const float back1 = l.getArray()[1];
     l.getArray()[1] = 1.0f;
     OIIO_CHECK_ASSERT(!l.isNoOp());
     OIIO_CHECK_ASSERT(!l.isIdentity());

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOpData.h
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOpData.h
@@ -229,7 +229,7 @@ public:
     // lookup rather than interpolation.
     bool mayLookup(BitDepth incomingDepth) const;
 
-    bool operator==(const OpData & other) const;
+    bool operator==(const OpData & other) const override;
 
     OpDataRcPtr getIdentityReplacement() const;
 

--- a/src/OpenColorIO/ops/Lut3D/Lut3DOp.cpp
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOp.cpp
@@ -802,7 +802,7 @@ void CreateLut3DOp(OpRcPtrVec & ops,
                         "invalid lut specified.");
     }
 
-    const long lutSize = (long)lut->size[0];
+    const unsigned long lutSize = lut->size[0];
     if (lut->lut.size() != lutSize*lutSize*lutSize * 3)
     {
         throw Exception("Cannot apply Lut3DOp op, "
@@ -817,19 +817,19 @@ void CreateLut3DOp(OpRcPtrVec & ops,
 
     Array & lutArray = lutBF->getArray();
 
-    for (long b = 0; b < lutSize; ++b)
+    for (unsigned long b = 0; b < lutSize; ++b)
     {
-        for (long g = 0; g < lutSize; ++g)
+        for (unsigned long g = 0; g < lutSize; ++g)
         {
-            for (long r = 0; r < lutSize; ++r)
+            for (unsigned long r = 0; r < lutSize; ++r)
             {
                 // OpData::Lut3D Array index. b changes fastest.
-                const long arrayIdx = 3 * ((r*lutSize + g)*lutSize + b);
+                const unsigned long arrayIdx = 3 * ((r*lutSize + g)*lutSize + b);
 
                 // Lut3D struct index. r changes fastest.
-                const long ocioIdx = 3 * ((b*lutSize + g)*lutSize + r);
+                const unsigned long ocioIdx = 3 * ((b*lutSize + g)*lutSize + r);
 
-                lutArray[arrayIdx] = lut->lut[ocioIdx];
+                lutArray[arrayIdx    ] = lut->lut[ocioIdx    ];
                 lutArray[arrayIdx + 1] = lut->lut[ocioIdx + 1];
                 lutArray[arrayIdx + 2] = lut->lut[ocioIdx + 2];
             }
@@ -902,7 +902,7 @@ OIIO_ADD_TEST(Lut3DOpStruct, NanInfValueCheck)
     
     OIIO_CHECK_NO_THROW(GenerateIdentityLut3D(
         &lut->lut[0], lut->size[0], 3, OCIO::LUT3DORDER_FAST_RED));
-    for(long i=0; i<lut->lut.size(); ++i)
+    for(size_t i=0; i<lut->lut.size(); ++i)
     {
         lut->lut[i] = powf(lut->lut[i], 2.0f);
     }
@@ -940,7 +940,7 @@ OIIO_ADD_TEST(Lut3DOpStruct, ValueCheck)
     lut->lut.resize(lut->size[0] * lut->size[1] * lut->size[2] * 3);
     OIIO_CHECK_NO_THROW(GenerateIdentityLut3D(
         &lut->lut[0], lut->size[0], 3, OCIO::LUT3DORDER_FAST_RED));
-    for (long i = 0; i < lut->lut.size(); ++i)
+    for (size_t i = 0; i < lut->lut.size(); ++i)
     {
         lut->lut[i] = powf(lut->lut[i], 2.0f);
     }

--- a/src/OpenColorIO/ops/Lut3D/Lut3DOpData.cpp
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOpData.cpp
@@ -200,7 +200,7 @@ void Lut3DOpData::Compose(Lut3DOpDataRcPtr & A,
     // TODO: Code to handle dynamic properties should go here.
 }
 
-Lut3DOpData::Lut3DArray::Lut3DArray(long length,
+Lut3DOpData::Lut3DArray::Lut3DArray(unsigned long length,
                                     BitDepth outBitDepth)
 {
     resize(length, getMaxColorComponents());
@@ -326,7 +326,7 @@ void Lut3DOpData::Lut3DArray::scale(float scaleFactor)
     }
 }
 
-Lut3DOpData::Lut3DOpData(long gridSize)
+Lut3DOpData::Lut3DOpData(unsigned long gridSize)
     : OpData(BIT_DEPTH_F32, BIT_DEPTH_F32)
     , m_interpolation(INTERP_DEFAULT)
     , m_array(gridSize, getOutputBitDepth())
@@ -340,7 +340,7 @@ Lut3DOpData::Lut3DOpData(BitDepth inBitDepth,
                          const std::string& id,
                          const Descriptions& descriptions,
                          Interpolation interpolation,
-                         long gridSize)
+                         unsigned long gridSize)
     : OpData(inBitDepth, outBitDepth, id, descriptions)
     , m_interpolation(interpolation)
     , m_array(gridSize, getOutputBitDepth())
@@ -791,7 +791,7 @@ OIIO_ADD_TEST(OpDataLut3D, OuputDepthScaling)
 
     float expectedValue = 0.0f;
 
-    for (long i = 0; i < newArrValues.size(); i++)
+    for(unsigned long i = 0; i < (unsigned long)newArrValues.size(); i++)
     {
         expectedValue = initialArrValues[i] * factor;
         OIIO_CHECK_ASSERT(OCIO::EqualWithAbsError(expectedValue,

--- a/src/OpenColorIO/ops/Lut3D/Lut3DOpData.h
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOpData.h
@@ -71,7 +71,7 @@ public:
 
 public:
     // The gridSize parameter is the length of the cube axis.
-    explicit Lut3DOpData(long gridSize);
+    explicit Lut3DOpData(unsigned long gridSize);
 
     Lut3DOpData(
         BitDepth             inBitDepth,
@@ -79,7 +79,7 @@ public:
         const std::string &  id,
         const Descriptions & descriptions,
         Interpolation        interpolation,
-        long                 gridSize
+        unsigned long        gridSize
     );
 
     virtual ~Lut3DOpData();
@@ -143,7 +143,7 @@ public:
     class Lut3DArray : public Array
     {
     public:
-        Lut3DArray(long dimension, BitDepth outBitDepth);
+        Lut3DArray(unsigned long dimension, BitDepth outBitDepth);
 
         Lut3DArray(const Lut3DArray &) = default;
         Lut3DArray & operator= (const Lut3DArray &) = default;

--- a/src/OpenColorIO/ops/Matrix/MatrixOpData.h
+++ b/src/OpenColorIO/ops/Matrix/MatrixOpData.h
@@ -199,16 +199,16 @@ public:
 
     bool hasAlpha() const;
 
-    virtual void setOutputBitDepth(BitDepth out);
+    virtual void setOutputBitDepth(BitDepth out) override;
 
-    virtual void setInputBitDepth(BitDepth in);
+    virtual void setInputBitDepth(BitDepth in) override;
 
     MatrixOpDataRcPtr compose(ConstMatrixOpDataRcPtr & B) const;
 
     // Used by composition to remove small errors.
     void cleanUp(double offsetScale);
 
-    bool operator==(const OpData & other) const;
+    bool operator==(const OpData & other) const override;
 
     MatrixOpDataRcPtr inverse() const;
 

--- a/src/OpenColorIO/ops/Range/RangeOpCPU.cpp
+++ b/src/OpenColorIO/ops/Range/RangeOpCPU.cpp
@@ -364,7 +364,8 @@ OIIO_ADD_TEST(RangeOpCPU, identity)
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
-    const std::string typeName(typeid(*op.get()).name());
+    const OCIO::OpCPU & c = *op;
+    const std::string typeName(typeid(c).name());
     OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "NoOpCPU"));
 
     const long numPixels = 3;
@@ -402,7 +403,8 @@ OIIO_ADD_TEST(RangeOpCPU, scale_with_low_and_high_clippings)
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
-    const std::string typeName(typeid(*op.get()).name());
+    const OCIO::OpCPU & c = *op;
+    const std::string typeName(typeid(c).name());
     OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeScaleMinMaxRenderer"));
 
     const long numPixels = 3;
@@ -441,7 +443,8 @@ OIIO_ADD_TEST(RangeOpCPU, scale_with_low_clipping)
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
-    const std::string typeName(typeid(*op.get()).name());
+    const OCIO::OpCPU & c = *op;
+    const std::string typeName(typeid(c).name());
     OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeScaleMinRenderer"));
 
     const long numPixels = 3;
@@ -480,7 +483,8 @@ OIIO_ADD_TEST(RangeOpCPU, scale_with_high_clipping)
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
-    const std::string typeName(typeid(*op.get()).name());
+    const OCIO::OpCPU & c = *op;
+    const std::string typeName(typeid(c).name());
     OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeScaleMaxRenderer"));
 
     const long numPixels = 3;
@@ -518,7 +522,8 @@ OIIO_ADD_TEST(RangeOpCPU, scale_with_low_and_high_clippings_2)
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
-    const std::string typeName(typeid(*op.get()).name());
+    const OCIO::OpCPU & c = *op;
+    const std::string typeName(typeid(c).name());
     OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeScaleMinMaxRenderer"));
 
     const long numPixels = 3;
@@ -556,7 +561,8 @@ OIIO_ADD_TEST(RangeOpCPU, offset_with_low_and_high_clippings)
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
-    const std::string typeName(typeid(*op.get()).name());
+    const OCIO::OpCPU & c = *op;
+    const std::string typeName(typeid(c).name());
     OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeScaleMinMaxRenderer"));
 
     const long numPixels = 3;
@@ -594,7 +600,8 @@ OIIO_ADD_TEST(RangeOpCPU, low_and_high_clippings)
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
-    const std::string typeName(typeid(*op.get()).name());
+    const OCIO::OpCPU & c = *op;
+    const std::string typeName(typeid(c).name());
     OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeMinMaxRenderer"));
 
     const long numPixels = 4;
@@ -639,7 +646,8 @@ OIIO_ADD_TEST(RangeOpCPU, low_clipping)
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
-    const std::string typeName(typeid(*op.get()).name());
+    const OCIO::OpCPU & c = *op;
+    const std::string typeName(typeid(c).name());
     OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeMinRenderer"));
 
     const long numPixels = 3;
@@ -678,7 +686,8 @@ OIIO_ADD_TEST(RangeOpCPU, high_clipping)
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
-    const std::string typeName(typeid(*op.get()).name());
+    const OCIO::OpCPU & c = *op;
+    const std::string typeName(typeid(c).name());
     OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeMaxRenderer"));
 
     const long numPixels = 3;


### PR DESCRIPTION
1. Try to fix the latest clang warnings (and some gcc ones) to increase the chance to enable "-wall" for all *nix platforms. Unfortunately, it's difficult to fix all the warnings (even if some are highlighting potential problems). I do not have all the platform/compiler combinations i.e. working with docker images & vim could be complex.
2. Re-enable the 'warning as error' flag to stop the build if some warnings are detected. By default, the flag is off to avoid blocking occasional library devs/users.

The Travis CI build will help me to see what is the library status.