### PR TITLE
Update OCIO mail lists to ASWF domain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,11 @@ save yourself a lot of time by asking first.
 
 How do you talk to us? There are several ways to get in touch:
 
-* [ocio-dev](https://groups.google.com/forum/#!forum/ocio-dev):
+* [ocio-dev](https://lists.aswf.io/g/ocio-dev):
 This is a development focused mail list with a deep history of technical
 conversations and decisions that have shaped the project.
 
-* [ocio-users](https://groups.google.com/forum/#!forum/ocio-users):
+* [ocio-user](https://lists.aswf.io/g/ocio-user):
 This is an end-user oriented mail list, focused on how to use OCIO’s features
 within a host application. Common topics include crafting configs, DCC behavior,
 and general color questions.
@@ -34,7 +34,7 @@ GitHub **issues** are a great place to start a conversation! Issues aren’t
 restricted to bugs; we happily welcome feature requests and other suggestions
 submitted as issues. The only conversations we would direct away from issues are
 questions in the form of “How do I do X”. Please direct these to the ocio-dev or
-ocio-users mail lists, and consider contributing what you've learned to our
+ocio-user mail lists, and consider contributing what you've learned to our
 docs if appropriate!
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Web Resources
 -------------
 * Web page: http://opencolorio.org
 * Mail lists:
-    * Developer: ocio-dev@googlegroups.com
-    * User: ocio-users@googlegroups.com
+    * Developer: ocio-dev@lists.aswf.io
+    * User: ocio-user@lists.aswf.io
 * Slack channel: https://opencolorio.slack.com
     * Please request access on the ocio-dev email with the email address you would like to be invited on
 

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -33,8 +33,8 @@ rst_prolog = """
 .. |Sony Imageworks| replace:: `Sony Imageworks`_
 .. _Jeremy Selan: mailto:jeremy.selan@gmail.com
 .. |Jeremy Selan| replace:: `Jeremy Selan`_
-.. _ocio-users: http://groups.google.com/group/ocio-users
-.. _ocio-dev: http://groups.google.com/group/ocio-dev
+.. _ocio-user: https://lists.aswf.io/g/ocio-user
+.. _ocio-dev: https://lists.aswf.io/g/ocio-dev
 """
 
 # -- Options for HTML output ---------------------------------------------------

--- a/docs/configurations/index.rst
+++ b/docs/configurations/index.rst
@@ -8,7 +8,7 @@ and how to create new ones.
 
 OCIO Configurations can be downloaded here: `.zip <http://github.com/imageworks/OpenColorIO-Configs/zipball/master>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO-Configs/tarball/master>`__ (OCIO v1.0+)
 
-If you are interested in crafting custom color configurations, and need assistance, please contact: `ocio-dev <https://lists.aswf.io/g/ocio-dev>`__\.
+If you are interested in crafting custom color configurations, and need assistance, please contact: `ocio-user <https://lists.aswf.io/g/ocio-user>`__\.
 
 Public Configs
 **************

--- a/docs/configurations/index.rst
+++ b/docs/configurations/index.rst
@@ -8,7 +8,7 @@ and how to create new ones.
 
 OCIO Configurations can be downloaded here: `.zip <http://github.com/imageworks/OpenColorIO-Configs/zipball/master>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO-Configs/tarball/master>`__ (OCIO v1.0+)
 
-If you are interested in crafting custom color configurations, and need assistance, please contact: `ocio-dev <http://groups.google.com/group/ocio-dev>`__\.
+If you are interested in crafting custom color configurations, and need assistance, please contact: `ocio-dev <https://lists.aswf.io/g/ocio-dev>`__\.
 
 Public Configs
 **************

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,7 +51,7 @@ provide a menu option to select a different OCIO configuration after launch.
 Please be sure to select a profile that matches your color workflow (VFX work
 typically requires a different profile than animated features). If you need
 assistance picking a profile, email 
-`ocio-user <http://lists.aswf.io/g/ocio-user>`__\.
+`ocio-user <https://lists.aswf.io/g/ocio-user>`__\.
 
 Downloading and Building the Code
 *********************************
@@ -64,7 +64,7 @@ Download a `.zip <http://github.com/imageworks/OpenColorIO/zipball/master>`_ or
 current state of the repository.
 
 Please see the :ref:`developer-guide` for more info, and contact `ocio-dev
-<http://lists.aswf.io/g/ocio-dev>`__\  with any questions.
+<https://lists.aswf.io/g/ocio-dev>`__\  with any questions.
 
 .. toctree::
     :hidden:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,11 +23,11 @@ Mailing Lists
 
 There are two mailing lists associated with OpenColorIO:
 
-`ocio-users <http://groups.google.com/group/ocio-users>`__\ ``@googlegroups.com``
+`ocio-user <https://lists.aswf.io/g/ocio-user>`__\ ``@lists.aswf.io``
     For end users (artists, often) interested in OCIO profile design,
     facility color management, and workflow.
 
-`ocio-dev <http://groups.google.com/group/ocio-dev>`__\ ``@googlegroups.com``
+`ocio-dev <https://lists.aswf.io/g/ocio-dev>`__\ ``@lists.aswf.io``
     For developers interested OCIO APIs, code integration, compilation, etc.
 
 Quick Start
@@ -40,7 +40,7 @@ each application.
 Note that OCIO configurations are required to do any 'real' work, and are
 available separately on the :ref:`downloads` section of this site. Example
 images are also available. For assistance customizing .ocio configurations,
-contact `ocio-users <http://groups.google.com/group/ocio-users>`__\.
+contact `ocio-user <https://lists.aswf.io/g/ocio-user>`__\.
 
 - Step 1:  set the OCIO environment-variable to /path/to/your/profile.ocio
 - Step 2:  Launch supported application.
@@ -51,7 +51,7 @@ provide a menu option to select a different OCIO configuration after launch.
 Please be sure to select a profile that matches your color workflow (VFX work
 typically requires a different profile than animated features). If you need
 assistance picking a profile, email 
-`ocio-users <http://groups.google.com/group/ocio-users>`__\.
+`ocio-user <http://lists.aswf.io/g/ocio-user>`__\.
 
 Downloading and Building the Code
 *********************************
@@ -64,7 +64,7 @@ Download a `.zip <http://github.com/imageworks/OpenColorIO/zipball/master>`_ or
 current state of the repository.
 
 Please see the :ref:`developer-guide` for more info, and contact `ocio-dev
-<http://groups.google.com/group/ocio-dev>`__\  with any questions.
+<http://lists.aswf.io/g/ocio-dev>`__\  with any questions.
 
 .. toctree::
     :hidden:


### PR DESCRIPTION
Notice of the mail list change has been sent to ocio-dev and ocio-users. This PR updates OCIO docs to reflect the change.