### PR TITLE
Restore C++03 compat when using old OIIO

### DIFF
--- a/src/apps/ocioconvert/main.cpp
+++ b/src/apps/ocioconvert/main.cpp
@@ -409,7 +409,11 @@ int main(int argc, const char **argv)
     std::cerr << "Loading " << inputimage << std::endl;
     try
     {
+#if OIIO_VERSION < 10903
+        ImageInput* f = OIIO::ImageInput::create(inputimage);
+#else
         auto f = OIIO::ImageInput::create(inputimage);
+#endif
         if(!f)
         {
             std::cerr << "Could not create image input." << std::endl;
@@ -623,7 +627,11 @@ int main(int argc, const char **argv)
     // Write out the result
     try
     {
+#if OIIO_VERSION < 10903
+        OIIO::ImageOutput* f = OIIO::ImageOutput::create(outputimage);
+#else
         auto f = OIIO::ImageOutput::create(outputimage);
+#endif
         if(!f)
         {
             std::cerr << "Could not create output input." << std::endl;

--- a/src/apps/ociodisplay/main.cpp
+++ b/src/apps/ociodisplay/main.cpp
@@ -101,7 +101,11 @@ static void InitImageTexture(const char * filename)
         std::cout << "loading: " << filename << std::endl;
         try
         {
+#if OIIO_VERSION < 10903
+            OIIO::ImageInput* f = OIIO::ImageInput::create(filename);
+#else
             auto f = OIIO::ImageInput::create(filename);
+#endif
             if(!f)
             {
                 std::cerr << "Could not create image input." << std::endl;

--- a/src/apps/ociolutimage/main.cpp
+++ b/src/apps/ociolutimage/main.cpp
@@ -113,7 +113,11 @@ void Generate(int cubesize, int maxwidth,
         processor->apply(imgdesc);
     }
 
+#if OIIO_VERSION < 10903
+    OIIO::ImageOutput* f = OIIO::ImageOutput::create(outputfile);
+#else
     auto f = OIIO::ImageOutput::create(outputfile);
+#endif
     if(!f)
     {
         throw Exception( "Could not create output image.");
@@ -136,7 +140,11 @@ void Extract(int cubesize, int maxwidth,
              const std::string & outputfile)
 {
     // Read the image
+#if OIIO_VERSION < 10903
+    OIIO::ImageInput* f = OIIO::ImageInput::create(inputfile);
+#else
     auto f = OIIO::ImageInput::create(inputfile);
+#endif
     if(!f)
     {
         throw Exception("Could not create input image.");


### PR DESCRIPTION
We recently tried to change the OCIO code so that it would build
against both OIIO 2.0 as well as the older 1.x versions. In doing so,
we inadvertently broke OCIO for C++03.

This patch still requires C++11 when building against OIIO 2.x (it has
to), but is fine with C++03 if using older OIIO.