### PR TITLE
Add USE_SSE Checks To Fix Compile on Linux

### DIFF
--- a/src/core/Lut1DOp.cpp
+++ b/src/core/Lut1DOp.cpp
@@ -189,6 +189,7 @@ OCIO_NAMESPACE_ENTER
             return simple_lut[clamp(index, 0.0f, maxIndex)];
         }
         
+#if !defined(USE_SSE) || defined(OCIO_UNIT_TEST)
         void Lut1D_Nearest(float* rgbaBuffer, long numPixels, const Lut1D & lut)
         {
             float maxIndex[3];
@@ -218,6 +219,8 @@ OCIO_NAMESPACE_ENTER
                 rgbaBuffer += 4;
             }
         }
+#endif
+
 #ifdef USE_SSE
         void Lut1D_Nearest_SSE(float* rgbaBuffer, long numPixels, const Lut1D & lut)
         {

--- a/src/core/MathUtils.cpp
+++ b/src/core/MathUtils.cpp
@@ -330,11 +330,13 @@ OCIO_NAMESPACE_ENTER
     namespace
     {
     
+#if defined(OCIO_UNIT_TEST)
     void GetMxbResult(float* vout, float* m, float* x, float* v)
     {
         GetM44V4Product(vout, m, x);
         GetV4Sum(vout, vout, v);
     }
+#endif
     
     } // anon namespace
     


### PR DESCRIPTION
Fixes #617.

I'm not 100% sure I'm understanding this correctly, but when SSE is enabled, in `Lut1DOp.cpp` the compiler complains because `Lut1D_Nearest()` is defined but not used. The function *is* used in the unit tests, so we include it only when SSE is disabled or we are compiling unit tests.

For `MathUtils.cpp` it is a similar story, but for some reason, even with SSE disabled, the compiler will complain that the `GetMxbResult()` function is defined but not used for the DLL (.so) build. The function *is* used for the static build of the library, so we include it in the static build and the unit tests.

The tests will run successfully, but I've only tested on Linux.

Tell me if I'm missing anything! :smiley: