### PR TITLE
Add openglbuilder target install

### DIFF
--- a/src/utils/openglbuilder/CMakeLists.txt
+++ b/src/utils/openglbuilder/CMakeLists.txt
@@ -32,3 +32,11 @@ target_link_libraries(openglbuilder
 	PUBLIC
 		public_api
 )
+
+install(TARGETS openglbuilder
+    ARCHIVE DESTINATION "share/openglbuilder/lib/"
+)
+
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/glsl.h
+    DESTINATION "share/openglbuilder/include/"
+)

--- a/src/utils/openglbuilder/CMakeLists.txt
+++ b/src/utils/openglbuilder/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(OpenGL REQUIRED)
 find_package(GLEW REQUIRED)
 
 set(SOURCES
-	glsl.cpp
+    glsl.cpp
 )
 
 add_library(openglbuilder STATIC ${SOURCES})
@@ -19,18 +19,18 @@ set_target_properties(openglbuilder PROPERTIES
     COMPILE_FLAGS "${PLATFORM_COMPILE_FLAGS}")
 
 target_include_directories(openglbuilder
-	PUBLIC
-		${CMAKE_CURRENT_SOURCE_DIR}
-	PRIVATE
-		${OPENGL_INCLUDE_DIR}
-		${GLEW_INCLUDE_DIRS}
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+    PRIVATE
+        ${OPENGL_INCLUDE_DIR}
+        ${GLEW_INCLUDE_DIRS}
 )
 target_link_libraries(openglbuilder
-	PRIVATE
-		${OPENGL_LIBRARIES}
-		${GLEW_LIBRARIES}
-	PUBLIC
-		public_api
+    PRIVATE
+        ${OPENGL_LIBRARIES}
+        ${GLEW_LIBRARIES}
+    PUBLIC
+        public_api
 )
 
 install(TARGETS openglbuilder

--- a/src/utils/openglbuilder/CMakeLists.txt
+++ b/src/utils/openglbuilder/CMakeLists.txt
@@ -36,7 +36,6 @@ target_link_libraries(openglbuilder
 install(TARGETS openglbuilder
     ARCHIVE DESTINATION "share/openglbuilder/lib/"
 )
-
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/glsl.h
     DESTINATION "share/openglbuilder/include/"
 )

--- a/src/utils/openglbuilder/glsl.cpp
+++ b/src/utils/openglbuilder/glsl.cpp
@@ -249,7 +249,7 @@ void OpenGLBuilder::allocateAllTextures(unsigned startIndex)
 
         if(!name || !*name || !uid || !*uid || edgelen==0)
         {
-            throw OCIO::Exception("The texture data are corrupted");
+            throw OCIO::Exception("The texture data is corrupted");
         }
 
         const float* values = 0x0;
@@ -288,7 +288,7 @@ void OpenGLBuilder::allocateAllTextures(unsigned startIndex)
 
         if(!name || !*name || !uid || !*uid || width==0)
         {
-            throw OCIO::Exception("The texture data are corrupted");
+            throw OCIO::Exception("The texture data is corrupted");
         }
 
         const float * values = 0x0;
@@ -412,7 +412,7 @@ unsigned OpenGLBuilder::GetTextureMaxWidth()
 
 #ifndef __APPLE__
         //
-        // In case of Linux, if glTexImage2D() succeed
+        // In case of Linux, if glTexImage2D() succeeds
         //  glGetTexLevelParameteriv() could fail.
         //
         // In case of OSX, glTexImage2D() will provide the right result,

--- a/src/utils/openglbuilder/glsl.h
+++ b/src/utils/openglbuilder/glsl.h
@@ -41,7 +41,7 @@ class OpenGLBuilder;
 typedef OCIO_SHARED_PTR<OpenGLBuilder> OpenGLBuilderRcPtr;
 
 
-// This a reference implementation showing how to do the texture updload & allocation, 
+// This is a reference implementation showing how to do the texture upload & allocation,
 // and the program compilation for the GLSL shader language.
 
 class OpenGLBuilder
@@ -86,7 +86,7 @@ public:
     void useProgram();
     unsigned getProgramHandle();
 
-    // Determine the maximun width value of a texture
+    // Determine the maximum width value of a texture
     // depending of the graphic card and its driver.
     static unsigned GetTextureMaxWidth();
 


### PR DESCRIPTION
OpenGLBuilder is really useful for integrating the new GPU renderer. Prior to the the repo refactor it was installed to share/, but now it is no longer being installed. This PR restores the install behavior, and fixes a few typos.