### PR TITLE
Fix minor typos

### DIFF
--- a/src/OpenColorIO/Baker.cpp
+++ b/src/OpenColorIO/Baker.cpp
@@ -79,6 +79,8 @@ OCIO_NAMESPACE_ENTER
             {
                 config_ = rhs.config_;
                 formatName_ = rhs.formatName_;
+                type_ = rhs.type_;
+                metadata_ = rhs.metadata_;
                 inputSpace_ = rhs.inputSpace_;
                 shaperSpace_ = rhs.shaperSpace_;
                 looks_ = rhs.looks_;

--- a/src/OpenColorIO/Op.h
+++ b/src/OpenColorIO/Op.h
@@ -187,6 +187,7 @@ OCIO_NAMESPACE_ENTER
             }
 
             iterator begin() noexcept { return m_descriptions.begin(); }
+            iterator end() noexcept { return m_descriptions.end(); }
             const_iterator begin() const noexcept { return m_descriptions.begin(); }
             const_iterator end() const noexcept { return m_descriptions.end(); }
 


### PR DESCRIPTION
*  Missing fields in `Baker` assignement operator
*  Missing non const method raising a warning when using for range loop : `warning: 'begin' and 'end' returning different types ('std::__1::__wrap_iter<std::__1::basic_string<char> *>' and 'std::__1::__wrap_iter<const std::__1::basic_string<char> *>') is a C++17 extension [-Wc++17-extensions]`