### PR TITLE
Update OCIO_VERSION_PATCH and ChangeLog for release 1.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(OpenColorIO)
 set(OCIO_VERSION_MAJOR 1)
 set(OCIO_VERSION_MINOR 1)
-set(OCIO_VERSION_PATCH 0)
+set(OCIO_VERSION_PATCH 1)
 
 cmake_minimum_required(VERSION 2.8)
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/share/cmake)

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+**Version 1.1.1 (March 25 2019):**
+    * Added optional compatibility for building apps with OpenImageIO 1.9+
+    * Added USE_SSE checks to fix Linux build failure
+    * getDisplays() result ordering now matches the active_displays config
+      definition or OCIO_ACTIVE_DISPLAYS env var override.
+    * Fixed incorrect getDefaultDisplay()/getDefaultView() result when
+      OCIO_ACTIVE_DISPLAYS or OCIO_ACTIVE_VIEWS env vars are unset.
+    * Fixed Windows-specific GetEnv() bug
+    * Fixed Windows and MacOS CI failure cases
+    * Updated mail list URLs to aswf.io domain
+
 **Version 1.1.0 (Jan 5 2018):**
     * libc++ build fixes
     * Added support for YAML > 5.0.1


### PR DESCRIPTION
This PR prepares the RB-1.1 branch for release 1.1.1. Please have a read of my ChangeLog notes to make sure we're in agreement that my descriptions are appropriate.

I preemptively suggested in the ChangeLog that we could release this next Monday (the 25th), but that date can move of course.