### PR TITLE
Setup SonarCloud static analysis via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,11 +69,6 @@ before_install:
       wget https://cmake.org/files/v3.12/cmake-3.12.2-Linux-x86_64.sh;
       sh cmake-3.12.2-Linux-x86_64.sh -- --skip-license --prefix=${TRAVIS_BUILD_DIR}/_cmake;
       export PATH="${TRAVIS_BUILD_DIR}/_cmake/bin:$PATH";
-      # if [[ "$TRAVIS_JOB_NAME" == linux_*_sonar ]]; then
-      #   wget https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip;
-      #   unzip build-wrapper-linux-x86.zip;
-      #   export PATH="$PATH:$PWD/build-wrapper-linux-x86";
-      # fi
     fi
   # OSX ones
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,11 +69,11 @@ before_install:
       wget https://cmake.org/files/v3.12/cmake-3.12.2-Linux-x86_64.sh;
       sh cmake-3.12.2-Linux-x86_64.sh -- --skip-license --prefix=${TRAVIS_BUILD_DIR}/_cmake;
       export PATH="${TRAVIS_BUILD_DIR}/_cmake/bin:$PATH";
-      #if [[ "$TRAVIS_JOB_NAME" == linux_*_sonar ]]; then
-      #  wget https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip;
-      #  unzip build-wrapper-linux-x86.zip;
-      #  export PATH="$PATH:$PWD/build-wrapper-linux-x86";
-      #fi
+      # if [[ "$TRAVIS_JOB_NAME" == linux_*_sonar ]]; then
+      #   wget https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip;
+      #   unzip build-wrapper-linux-x86.zip;
+      #   export PATH="$PATH:$PWD/build-wrapper-linux-x86";
+      # fi
     fi
   # OSX ones
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ script:
   - cmake .. -DCMAKE_INSTALL_PREFIX=../_install $OPTIONS $OPTIONS_BUILD
   - if [[ "$TRAVIS_JOB_NAME" == linux_*_sonar ]];
     then
-      build-wrapper-linux-x86-64 --out_dir bw-output cmake --build . --target install;
+      build-wrapper-linux-x86-64 --out-dir bw-output cmake --build . --target install;
     else
       cmake --build . --target install;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,14 +91,15 @@ script:
   - mkdir _build
   - cd _build
   - cmake .. -DCMAKE_INSTALL_PREFIX=../_install $OPTIONS $OPTIONS_BUILD
-  - if [[ "$TRAVIS_JOB_NAME" == linux_*_sonar ]]; then
-      build-wrapper-linux-x86-64 --out_dir bw-output cmake --build . --target install
+  - if [[ "$TRAVIS_JOB_NAME" == linux_*_sonar ]];
+    then
+      build-wrapper-linux-x86-64 --out_dir bw-output cmake --build . --target install;
     else
-      cmake --build . --target install
+      cmake --build . --target install;
     fi
   - ctest -V
   - if [[ "$TRAVIS_JOB_NAME" == *_sonar ]]; then
-      sonar-scanner
+      sonar-scanner;
     fi
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,23 +37,17 @@ matrix:
         - OPTIONS_BUILD="-DOCIO_USE_SSE=OFF"
 
     # OSX jobs
-    - name: osx_clang
+    - name: osx_10.12_clang
       os: osx
       language: cpp
       compiler: clang
       osx_image: xcode9.1
-      env:
-        - MATRIX_EVAL=""
 
-    - name: osx_gcc
+    - name: osx_10.14_clang
       os: osx
       language: cpp
-      # Note: On macOS, compiler "gcc" is an alias for "clang". This is how to
-      # actually build with GCC:
-      #   https://docs.travis-ci.com/user/languages/cpp#gcc-on-macos
-      osx_image: xcode8
-      env:
-        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+      compiler: clang
+      osx_image: xcode10.2
 
 env:
   global:
@@ -84,7 +78,6 @@ before_install:
       export OPTIONS="$OPTIONS -DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython2.7.dylib";
       export OPTIONS="$OPTIONS -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python2.7";
       export OPTIONS="$OPTIONS -DPYTHON_EXECUTABLE=$(which python2)";
-      eval "${MATRIX_EVAL}";
     fi
 
 # Run the Build script

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,59 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
 # travis-ci.org build file
 # https://docs.travis-ci.com/user/languages/cpp
 
 matrix:
   include:
-    - os: linux
+    # Linux jobs
+    - name: linux_clang
+    # TODO: Enable once analysis is confirmed to be working
+    # if: type != cron OR branch != master
+      os: linux
       language: cpp
       compiler: clang
-    - os: linux
+
+    - name: linux_clang_sonar
+    # TODO: Enable once analysis is confirmed to be working
+    # if: type = cron AND branch = master
+      os: linux
+      dist: trusty
+      language: cpp
+      compiler: clang
+      addons:
+        sonarcloud:
+          organization: imageworks
+          token: $SONAR_TOKEN
+
+    - name: linux_gcc
+      os: linux
       language: cpp
       compiler: gcc
-    - os: linux
+
+    - name: linux_gcc_sse_off
+      os: linux
       language: cpp
       compiler: gcc
       env:
         - OPTIONS_BUILD="-DOCIO_USE_SSE=OFF"
-    - os: osx
-      language: cpp
-      compiler: clang
-    - os: osx
-      language: cpp
-      compiler: gcc
-    - os: osx
+
+    # OSX jobs
+    - name: osx_clang
+      os: osx
       language: cpp
       compiler: clang
       osx_image: xcode9.1
