### PR TITLE
Repoint docs mail list URL to aswf.io

### DIFF
--- a/docs/CompatibleSoftware.rst
+++ b/docs/CompatibleSoftware.rst
@@ -226,7 +226,7 @@ Export capabilities through ociobakelut::
 
 
 See this `ocio-dev thread 
-<http://groups.google.com/group/ocio-dev/browse_thread/thread/56fd58e60d98e0f6#>`__
+<https://lists.aswf.io/g/ocio-dev/topic/30498585>`__
 for additional usage discussions.
 
 When exporting an ICC Profile, you will be asked to specify your monitor’s


### PR DESCRIPTION
This change has been submitted with #698 for RB-1.1. This PR makes the same change in master, which points the documentation to the recently moved aswf.io mail lists.