### PR TITLE
Fix stray isnan in Lut3DOp test

### DIFF
--- a/src/OpenColorIO/ops/Lut3D/Lut3DOp.cpp
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOp.cpp
@@ -519,7 +519,7 @@ void Lut3D_Tetrahedral(float* rgbaBuffer, long numPixels, const Lut3D & lut)
                         (fz)* startPos[n111 + 2];
                 }
             }
-        } // !isnan
+        } // !IsNan
 
         rgbaBuffer += 4;
     }
@@ -1671,7 +1671,7 @@ OIIO_ADD_TEST(Lut3DOp, cpu_renderer_lut3d_with_nan)
     OIIO_CHECK_EQUAL(myImage[5], 0.0f);
     OIIO_CHECK_EQUAL(myImage[10], 0.0f);
 
-    OIIO_CHECK_ASSERT(isnan(myImage[15]));
+    OIIO_CHECK_ASSERT(OCIO::IsNan(myImage[15]));
 
     OIIO_CHECK_EQUAL(myImage[16], 0.5f);
     OIIO_CHECK_EQUAL(myImage[17], 0.5f);


### PR DESCRIPTION
This failed a build while testing Azure Pipelines CI (both GCC 5.4.0 & Clang 6.0.1). It's not failing builds on Travis or AppVeyor...