+
+    - name: osx_gcc
+      os: osx
+      language: cpp
+      # Note: On macOS, compiler "gcc" is an alias for "clang". This is how to
+      # actually build with GCC:
+      #   https://docs.travis-ci.com/user/languages/cpp#gcc-on-macos
+      osx_image: xcode9.1
+      env:
+        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
 
 env:
   global:
@@ -61,8 +91,19 @@ script:
   - mkdir _build
   - cd _build
   - cmake .. -DCMAKE_INSTALL_PREFIX=../_install $OPTIONS $OPTIONS_BUILD
-  - cmake --build . --target install
+  - if [[ "$TRAVIS_JOB_NAME" == linux_*_sonar ]]; then
+      build-wrapper-linux-x86-64 --out_dir bw-output cmake --build . --target install
+    else
+      cmake --build . --target install
+    fi
   - ctest -V
+  - if [[ "$TRAVIS_JOB_NAME" == *_sonar ]]; then
+      sonar-scanner
+    fi
+
+cache:
+  directories:
+    - '$HOME/.sonar/cache'
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
       # Note: On macOS, compiler "gcc" is an alias for "clang". This is how to
       # actually build with GCC:
       #   https://docs.travis-ci.com/user/languages/cpp#gcc-on-macos
-      osx_image: xcode9.1
+      osx_image: xcode8
       env:
         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,11 @@ before_install:
       wget https://cmake.org/files/v3.12/cmake-3.12.2-Linux-x86_64.sh;
       sh cmake-3.12.2-Linux-x86_64.sh -- --skip-license --prefix=${TRAVIS_BUILD_DIR}/_cmake;
       export PATH="${TRAVIS_BUILD_DIR}/_cmake/bin:$PATH";
+      if [[ "$TRAVIS_JOB_NAME" == linux_*_sonar ]]; then
+        wget https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip;
+        unzip build-wrapper-linux-x86.zip;
+        export PATH="$PATH:$PWD/build-wrapper-linux-x86";
+      fi
     fi
   # OSX ones
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,13 @@ matrix:
   include:
     # Linux jobs
     - name: linux_clang
-    # TODO: Enable once analysis is confirmed to be working
-    # if: type != cron OR branch != master
+      if: type != cron OR branch != master
       os: linux
       language: cpp
       compiler: clang
 
     - name: linux_clang_sonar
-    # TODO: Enable once analysis is confirmed to be working
-    # if: type = cron AND branch = master
+      if: type = cron AND branch = master
       os: linux
       dist: trusty
       language: cpp
@@ -44,6 +42,8 @@ matrix:
       language: cpp
       compiler: clang
       osx_image: xcode9.1
+      env:
+        - MATRIX_EVAL=""
 
     - name: osx_gcc
       os: osx
@@ -69,11 +69,11 @@ before_install:
       wget https://cmake.org/files/v3.12/cmake-3.12.2-Linux-x86_64.sh;
       sh cmake-3.12.2-Linux-x86_64.sh -- --skip-license --prefix=${TRAVIS_BUILD_DIR}/_cmake;
       export PATH="${TRAVIS_BUILD_DIR}/_cmake/bin:$PATH";
-      if [[ "$TRAVIS_JOB_NAME" == linux_*_sonar ]]; then
-        wget https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip;
-        unzip build-wrapper-linux-x86.zip;
-        export PATH="$PATH:$PWD/build-wrapper-linux-x86";
-      fi
+      #if [[ "$TRAVIS_JOB_NAME" == linux_*_sonar ]]; then
+      #  wget https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip;
+      #  unzip build-wrapper-linux-x86.zip;
+      #  export PATH="$PATH:$PWD/build-wrapper-linux-x86";
+      #fi
     fi
   # OSX ones
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -89,6 +89,7 @@ before_install:
       export OPTIONS="$OPTIONS -DPYTHON_LIBRARY=$(python-config --prefix)/lib/libpython2.7.dylib";
       export OPTIONS="$OPTIONS -DPYTHON_INCLUDE_DIR=$(python-config --prefix)/include/python2.7";
       export OPTIONS="$OPTIONS -DPYTHON_EXECUTABLE=$(which python2)";
+      eval "${MATRIX_EVAL}";
     fi
 
 # Run the Build script

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright Contributors to the OpenColorIO Project.
+
+# SonarCloud analysis configuration file
+# https://sonarcloud.io/documentation/analysis/analysis-parameters
+
+sonar.projectKey=imageworks_OpenColorIO
+sonar.projectName=OpenColorIO
+
+# Project configuration
+sonar.sources=src,include
+sonar.tests=tests
+sonar.language=c++
+sonar.sourceEncoding=UTF-8
+
+# C/C++ analyzer properties
+sonar.cfamily.build-wrapper-output=bw-output


### PR DESCRIPTION
This PR adds C++ static analysis to the project, courtesy of SonarCloud and Travis CI. Additional commits will be needed to complete this work, based on test results; I may need to close and reopen it a few times to coax Travis into triggering rebuilds.

The goal is to hook this to a weekly Travis cron job, which will run our typical build matrix, but also run analysis (on just the Linux Clang build for now) and push the results here:
https://sonarcloud.io/dashboard?id=imageworks_OpenColorIO

This will have to be reconfigured when the project repo moves to the ASWF organization, but the changes should be minimal.

This PR also proposes some general improvements to the Travis build configuration:
- Adds job names, which allow use of $TRAVIS_JOB_NAME for build conditions
- Reworks the OSX GCC build, which appears to have actually been a second Clang build due to "gcc" being an alias to "clang", per the Travis docs. I removed the third OSX job, since I bumped the other two to use the same Xcode version. Perhaps we should add a job with a more recent macOS version to replace it?
- Added the new OCIO copyright/license statement
