### PR TITLE
Adsk Contrib - Fix 'Not SSE' Linux build break for gcc 7.3

### DIFF
--- a/src/OpenColorIO/ops/Gamma/GammaOpCPU.cpp
+++ b/src/OpenColorIO/ops/Gamma/GammaOpCPU.cpp
@@ -27,6 +27,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <algorithm>
+#include <cmath>
 
 #include <OpenColorIO/OpenColorIO.h>
 


### PR DESCRIPTION
Please refer to #709 