### PR TITLE
ASWF mail list updates for RB-1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Web Resources
 -------------
 * Web page: http://opencolorio.org
 * Mail lists:
-    * Developer: ocio-dev@googlegroups.com
-    * User: ocio-users@googlegroups.com
+    * Developer: ocio-dev@lists.aswf.io
+    * User: ocio-user@lists.aswf.io
 * Slack channel: https://opencolorio.slack.com
     * Please request access on the ocio-dev email with the email address you would like to be invited on
 

--- a/docs/CompatibleSoftware.rst
+++ b/docs/CompatibleSoftware.rst
@@ -225,9 +225,8 @@ Export capabilities through ociobakelut::
     
 
 
-.. TODO: Update this thread URL once Google group history is ported to aswf.io
 See this `ocio-dev thread
-<http://groups.google.com/group/ocio-dev/browse_thread/thread/56fd58e60d98e0f6#>`__
+<https://lists.aswf.io/g/ocio-dev/topic/30498585>`__
 for additional usage discussions.
 
 When exporting an ICC Profile, you will be asked to specify your monitor’s

--- a/docs/CompatibleSoftware.rst
+++ b/docs/CompatibleSoftware.rst
@@ -225,7 +225,8 @@ Export capabilities through ociobakelut::
     
 
 
-See this `ocio-dev thread 
+.. TODO: Update this thread URL once Google group history is ported to aswf.io
+See this `ocio-dev thread
 <http://groups.google.com/group/ocio-dev/browse_thread/thread/56fd58e60d98e0f6#>`__
 for additional usage discussions.
 

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -33,8 +33,8 @@ rst_prolog = """
 .. |Sony Imageworks| replace:: `Sony Imageworks`_
 .. _Jeremy Selan: mailto:jeremy.selan@gmail.com
 .. |Jeremy Selan| replace:: `Jeremy Selan`_
-.. _ocio-users: http://groups.google.com/group/ocio-users
-.. _ocio-dev: http://groups.google.com/group/ocio-dev
+.. _ocio-user: https://lists.aswf.io/g/ocio-user
+.. _ocio-dev: https://lists.aswf.io/g/ocio-dev
 """
 
 # -- Options for HTML output ---------------------------------------------------

--- a/docs/configurations/index.rst
+++ b/docs/configurations/index.rst
@@ -8,7 +8,7 @@ and how to create new ones.
 
 OCIO Configurations can be downloaded here: `.zip <http://github.com/imageworks/OpenColorIO-Configs/zipball/master>`__ `.tar.gz <http://github.com/imageworks/OpenColorIO-Configs/tarball/master>`__ (OCIO v1.0+)
 
-If you are interested in crafting custom color configurations, and need assistance, please contact: `ocio-dev <http://groups.google.com/group/ocio-dev>`__\.
+If you are interested in crafting custom color configurations, and need assistance, please contact: `ocio-user <https://lists.aswf.io/g/ocio-user>`__\.
 
 Public Configs
 **************

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,11 +23,11 @@ Mailing Lists
 
 There are two mailing lists associated with OpenColorIO:
 
-`ocio-users <http://groups.google.com/group/ocio-users>`__\ ``@googlegroups.com``
+`ocio-user <https://lists.aswf.io/g/ocio-user>`__\ ``@lists.aswf.io``
     For end users (artists, often) interested in OCIO profile design,
     facility color management, and workflow.
 
-`ocio-dev <http://groups.google.com/group/ocio-dev>`__\ ``@googlegroups.com``
+`ocio-dev <https://lists.aswf.io/g/ocio-dev>`__\ ``@lists.aswf.io``
     For developers interested OCIO APIs, code integration, compilation, etc.
 
 Quick Start
@@ -40,7 +40,7 @@ each application.
 Note that OCIO configurations are required to do any 'real' work, and are
 available separately on the :ref:`downloads` section of this site. Example
 images are also available. For assistance customizing .ocio configurations,
-contact `ocio-users <http://groups.google.com/group/ocio-users>`__\.
+contact `ocio-user <https://lists.aswf.io/g/ocio-user>`__\.
 
 - Step 1:  set the OCIO environment-variable to /path/to/your/profile.ocio
 - Step 2:  Launch supported application.
@@ -51,7 +51,7 @@ provide a menu option to select a different OCIO configuration after launch.
 Please be sure to select a profile that matches your color workflow (VFX work
 typically requires a different profile than animated features). If you need
 assistance picking a profile, email 
-`ocio-users <http://groups.google.com/group/ocio-users>`__\.
+`ocio-user <https://lists.aswf.io/g/ocio-user>`__\.
 
 Downloading and Building the Code
 *********************************
@@ -64,7 +64,7 @@ Download a `.zip <http://github.com/imageworks/OpenColorIO/zipball/master>`_ or
 current state of the repository.
 
 Please see the :ref:`developer-guide` for more info, and contact `ocio-dev
-<http://groups.google.com/group/ocio-dev>`__\  with any questions.
+<https://lists.aswf.io/g/ocio-dev>`__\  with any questions.
 
 .. toctree::
     :hidden:


### PR DESCRIPTION
Note: this PR contains one placeholder comment regarding a URL to a specific ocio-dev thread (in CompatibleSoftware.rst). Once the Google group history is ported to aswf.io, I will push a commit to swap in the new URL. This PR should not be merged until that happens.

As @scoopxyz noted in Slack, putting the mail list changes in RB-1.1 prior to our 1.1.1 release should facilitate an automated deployment to the OCIO website.