### PR TITLE
Cherry picked fixes for proposed 1.1.x release

### DIFF
--- a/src/apps/ocioconvert/main.cpp
+++ b/src/apps/ocioconvert/main.cpp
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenColorIO/OpenColorIO.h>
 namespace OCIO = OCIO_NAMESPACE;
 
+// NB: OIIO_VERSION >= 10903 requires C++11 or later
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/typedesc.h>
 #if (OIIO_VERSION < 10100)

--- a/src/apps/ocioconvert/main.cpp
+++ b/src/apps/ocioconvert/main.cpp
@@ -321,7 +321,7 @@ int main(int argc, const char **argv)
         f->write_image(OIIO::TypeDesc::FLOAT, &img[0]);
         f->close();
 #if OIIO_VERSION < 10903
-        OIIO::ImageInput::destroy(f);
+        OIIO::ImageOutput::destroy(f);
 #endif
     }
     catch(...)

--- a/src/apps/ocioconvert/main.cpp
+++ b/src/apps/ocioconvert/main.cpp
@@ -119,7 +119,11 @@ int main(int argc, const char **argv)
     std::cerr << "Loading " << inputimage << std::endl;
     try
     {
+#if OIIO_VERSION < 10903
+        ImageInput* f = OIIO::ImageInput::create(inputimage);
+#else
         auto f = OIIO::ImageInput::create(inputimage);
+#endif
         if(!f)
         {
             std::cerr << "Could not create image input." << std::endl;
@@ -310,7 +314,11 @@ int main(int argc, const char **argv)
     // Write out the result
     try
     {
+#if OIIO_VERSION < 10903
+        OIIO::ImageOutput* f = OIIO::ImageOutput::create(outputimage);
+#else
         auto f = OIIO::ImageOutput::create(outputimage);
+#endif
         if(!f)
         {
             std::cerr << "Could not create output input." << std::endl;

--- a/src/apps/ocioconvert/main.cpp
+++ b/src/apps/ocioconvert/main.cpp
@@ -119,7 +119,7 @@ int main(int argc, const char **argv)
     std::cerr << "Loading " << inputimage << std::endl;
     try
     {
-        OIIO::ImageInput* f = OIIO::ImageInput::create(inputimage);
+        auto f = OIIO::ImageInput::create(inputimage);
         if(!f)
         {
             std::cerr << "Could not create image input." << std::endl;
@@ -143,7 +143,9 @@ int main(int argc, const char **argv)
         memset(&img[0], 0, imgwidth*imgheight*components*sizeof(float));
         
         f->read_image(OIIO::TypeDesc::TypeFloat, &img[0]);
-        delete f;
+#if OIIO_VERSION < 10903
+        OIIO::ImageInput::destroy(f);
+#endif
         
         std::vector<int> kchannels;
         //parse --ch argument
@@ -308,7 +310,7 @@ int main(int argc, const char **argv)
     // Write out the result
     try
     {
-        OIIO::ImageOutput* f = OIIO::ImageOutput::create(outputimage);
+        auto f = OIIO::ImageOutput::create(outputimage);
         if(!f)
         {
             std::cerr << "Could not create output input." << std::endl;
@@ -318,7 +320,9 @@ int main(int argc, const char **argv)
         f->open(outputimage, spec);
         f->write_image(OIIO::TypeDesc::FLOAT, &img[0]);
         f->close();
-        delete f;
+#if OIIO_VERSION < 10903
+        OIIO::ImageInput::destroy(f);
+#endif
     }
     catch(...)
     {

--- a/src/apps/ocioconvert/main.cpp
+++ b/src/apps/ocioconvert/main.cpp
@@ -33,13 +33,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenColorIO/OpenColorIO.h>
 namespace OCIO = OCIO_NAMESPACE;
 
-// NB: OIIO_VERSION >= 10903 requires C++11 or later
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/typedesc.h>
 #if (OIIO_VERSION < 10100)
 namespace OIIO = OIIO_NAMESPACE;
 #endif
 
+#if OIIO_VERSION >= 10903 && __cplusplus < 201103
+#error While not officially supported, compile with C++11 (or higher) to use OIIO versions 1.9.3 or newer
+#endif
 
 #include "argparse.h"
 
@@ -121,7 +123,7 @@ int main(int argc, const char **argv)
     try
     {
 #if OIIO_VERSION < 10903
-        ImageInput* f = OIIO::ImageInput::create(inputimage);
+        OIIO::ImageInput* f = OIIO::ImageInput::create(inputimage);
 #else
         auto f = OIIO::ImageInput::create(inputimage);
 #endif

--- a/src/apps/ociodisplay/main.cpp
+++ b/src/apps/ociodisplay/main.cpp
@@ -39,9 +39,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenColorIO/OpenColorIO.h>
 namespace OCIO = OCIO_NAMESPACE;
 
-// NB: OIIO_VERSION >= 10903 requires C++11 or later
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/typedesc.h>
+
+#if OIIO_VERSION >= 10903 && __cplusplus < 201103
+#error While not officially supported, compile with C++11 (or higher) to use OIIO versions 1.9.3 or newer
+#endif
 
 #ifdef __APPLE__
 #include <OpenGL/gl.h>

--- a/src/apps/ociodisplay/main.cpp
+++ b/src/apps/ociodisplay/main.cpp
@@ -103,7 +103,11 @@ static void InitImageTexture(const char * filename)
         std::cout << "loading: " << filename << std::endl;
         try
         {
+#if OIIO_VERSION < 10903
+            OIIO::ImageInput* f = OIIO::ImageInput::create(filename);
+#else
             auto f = OIIO::ImageInput::create(filename);
+#endif
             if(!f)
             {
                 std::cerr << "Could not create image input." << std::endl;

--- a/src/apps/ociodisplay/main.cpp
+++ b/src/apps/ociodisplay/main.cpp
@@ -41,9 +41,6 @@ namespace OCIO = OCIO_NAMESPACE;
 
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/typedesc.h>
-#if (OIIO_VERSION < 10100)
-namespace OIIO = OIIO_NAMESPACE;
-#endif
 
 #ifdef __APPLE__
 #include <OpenGL/gl.h>
@@ -106,7 +103,7 @@ static void InitImageTexture(const char * filename)
         std::cout << "loading: " << filename << std::endl;
         try
         {
-            OIIO::ImageInput* f = OIIO::ImageInput::create(filename);
+            auto f = OIIO::ImageInput::create(filename);
             if(!f)
             {
                 std::cerr << "Could not create image input." << std::endl;
@@ -137,7 +134,9 @@ static void InitImageTexture(const char * filename)
                 OIIO::TypeDesc::TypeFloat, 
 #endif
                 &img[0]);
+#if OIIO_VERSION < 10903
             OIIO::ImageInput::destroy(f);
+#endif
         }
         catch(...)
         {

--- a/src/apps/ociodisplay/main.cpp
+++ b/src/apps/ociodisplay/main.cpp
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <OpenColorIO/OpenColorIO.h>
 namespace OCIO = OCIO_NAMESPACE;
 
+// NB: OIIO_VERSION >= 10903 requires C++11 or later
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/typedesc.h>
 

--- a/src/apps/ociolutimage/main.cpp
+++ b/src/apps/ociolutimage/main.cpp
@@ -113,7 +113,11 @@ void Generate(int cubesize, int maxwidth,
         processor->apply(imgdesc);
     }
 
+#if OIIO_VERSION < 10903
+    OIIO::ImageOutput* f = OIIO::ImageOutput::create(outputfile);
+#else
     auto f = OIIO::ImageOutput::create(outputfile);
+#endif
     if(!f)
     {
         throw Exception( "Could not create output image.");
@@ -136,7 +140,11 @@ void Extract(int cubesize, int maxwidth,
              const std::string & outputfile)
 {
     // Read the image
+#if OIIO_VERSION < 10903
+    OIIO::ImageInput* f = OIIO::ImageInput::create(inputfile);
+#else
     auto f = OIIO::ImageInput::create(inputfile);
+#endif
     if(!f)
     {
         throw Exception("Could not create input image.");

--- a/src/apps/ociolutimage/main.cpp
+++ b/src/apps/ociolutimage/main.cpp
@@ -126,7 +126,7 @@ void Generate(int cubesize, int maxwidth,
     f->write_image(OIIO::TypeDesc::FLOAT, &img[0]);
     f->close();
 #if OIIO_VERSION < 10903
-    OIIO::ImageInput::destroy(f);
+    OIIO::ImageOutput::destroy(f);
 #endif
 }
 

--- a/src/apps/ociolutimage/main.cpp
+++ b/src/apps/ociolutimage/main.cpp
@@ -30,9 +30,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace OCIO = OCIO_NAMESPACE;
 OCIO_NAMESPACE_USING;
 
-// NB: OIIO_VERSION >= 10903 requires C++11 or later
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/typedesc.h>
+
+#if OIIO_VERSION >= 10903 && __cplusplus < 201103
+#error While not officially supported, compile with C++11 (or higher) to use OIIO versions 1.9.3 or newer
+#endif
 
 #include "argparse.h"
 

--- a/src/apps/ociolutimage/main.cpp
+++ b/src/apps/ociolutimage/main.cpp
@@ -32,9 +32,6 @@ OCIO_NAMESPACE_USING;
 
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/typedesc.h>
-#if (OIIO_VERSION < 10100)
-namespace OIIO = OIIO_NAMESPACE;
-#endif
 
 #include "argparse.h"
 
@@ -116,7 +113,7 @@ void Generate(int cubesize, int maxwidth,
         processor->apply(imgdesc);
     }
 
-    OIIO::ImageOutput* f = OIIO::ImageOutput::create(outputfile);
+    auto f = OIIO::ImageOutput::create(outputfile);
     if(!f)
     {
         throw Exception( "Could not create output image.");
@@ -128,7 +125,9 @@ void Generate(int cubesize, int maxwidth,
     f->open(outputfile, spec);
     f->write_image(OIIO::TypeDesc::FLOAT, &img[0]);
     f->close();
-    delete f;
+#if OIIO_VERSION < 10903
+    OIIO::ImageInput::destroy(f);
+#endif
 }
 
 
@@ -137,7 +136,7 @@ void Extract(int cubesize, int maxwidth,
              const std::string & outputfile)
 {
     // Read the image
-    OIIO::ImageInput* f = OIIO::ImageInput::create(inputfile);
+    auto f = OIIO::ImageInput::create(inputfile);
     if(!f)
     {
         throw Exception("Could not create input image.");
@@ -183,7 +182,9 @@ void Extract(int cubesize, int maxwidth,
     std::vector<float> img;
     img.resize(spec.width*spec.height*spec.nchannels, 0);
     f->read_image(OIIO::TypeDesc::TypeFloat, &img[0]);
-    delete f;
+#if OIIO_VERSION < 10903
+    OIIO::ImageInput::destroy(f);
+#endif
     
     // Repack into rgb
     // Convert the RGB[...] image to an RGB image, in place.

--- a/src/apps/ociolutimage/main.cpp
+++ b/src/apps/ociolutimage/main.cpp
@@ -30,6 +30,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace OCIO = OCIO_NAMESPACE;
 OCIO_NAMESPACE_USING;
 
+// NB: OIIO_VERSION >= 10903 requires C++11 or later
 #include <OpenImageIO/imageio.h>
 #include <OpenImageIO/typedesc.h>
 

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -265,11 +265,17 @@ OCIO_NAMESPACE_ENTER
         {
             std::string activeDisplays;
             Platform::getenv(OCIO_ACTIVE_DISPLAYS_ENVVAR, activeDisplays);
-            SplitStringEnvStyle(activeDisplaysEnvOverride_, activeDisplays.c_str());
+            activeDisplays = pystring::strip(activeDisplays);
+            if (!activeDisplays.empty()) {
+                SplitStringEnvStyle(activeDisplaysEnvOverride_, activeDisplays.c_str());
+            }
             
             std::string activeViews;
             Platform::getenv(OCIO_ACTIVE_VIEWS_ENVVAR, activeViews);
-            SplitStringEnvStyle(activeViewsEnvOverride_, activeViews.c_str());
+            activeViews = pystring::strip(activeViews);
+            if (!activeViews.empty()) {
+                SplitStringEnvStyle(activeViewsEnvOverride_, activeViews.c_str());
+            }
             
             defaultLumaCoefs_.resize(3);
             defaultLumaCoefs_[0] = DEFAULT_LUMA_COEFF_R;
@@ -2074,6 +2080,372 @@ OIIO_ADD_TEST(Config, Env_colorspace_name)
         std::stringstream ss;
         ss << *config.get();
         OIIO_CHECK_EQUAL(ss.str(), MY_OCIO_CONFIG);
+    }
+}
+
+OIIO_ADD_TEST(Config, display)
+{
+    static const std::string SIMPLE_PROFILE_HEADER =
+        "ocio_profile_version: 1\n"
+        "\n"
+        "search_path: luts\n"
+        "strictparsing: true\n"
+        "luma: [0.2126, 0.7152, 0.0722]\n"
+        "\n"
+        "roles:\n"
+        "  default: raw\n"
+        "  scene_linear: lnh\n"
+        "\n"
+        "displays:\n"
+        "  sRGB_1:\n"
+        "    - !<View> {name: Raw, colorspace: raw}\n"
+        "  sRGB_2:\n"
+        "    - !<View> {name: Raw, colorspace: raw}\n"
+        "  sRGB_3:\n"
+        "    - !<View> {name: Raw, colorspace: raw}\n"
+        "\n";
+
+    static const std::string SIMPLE_PROFILE_FOOTER =
+        "\n"
+        "colorspaces:\n"
+        "  - !<ColorSpace>\n"
+        "    name: raw\n"
+        "    family: \"\"\n"
+        "    equalitygroup: \"\"\n"
+        "    bitdepth: unknown\n"
+        "    isdata: false\n"
+        "    allocation: uniform\n"
+        "\n"
+        "  - !<ColorSpace>\n"
+        "    name: lnh\n"
+        "    family: \"\"\n"
+        "    equalitygroup: \"\"\n"
+        "    bitdepth: unknown\n"
+        "    isdata: false\n"
+        "    allocation: uniform\n";
+
+    {
+        std::string myProfile = 
+            SIMPLE_PROFILE_HEADER
+            +
+            "active_displays: []\n"
+            "active_views: []\n"
+            + SIMPLE_PROFILE_FOOTER;
+
+        std::istringstream is(myProfile);
+        OCIO::ConstConfigRcPtr config;
+        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OIIO_CHECK_EQUAL(config->getNumDisplays(), 3);
+        OIIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_1"));
+        OIIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_2"));
+        OIIO_CHECK_EQUAL(std::string(config->getDisplay(2)), std::string("sRGB_3"));
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_1");
+    }
+
+    {
+        std::string myProfile = 
+            SIMPLE_PROFILE_HEADER
+            +
+            "active_displays: [sRGB_1]\n"
+            "active_views: []\n"
+            + SIMPLE_PROFILE_FOOTER;
+
+        std::istringstream is(myProfile);
+        OCIO::ConstConfigRcPtr config;
+        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OIIO_CHECK_EQUAL(config->getNumDisplays(), 1);
+        OIIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_1"));
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_1");
+    }
+
+    {
+        std::string myProfile = 
+            SIMPLE_PROFILE_HEADER
+            +
+            "active_displays: [sRGB_2, sRGB_1]\n"
+            "active_views: []\n"
+            + SIMPLE_PROFILE_FOOTER;
+
+        std::istringstream is(myProfile);
+        OCIO::ConstConfigRcPtr config;
+        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OIIO_CHECK_EQUAL(config->getNumDisplays(), 2);
+        OIIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_2"));
+        OIIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_1"));
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_2");
+    }
+
+    {
+        std::string myProfile = 
+            SIMPLE_PROFILE_HEADER
+            +
+            "active_displays: []\n"
+            "active_views: []\n"
+            + SIMPLE_PROFILE_FOOTER;
+
+        const std::string active_displays(
+            std::string(OCIO::OCIO_ACTIVE_DISPLAYS_ENVVAR) + "= sRGB_3, sRGB_2");
+        putenv(const_cast<char *>(active_displays.c_str()));
+
+        std::istringstream is(myProfile);
+        OCIO::ConstConfigRcPtr config;
+        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OIIO_CHECK_EQUAL(config->getNumDisplays(), 2);
+        OIIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_3"));
+        OIIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_2"));
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_3");
+    }
+
+    {
+        std::string myProfile = 
+            SIMPLE_PROFILE_HEADER
+            +
+            "active_displays: [sRGB_2, sRGB_1]\n"
+            "active_views: []\n"
+            + SIMPLE_PROFILE_FOOTER;
+
+        const std::string active_displays(
+            std::string(OCIO::OCIO_ACTIVE_DISPLAYS_ENVVAR) + "= sRGB_3, sRGB_2");
+        putenv(const_cast<char *>(active_displays.c_str()));
+
+        std::istringstream is(myProfile);
+        OCIO::ConstConfigRcPtr config;
+        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OIIO_CHECK_EQUAL(config->getNumDisplays(), 2);
+        OIIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_3"));
+        OIIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_2"));
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_3");
+    }
+
+    {
+        const std::string active_displays(
+            std::string(OCIO::OCIO_ACTIVE_DISPLAYS_ENVVAR) + "="); // No value
+        putenv(const_cast<char *>(active_displays.c_str()));
+
+        std::string myProfile = 
+            SIMPLE_PROFILE_HEADER
+            +
+            "active_displays: [sRGB_2, sRGB_1]\n"
+            "active_views: []\n"
+            + SIMPLE_PROFILE_FOOTER;
+
+        std::istringstream is(myProfile);
+        OCIO::ConstConfigRcPtr config;
+        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OIIO_CHECK_EQUAL(config->getNumDisplays(), 2);
+        OIIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_2"));
+        OIIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_1"));
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_2");
+    }
+
+    {
+        const std::string active_displays(
+            std::string(OCIO::OCIO_ACTIVE_DISPLAYS_ENVVAR) + "= "); // No value, but misleading space
+        putenv(const_cast<char *>(active_displays.c_str()));
+
+        std::string myProfile = 
+            SIMPLE_PROFILE_HEADER
+            +
+            "active_displays: [sRGB_2, sRGB_1]\n"
+            "active_views: []\n"
+            + SIMPLE_PROFILE_FOOTER;
+
+        std::istringstream is(myProfile);
+        OCIO::ConstConfigRcPtr config;
+        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OIIO_CHECK_EQUAL(config->getNumDisplays(), 2);
+        OIIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_2"));
+        OIIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_1"));
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_2");
+    }
+}
+
+OIIO_ADD_TEST(Config, view)
+{
+    static const std::string SIMPLE_PROFILE_HEADER =
+        "ocio_profile_version: 1\n"
+        "\n"
+        "search_path: luts\n"
+        "strictparsing: true\n"
+        "luma: [0.2126, 0.7152, 0.0722]\n"
+        "\n"
+        "roles:\n"
+        "  default: raw\n"
+        "  scene_linear: lnh\n"
+        "\n"
+        "displays:\n"
+        "  sRGB_1:\n"
+        "    - !<View> {name: View_1, colorspace: raw}\n"
+        "    - !<View> {name: View_2, colorspace: raw}\n"
+        "  sRGB_2:\n"
+        "    - !<View> {name: View_2, colorspace: raw}\n"
+        "    - !<View> {name: View_3, colorspace: raw}\n"
+        "  sRGB_3:\n"
+        "    - !<View> {name: View_3, colorspace: raw}\n"
+        "    - !<View> {name: View_1, colorspace: raw}\n"
+        "\n";
+
+    static const std::string SIMPLE_PROFILE_FOOTER =
+        "\n"
+        "colorspaces:\n"
+        "  - !<ColorSpace>\n"
+        "    name: raw\n"
+        "    family: \"\"\n"
+        "    equalitygroup: \"\"\n"
+        "    bitdepth: unknown\n"
+        "    isdata: false\n"
+        "    allocation: uniform\n"
+        "\n"
+        "  - !<ColorSpace>\n"
+        "    name: lnh\n"
+        "    family: \"\"\n"
+        "    equalitygroup: \"\"\n"
+        "    bitdepth: unknown\n"
+        "    isdata: false\n"
+        "    allocation: uniform\n";
+
+    {
+        std::string myProfile = 
+            SIMPLE_PROFILE_HEADER
+            +
+            "active_displays: []\n"
+            "active_views: []\n"
+            + SIMPLE_PROFILE_FOOTER;
+
+        std::istringstream is(myProfile);
+        OCIO::ConstConfigRcPtr config;
+        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_1");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
+    }
+
+    {
+        std::string myProfile = 
+            SIMPLE_PROFILE_HEADER
+            +
+            "active_displays: []\n"
+            "active_views: [View_3]\n"
+            + SIMPLE_PROFILE_FOOTER;
+
+        std::istringstream is(myProfile);
+        OCIO::ConstConfigRcPtr config;
+        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_1");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
+    }
+
+    {
+        std::string myProfile = 
+            SIMPLE_PROFILE_HEADER
+            +
+            "active_displays: []\n"
+            "active_views: [View_3, View_2, View_1]\n"
+            + SIMPLE_PROFILE_FOOTER;
+
+        std::istringstream is(myProfile);
+        OCIO::ConstConfigRcPtr config;
+        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
+    }
+
+    {
+        std::string myProfile = 
+            SIMPLE_PROFILE_HEADER
+            +
+            "active_displays: []\n"
+            "active_views: []\n"
+            + SIMPLE_PROFILE_FOOTER;
+
+        const std::string active_displays(
+            std::string(OCIO::OCIO_ACTIVE_VIEWS_ENVVAR) + "= View_3, View_2");
+        putenv(const_cast<char *>(active_displays.c_str()));
+
+        std::istringstream is(myProfile);
+        OCIO::ConstConfigRcPtr config;
+        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
+    }
+
+    {
+        std::string myProfile = 
+            SIMPLE_PROFILE_HEADER
+            +
+            "active_displays: []\n"
+            "active_views: []\n"
+            + SIMPLE_PROFILE_FOOTER;
+
+        const std::string active_displays(
+            std::string(OCIO::OCIO_ACTIVE_VIEWS_ENVVAR) + "="); // No value.
+        putenv(const_cast<char *>(active_displays.c_str()));
+
+        std::istringstream is(myProfile);
+        OCIO::ConstConfigRcPtr config;
+        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_1");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
+    }
+
+    {
+        std::string myProfile = 
+            SIMPLE_PROFILE_HEADER
+            +
+            "active_displays: []\n"
+            "active_views: []\n"
+            + SIMPLE_PROFILE_FOOTER;
+
+        const std::string active_displays(
+            std::string(OCIO::OCIO_ACTIVE_VIEWS_ENVVAR) + "= "); // No value, but misleading space
+        putenv(const_cast<char *>(active_displays.c_str()));
+
+        std::istringstream is(myProfile);
+        OCIO::ConstConfigRcPtr config;
+        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_1");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
+        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
     }
 }
 

--- a/src/core/Display.cpp
+++ b/src/core/Display.cpp
@@ -114,13 +114,13 @@ OCIO_NAMESPACE_ENTER
         // Apply the env override if it's not empty.
         if(!activeDisplaysEnvOverride.empty())
         {
-            displayCache = IntersectStringVecsCaseIgnore(displayMasterList, activeDisplaysEnvOverride);
+            displayCache = IntersectStringVecsCaseIgnore(activeDisplaysEnvOverride, displayMasterList);
             if(!displayCache.empty()) return;
         }
         // Otherwise, aApply the active displays if it's not empty.
         else if(!activeDisplays.empty())
         {
-            displayCache = IntersectStringVecsCaseIgnore(displayMasterList, activeDisplays);
+            displayCache = IntersectStringVecsCaseIgnore(activeDisplays, displayMasterList);
             if(!displayCache.empty()) return;
         }
         

--- a/src/core/Platform.cpp
+++ b/src/core/Platform.cpp
@@ -35,8 +35,9 @@ OCIO_NAMESPACE_ENTER
             }
             else
             {
-                value.resize(len+1);
-                ::snprintf(&value[0], len, "%s", val);
+                // NB: len is the sizeof() of a string ( i.e. not its strlen() )
+                value = val;
+                value.resize(len-1);
                 if(val) free(val);
             }
 #else
@@ -89,11 +90,31 @@ OIIO_ADD_TEST(Platform, getenv)
 OIIO_ADD_TEST(Platform, putenv)
 {
     {
-        ::putenv("MY_DUMMY_ENV=SomeValue");
+        const std::string value("MY_DUMMY_ENV=SomeValue");
+        ::putenv(const_cast<char*>(value.c_str()));
         std::string env;
         OCIO::Platform::getenv("MY_DUMMY_ENV", env);
         OIIO_CHECK_ASSERT(!env.empty());
+
         OIIO_CHECK_ASSERT(0==strcmp("SomeValue", env.c_str()));
+        OIIO_CHECK_EQUAL(strlen("SomeValue"), env.size());
+    }
+    {
+        const std::string value("MY_DUMMY_ENV= ");
+        ::putenv(const_cast<char*>(value.c_str()));
+        std::string env;
+        OCIO::Platform::getenv("MY_DUMMY_ENV", env);
+        OIIO_CHECK_ASSERT(!env.empty());
+
+        OIIO_CHECK_ASSERT(0==strcmp(" ", env.c_str()));
+        OIIO_CHECK_EQUAL(strlen(" "), env.size());
+    }
+    {
+        const std::string value("MY_DUMMY_ENV=");
+        ::putenv(const_cast<char*>(value.c_str()));
+        std::string env;
+        OCIO::Platform::getenv("MY_DUMMY_ENV", env);
+        OIIO_CHECK_ASSERT(env.empty());
     }
 }
 


### PR DESCRIPTION
This PR merges the two fixes from the master branch proposed for a new 1.1.x patch.

The changes to the apps (related to OpenImageIO) add a requirement for C++11 that was not previously present, so that impact needs weighing before we decide to merge this. I have successfully built and tested this against the latest OIIO release on Linux, but can also confirm it will not build with an earlier CXX standard. One solution may be to support both paths with some CMake magic.

Commits cherry picked from:
https://github.com/imageworks/OpenColorIO/commit/718cc7f9f7ebb189643b8691df7ef4d9a735adac
https://github.com/imageworks/OpenColorIO/commit/1ff22741ff577bd1be504452eb3fa4ce1a652370
(plus a later correction made to two ImageInput/ImageOutput mismatches)