### PR TITLE
Update the CCLA with the extra words from the e-signature page.

### DIFF
--- a/docs/aswf/CLA-corporate.md
+++ b/docs/aswf/CLA-corporate.md
@@ -30,6 +30,18 @@ to the Project shall be:
 Submitted under a Developer's Certificate of Origin v. 1.1 (DCO); and
 Licensed under the BSD-3-Clause License.
 
+You agree that You shall be bound by the terms of the BSD-3-Clause
+License for all contributions made by You and Your employees. Your
+designated employees are those listed by Your CLA Manager(s) on the
+system of record for the Project. You agree to identify Your initial
+CLA Manager below and thereafter maintain current CLA Manager records
+in the Project's system of record.
+
+Initial CLA Manager (Name and Email):
+
+Name: ____________________________ Email: ___________________________
+
+
 
 Corporate Signature:
 


### PR DESCRIPTION
One paragraph is additionally listed when you go to sign the actual
new CLA, which clarifies the role of the CLA manager. Adding it to the
copy of the CLA in our repo just so it exactly matches what people will
see and sign when they use the e-signature system.