### PR TITLE
Fix typo in FormatRegistry::getFormatNameByIndex (RB-1.1)

### DIFF
--- a/src/core/FileTransform.cpp
+++ b/src/core/FileTransform.cpp
@@ -684,15 +684,15 @@ void ValidateFormatByIndex(OCIO::FormatRegistry &reg, int cap)
     int numFormat = reg.getNumFormats(cap);
 
     // Check out of bounds access
-    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatNameByIndex(cap, -1), ""));
-    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatExtensionByIndex(cap, -1), ""));
-    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatNameByIndex(cap, numFormat), ""));
-    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatExtensionByIndex(cap, numFormat), ""));
+    OIIO_CHECK_EQUAL(0, strcmp(reg.getFormatNameByIndex(cap, -1), ""));
+    OIIO_CHECK_EQUAL(0, strcmp(reg.getFormatExtensionByIndex(cap, -1), ""));
+    OIIO_CHECK_EQUAL(0, strcmp(reg.getFormatNameByIndex(cap, numFormat), ""));
+    OIIO_CHECK_EQUAL(0, strcmp(reg.getFormatExtensionByIndex(cap, numFormat), ""));
 
     // Check valid access
     for (int i = 0; i < numFormat; ++i) {
-        OIIO_CHECK_NE(0, OCIO::Platform::Strcasecmp(reg.getFormatNameByIndex(cap, i), ""));
-        OIIO_CHECK_NE(0, OCIO::Platform::Strcasecmp(reg.getFormatExtensionByIndex(cap, i), ""));
+        OIIO_CHECK_NE(0, strcmp(reg.getFormatNameByIndex(cap, i), ""));
+        OIIO_CHECK_NE(0, strcmp(reg.getFormatExtensionByIndex(cap, i), ""));
     }
 }
 

--- a/src/core/FileTransform.cpp
+++ b/src/core/FileTransform.cpp
@@ -334,7 +334,7 @@ OCIO_NAMESPACE_ENTER
         }
         else if(capability == FORMAT_CAPABILITY_WRITE)
         {
-            if(index<0 || index>=static_cast<int>(m_readFormatNames.size()))
+            if(index<0 || index>=static_cast<int>(m_writeFormatNames.size()))
             {
                 return "";
             }
@@ -671,3 +671,36 @@ OCIO_NAMESPACE_ENTER
     }
 }
 OCIO_NAMESPACE_EXIT
+
+///////////////////////////////////////////////////////////////////////////////
+
+#ifdef OCIO_UNIT_TEST
+
+namespace OCIO = OCIO_NAMESPACE;
+#include "UnitTest.h"
+
+void ValidateFormatByIndex(OCIO::FormatRegistry &reg, int cap)
+{
+    int numFormat = reg.getNumFormats(cap);
+
+    // Check out of bounds access
+    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatNameByIndex(cap, -1), ""));
+    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatExtensionByIndex(cap, -1), ""));
+    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatNameByIndex(cap, numFormat), ""));
+    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatExtensionByIndex(cap, numFormat), ""));
+
+    // Check valid access
+    for (int i = 0; i < numFormat; ++i) {
+        OIIO_CHECK_NE(0, OCIO::Platform::Strcasecmp(reg.getFormatNameByIndex(cap, i), ""));
+        OIIO_CHECK_NE(0, OCIO::Platform::Strcasecmp(reg.getFormatExtensionByIndex(cap, i), ""));
+    }
+}
+
+OIIO_ADD_TEST(FileTransform, FormatByIndex)
+{
+    OCIO::FormatRegistry & formatRegistry = OCIO::FormatRegistry::GetInstance();
+    ValidateFormatByIndex(formatRegistry, OCIO::FORMAT_CAPABILITY_WRITE);
+    ValidateFormatByIndex(formatRegistry, OCIO::FORMAT_CAPABILITY_READ);
+}
+
+#endif // OCIO_UNIT_TEST


### PR DESCRIPTION
As discussed with @hodoulp , this is cherry picked from @remia 's PR #732 for RB-1.1.

I tweaked the tests to not depend on the Platform::Strcasecmp function. Since we're comparing with an empty string, strcmp should work fine.