### PR TITLE
Adopt OIIO unittest.h as OCIO UnitTest.h

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -199,9 +199,3 @@ set_property(TARGET ilmbase PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${ILMBASE_INC
 # sampleicc
 add_library(sampleicc INTERFACE IMPORTED GLOBAL)
 set_property(TARGET sampleicc PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/sampleicc/src/include")
-
-
-######################################################################
-# oiio unit tests
-add_library(oiio_unittest INTERFACE IMPORTED GLOBAL)
-set_property(TARGET oiio_unittest PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/oiio/src/include")

--- a/src/OpenColorIO/Baker.cpp
+++ b/src/OpenColorIO/Baker.cpp
@@ -275,10 +275,10 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 /*
-OIIO_ADD_TEST(Baker_Unit_Tests, test_listlutwriters)
+OCIO_ADD_TEST(Baker_Unit_Tests, test_listlutwriters)
 {
     
     std::vector<std::string> current_writers;
@@ -287,19 +287,19 @@ OIIO_ADD_TEST(Baker_Unit_Tests, test_listlutwriters)
     
     OCIO::BakerRcPtr baker = OCIO::Baker::Create();
     
-    OIIO_CHECK_EQUAL(baker->getNumFormats(), (int)current_writers.size());
+    OCIO_CHECK_EQUAL(baker->getNumFormats(), (int)current_writers.size());
     
     std::vector<std::string> test;
     for(int i = 0; i < baker->getNumFormats(); ++i)
         test.push_back(baker->getFormatNameByIndex(i));
     
     for(unsigned int i = 0; i < current_writers.size(); ++i)
-        OIIO_CHECK_EQUAL(current_writers[i], test[i]);
+        OCIO_CHECK_EQUAL(current_writers[i], test[i]);
     
 }
 */
 
-OIIO_ADD_TEST(Baker_Unit_Tests, bake)
+OCIO_ADD_TEST(Baker_Unit_Tests, bake)
 {
     // SSE aware test, similar to python test.
     OCIO::BakerRcPtr bake = OCIO::Baker::Create();
@@ -375,35 +375,35 @@ OIIO_ADD_TEST(Baker_Unit_Tests, bake)
         "\n";
     std::istringstream is(myProfile);
     OCIO::ConstConfigRcPtr config;
-    OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-    OIIO_REQUIRE_EQUAL(config->getNumColorSpaces(), 2);
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_REQUIRE_EQUAL(config->getNumColorSpaces(), 2);
     bake->setConfig(config);
     auto cfg2 = bake->getConfig();
-    OIIO_REQUIRE_EQUAL(cfg2->getNumColorSpaces(), 2);
+    OCIO_REQUIRE_EQUAL(cfg2->getNumColorSpaces(), 2);
 
     bake->setFormat("cinespace");
-    OIIO_CHECK_EQUAL("cinespace", std::string(bake->getFormat()));
+    OCIO_CHECK_EQUAL("cinespace", std::string(bake->getFormat()));
     bake->setType("3D");
-    OIIO_CHECK_EQUAL("3D", std::string(bake->getType()));
+    OCIO_CHECK_EQUAL("3D", std::string(bake->getType()));
     bake->setMetadata("this is some metadata!");
-    OIIO_CHECK_EQUAL("this is some metadata!", std::string(bake->getMetadata()));
+    OCIO_CHECK_EQUAL("this is some metadata!", std::string(bake->getMetadata()));
     bake->setInputSpace("lnh");
-    OIIO_CHECK_EQUAL("lnh", std::string(bake->getInputSpace()));
+    OCIO_CHECK_EQUAL("lnh", std::string(bake->getInputSpace()));
     bake->setLooks("foo, +bar");
-    OIIO_CHECK_EQUAL("foo, +bar", std::string(bake->getLooks()));
+    OCIO_CHECK_EQUAL("foo, +bar", std::string(bake->getLooks()));
     bake->setLooks("");
     bake->setTargetSpace("test");
-    OIIO_CHECK_EQUAL("test", std::string(bake->getTargetSpace()));
+    OCIO_CHECK_EQUAL("test", std::string(bake->getTargetSpace()));
     bake->setShaperSize(4);
-    OIIO_CHECK_EQUAL(4, bake->getShaperSize());
+    OCIO_CHECK_EQUAL(4, bake->getShaperSize());
     bake->setCubeSize(2);
-    OIIO_CHECK_EQUAL(2, bake->getCubeSize());
+    OCIO_CHECK_EQUAL(2, bake->getCubeSize());
     std::ostringstream os;
     bake->bake(os);
-    OIIO_CHECK_EQUAL(expectedLut, os.str());
-    OIIO_CHECK_EQUAL(8, bake->getNumFormats());
-    OIIO_CHECK_EQUAL("cinespace", std::string(bake->getFormatNameByIndex(2)));
-    OIIO_CHECK_EQUAL("3dl", std::string(bake->getFormatExtensionByIndex(1)));
+    OCIO_CHECK_EQUAL(expectedLut, os.str());
+    OCIO_CHECK_EQUAL(8, bake->getNumFormats());
+    OCIO_CHECK_EQUAL("cinespace", std::string(bake->getFormatNameByIndex(2)));
+    OCIO_CHECK_EQUAL("3dl", std::string(bake->getFormatExtensionByIndex(1)));
 }
 
 #endif // OCIO_BUILD_TESTS

--- a/src/OpenColorIO/BitDepthUtils.cpp
+++ b/src/OpenColorIO/BitDepthUtils.cpp
@@ -111,37 +111,37 @@ OCIO_NAMESPACE_EXIT
 
 namespace OCIO = OCIO_NAMESPACE;
 
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(BitDepthUtils, GetBitDepthMaxValue)
+OCIO_ADD_TEST(BitDepthUtils, GetBitDepthMaxValue)
 {
-    OIIO_CHECK_EQUAL(OCIO::GetBitDepthMaxValue(OCIO::BIT_DEPTH_UINT8), 255.0f);
-    OIIO_CHECK_EQUAL(OCIO::GetBitDepthMaxValue(OCIO::BIT_DEPTH_UINT16), 65535.0f);
+    OCIO_CHECK_EQUAL(OCIO::GetBitDepthMaxValue(OCIO::BIT_DEPTH_UINT8), 255.0f);
+    OCIO_CHECK_EQUAL(OCIO::GetBitDepthMaxValue(OCIO::BIT_DEPTH_UINT16), 65535.0f);
 
-    OIIO_CHECK_EQUAL(OCIO::GetBitDepthMaxValue(OCIO::BIT_DEPTH_F16), 1.0f);
-    OIIO_CHECK_EQUAL(OCIO::GetBitDepthMaxValue(OCIO::BIT_DEPTH_F32), 1.0f);
+    OCIO_CHECK_EQUAL(OCIO::GetBitDepthMaxValue(OCIO::BIT_DEPTH_F16), 1.0f);
+    OCIO_CHECK_EQUAL(OCIO::GetBitDepthMaxValue(OCIO::BIT_DEPTH_F32), 1.0f);
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         OCIO::GetBitDepthMaxValue((OCIO::BitDepth)42), OCIO::Exception, "not supported");
 }
 
-OIIO_ADD_TEST(BitDepthUtils, IsFloatBitDepth)
+OCIO_ADD_TEST(BitDepthUtils, IsFloatBitDepth)
 {
-    OIIO_CHECK_ASSERT(!OCIO::IsFloatBitDepth(OCIO::BIT_DEPTH_UINT8));
-    OIIO_CHECK_ASSERT(!OCIO::IsFloatBitDepth(OCIO::BIT_DEPTH_UINT10));
-    OIIO_CHECK_ASSERT(!OCIO::IsFloatBitDepth(OCIO::BIT_DEPTH_UINT12));
-    OIIO_CHECK_ASSERT(!OCIO::IsFloatBitDepth(OCIO::BIT_DEPTH_UINT16));
+    OCIO_CHECK_ASSERT(!OCIO::IsFloatBitDepth(OCIO::BIT_DEPTH_UINT8));
+    OCIO_CHECK_ASSERT(!OCIO::IsFloatBitDepth(OCIO::BIT_DEPTH_UINT10));
+    OCIO_CHECK_ASSERT(!OCIO::IsFloatBitDepth(OCIO::BIT_DEPTH_UINT12));
+    OCIO_CHECK_ASSERT(!OCIO::IsFloatBitDepth(OCIO::BIT_DEPTH_UINT16));
     
-    OIIO_CHECK_ASSERT(OCIO::IsFloatBitDepth(OCIO::BIT_DEPTH_F16));
-    OIIO_CHECK_ASSERT(OCIO::IsFloatBitDepth(OCIO::BIT_DEPTH_F32));
+    OCIO_CHECK_ASSERT(OCIO::IsFloatBitDepth(OCIO::BIT_DEPTH_F16));
+    OCIO_CHECK_ASSERT(OCIO::IsFloatBitDepth(OCIO::BIT_DEPTH_F32));
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         OCIO::IsFloatBitDepth(OCIO::BIT_DEPTH_UINT14), OCIO::Exception, "not supported");
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         OCIO::IsFloatBitDepth(OCIO::BIT_DEPTH_UINT32), OCIO::Exception, "not supported");
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         OCIO::IsFloatBitDepth((OCIO::BitDepth)42), OCIO::Exception, "not supported");
 }
 

--- a/src/OpenColorIO/CPUProcessor.cpp
+++ b/src/OpenColorIO/CPUProcessor.cpp
@@ -440,7 +440,7 @@ namespace OCIO = OCIO_NAMESPACE;
 
 #include "ops/Lut1D/Lut1DOp.h"
 #include "ops/Lut1D/Lut1DOpData.h"
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
 
@@ -468,12 +468,12 @@ OCIO::ConstCPUProcessorRcPtr ComputeValues(OCIO::ConstProcessorRcPtr processor,
     typedef typename OCIO::BitDepthInfo< ExtractBitDepthInfo<outPF>::bd >::Type outType;
 
     OCIO::ConstCPUProcessorRcPtr cpuProcessor;
-    OIIO_CHECK_NO_THROW(cpuProcessor = processor->getCPUProcessor(inPF, outPF));
+    OCIO_CHECK_NO_THROW(cpuProcessor = processor->getCPUProcessor(inPF, outPF));
 
     const size_t numValues = size_t(numPixels * 4);
 
     std::vector<outType> out(numValues);
-    OIIO_CHECK_NO_THROW(cpuProcessor->apply(inImg, &out[0], numPixels));
+    OCIO_CHECK_NO_THROW(cpuProcessor->apply(inImg, &out[0], numPixels));
 
     const outType * res = (const outType *)resImg;
 
@@ -481,18 +481,18 @@ OCIO::ConstCPUProcessorRcPtr ComputeValues(OCIO::ConstProcessorRcPtr processor,
     {
         if(OCIO::BitDepthInfo< ExtractBitDepthInfo<outPF>::bd >::isFloat)
         {
-            OIIO_CHECK_CLOSE_FROM(out[idx], res[idx], absErrorThreshold, line);
+            OCIO_CHECK_CLOSE_FROM(out[idx], res[idx], absErrorThreshold, line);
         }
         else
         {
-            OIIO_CHECK_EQUAL_FROM(out[idx], res[idx], line);
+            OCIO_CHECK_EQUAL_FROM(out[idx], res[idx], line);
         }
     }
 
     return cpuProcessor;
 }
 
-OIIO_ADD_TEST(CPUProcessor, with_one_matrix)
+OCIO_ADD_TEST(CPUProcessor, with_one_matrix)
 {
     // The unit test validates that pixel formats are correctly 
     // processed when the op list contains only one arbitrary Op
@@ -505,7 +505,7 @@ OIIO_ADD_TEST(CPUProcessor, with_one_matrix)
     transform->setOffset( offset4 );
 
     OCIO::ConstProcessorRcPtr processor; 
-    OIIO_CHECK_NO_THROW(processor = config->getProcessor(transform));
+    OCIO_CHECK_NO_THROW(processor = config->getProcessor(transform));
 
     const unsigned NB_PIXELS = 3;
 
@@ -527,8 +527,8 @@ OIIO_ADD_TEST(CPUProcessor, with_one_matrix)
                             OCIO::PIXEL_FORMAT_RGBA_F32,
                             __LINE__>(processor, &f_inImg[0], &resImg[0], NB_PIXELS, 1e-7f);
 
-        OIIO_CHECK_EQUAL(cpuProcessor->getInputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
-        OIIO_CHECK_EQUAL(cpuProcessor->getOutputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
+        OCIO_CHECK_EQUAL(cpuProcessor->getInputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
+        OCIO_CHECK_EQUAL(cpuProcessor->getOutputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
 
         // Validate that the two apply paths produce identical results.
 
@@ -536,11 +536,11 @@ OIIO_ADD_TEST(CPUProcessor, with_one_matrix)
         f_outImg2 = f_inImg;
 
         OCIO::PackedImageDesc desc(&f_outImg2[0], NB_PIXELS, 1, 4);
-        OIIO_CHECK_NO_THROW(processor->apply(desc));
+        OCIO_CHECK_NO_THROW(processor->apply(desc));
 
         for(unsigned idx=0; idx<(NB_PIXELS*4); ++idx)
         {
-            OIIO_CHECK_CLOSE(f_outImg2[idx], resImg[idx],  1e-7f);
+            OCIO_CHECK_CLOSE(f_outImg2[idx], resImg[idx],  1e-7f);
         }
     }
 
@@ -619,7 +619,7 @@ OIIO_ADD_TEST(CPUProcessor, with_one_matrix)
 */
 }
 
-OIIO_ADD_TEST(CPUProcessor, with_one_1d_lut)
+OCIO_ADD_TEST(CPUProcessor, with_one_1d_lut)
 {
     // The unit test validates that pixel formats are correctly 
     // processed when the op list contains only one 1D LUT.
@@ -635,7 +635,7 @@ OIIO_ADD_TEST(CPUProcessor, with_one_1d_lut)
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
 
     OCIO::ConstProcessorRcPtr processor; 
-    OIIO_CHECK_NO_THROW(processor = config->getProcessor(transform));
+    OCIO_CHECK_NO_THROW(processor = config->getProcessor(transform));
 
     const unsigned NB_PIXELS = 4;
 
@@ -659,8 +659,8 @@ OIIO_ADD_TEST(CPUProcessor, with_one_1d_lut)
                             OCIO::PIXEL_FORMAT_RGBA_F32,
                             __LINE__>(processor, &f_inImg[0], &resImg[0], NB_PIXELS, 1e-7f);
 
-        OIIO_CHECK_EQUAL(cpuProcessor->getInputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
-        OIIO_CHECK_EQUAL(cpuProcessor->getOutputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
+        OCIO_CHECK_EQUAL(cpuProcessor->getInputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
+        OCIO_CHECK_EQUAL(cpuProcessor->getOutputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
 
         // Validate that the two apply paths produce identical results.
 
@@ -668,11 +668,11 @@ OIIO_ADD_TEST(CPUProcessor, with_one_1d_lut)
         f_outImg2 = f_inImg;
 
         OCIO::PackedImageDesc desc(&f_outImg2[0], NB_PIXELS, 1, 4);
-        OIIO_CHECK_NO_THROW(processor->apply(desc));
+        OCIO_CHECK_NO_THROW(processor->apply(desc));
 
         for(unsigned idx=0; idx<(NB_PIXELS*4); ++idx)
         {
-            OIIO_CHECK_CLOSE(f_outImg2[idx], resImg[idx],  1e-7f);
+            OCIO_CHECK_CLOSE(f_outImg2[idx], resImg[idx],  1e-7f);
         }
     }
 
@@ -758,7 +758,7 @@ OIIO_ADD_TEST(CPUProcessor, with_one_1d_lut)
 */
 }
 
-OIIO_ADD_TEST(CPUProcessor, with_several_ops)
+OCIO_ADD_TEST(CPUProcessor, with_several_ops)
 {
     // The unit test validates that pixel formats are correctly 
     // processed when the op list starts or ends with a 1D LUT.
@@ -802,11 +802,11 @@ OIIO_ADD_TEST(CPUProcessor, with_several_ops)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         OCIO::ConstProcessorRcPtr processor; 
-        OIIO_CHECK_NO_THROW(processor = config->getProcessor("cs1", "cs2"));
+        OCIO_CHECK_NO_THROW(processor = config->getProcessor("cs1", "cs2"));
 
         const unsigned NB_PIXELS = 4;
 
@@ -830,8 +830,8 @@ OIIO_ADD_TEST(CPUProcessor, with_several_ops)
                                 OCIO::PIXEL_FORMAT_RGBA_F32,
                                 __LINE__>(processor, &f_inImg[0], &resImg[0], NB_PIXELS, 1e-7f);    
 
-            OIIO_CHECK_EQUAL(cpuProcessor->getInputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
-            OIIO_CHECK_EQUAL(cpuProcessor->getOutputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
+            OCIO_CHECK_EQUAL(cpuProcessor->getInputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
+            OCIO_CHECK_EQUAL(cpuProcessor->getOutputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
 
             // Validate that the two apply paths produce identical results.
 
@@ -839,11 +839,11 @@ OIIO_ADD_TEST(CPUProcessor, with_several_ops)
             f_outImg2 = f_inImg;
 
             OCIO::PackedImageDesc desc(&f_outImg2[0], NB_PIXELS, 1, 4);
-            OIIO_CHECK_NO_THROW(processor->apply(desc));
+            OCIO_CHECK_NO_THROW(processor->apply(desc));
 
             for(unsigned idx=0; idx<(NB_PIXELS*4); ++idx)
             {
-                OIIO_CHECK_CLOSE(f_outImg2[idx], resImg[idx],  1e-7f);
+                OCIO_CHECK_CLOSE(f_outImg2[idx], resImg[idx],  1e-7f);
             }
         }
 
@@ -945,11 +945,11 @@ OIIO_ADD_TEST(CPUProcessor, with_several_ops)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         OCIO::ConstProcessorRcPtr processor; 
-        OIIO_CHECK_NO_THROW(processor = config->getProcessor("cs1", "cs2"));
+        OCIO_CHECK_NO_THROW(processor = config->getProcessor("cs1", "cs2"));
 
         const unsigned NB_PIXELS = 4;
 
@@ -973,8 +973,8 @@ OIIO_ADD_TEST(CPUProcessor, with_several_ops)
                                 OCIO::PIXEL_FORMAT_RGBA_F32,
                                 __LINE__>(processor, &f_inImg[0], &resImg[0], NB_PIXELS, 1e-7f);    
 
-            OIIO_CHECK_EQUAL(cpuProcessor->getInputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
-            OIIO_CHECK_EQUAL(cpuProcessor->getOutputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
+            OCIO_CHECK_EQUAL(cpuProcessor->getInputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
+            OCIO_CHECK_EQUAL(cpuProcessor->getOutputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
 
             // Validate that the two apply paths produce identical results.
 
@@ -982,11 +982,11 @@ OIIO_ADD_TEST(CPUProcessor, with_several_ops)
             f_outImg2 = f_inImg;
 
             OCIO::PackedImageDesc desc(&f_outImg2[0], NB_PIXELS, 1, 4);
-            OIIO_CHECK_NO_THROW(processor->apply(desc));
+            OCIO_CHECK_NO_THROW(processor->apply(desc));
 
             for(unsigned idx=0; idx<(NB_PIXELS*4); ++idx)
             {
-                OIIO_CHECK_CLOSE(f_outImg2[idx], resImg[idx],  1e-7f);
+                OCIO_CHECK_CLOSE(f_outImg2[idx], resImg[idx],  1e-7f);
             }
         }
 /*
@@ -1050,11 +1050,11 @@ OIIO_ADD_TEST(CPUProcessor, with_several_ops)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         OCIO::ConstProcessorRcPtr processor; 
-        OIIO_CHECK_NO_THROW(processor = config->getProcessor("cs1", "cs2"));
+        OCIO_CHECK_NO_THROW(processor = config->getProcessor("cs1", "cs2"));
 
         const unsigned NB_PIXELS = 4;
 
@@ -1078,8 +1078,8 @@ OIIO_ADD_TEST(CPUProcessor, with_several_ops)
                                 OCIO::PIXEL_FORMAT_RGBA_F32,
                                 __LINE__>(processor, &f_inImg[0], &resImg[0], NB_PIXELS, 1e-7f);    
 
-            OIIO_CHECK_EQUAL(cpuProcessor->getInputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
-            OIIO_CHECK_EQUAL(cpuProcessor->getOutputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
+            OCIO_CHECK_EQUAL(cpuProcessor->getInputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
+            OCIO_CHECK_EQUAL(cpuProcessor->getOutputPixelFormat(), OCIO::PIXEL_FORMAT_RGBA_F32);
 
             // Validate that the two apply paths produce identical results.
 
@@ -1087,11 +1087,11 @@ OIIO_ADD_TEST(CPUProcessor, with_several_ops)
             f_outImg2 = f_inImg;
 
             OCIO::PackedImageDesc desc(&f_outImg2[0], NB_PIXELS, 1, 4);
-            OIIO_CHECK_NO_THROW(processor->apply(desc));
+            OCIO_CHECK_NO_THROW(processor->apply(desc));
 
             for(unsigned idx=0; idx<(NB_PIXELS*4); ++idx)
             {
-                OIIO_CHECK_CLOSE(f_outImg2[idx], resImg[idx],  1e-7f);
+                OCIO_CHECK_CLOSE(f_outImg2[idx], resImg[idx],  1e-7f);
             }
         }
 /*

--- a/src/OpenColorIO/ColorSpace.cpp
+++ b/src/OpenColorIO/ColorSpace.cpp
@@ -377,44 +377,44 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(ColorSpace, category)
+OCIO_ADD_TEST(ColorSpace, category)
 {
     OCIO::ColorSpaceRcPtr cs = OCIO::ColorSpace::Create();
-    OIIO_CHECK_EQUAL(cs->getNumCategories(), 0);
+    OCIO_CHECK_EQUAL(cs->getNumCategories(), 0);
 
-    OIIO_CHECK_ASSERT(!cs->hasCategory("linear"));
-    OIIO_CHECK_ASSERT(!cs->hasCategory("rendering"));
-    OIIO_CHECK_ASSERT(!cs->hasCategory("log"));
+    OCIO_CHECK_ASSERT(!cs->hasCategory("linear"));
+    OCIO_CHECK_ASSERT(!cs->hasCategory("rendering"));
+    OCIO_CHECK_ASSERT(!cs->hasCategory("log"));
 
-    OIIO_CHECK_NO_THROW(cs->addCategory("linear"));
-    OIIO_CHECK_NO_THROW(cs->addCategory("rendering"));
-    OIIO_CHECK_EQUAL(cs->getNumCategories(), 2);
+    OCIO_CHECK_NO_THROW(cs->addCategory("linear"));
+    OCIO_CHECK_NO_THROW(cs->addCategory("rendering"));
+    OCIO_CHECK_EQUAL(cs->getNumCategories(), 2);
 
-    OIIO_CHECK_ASSERT(cs->hasCategory("linear"));
-    OIIO_CHECK_ASSERT(cs->hasCategory("rendering"));
-    OIIO_CHECK_ASSERT(!cs->hasCategory("log"));
+    OCIO_CHECK_ASSERT(cs->hasCategory("linear"));
+    OCIO_CHECK_ASSERT(cs->hasCategory("rendering"));
+    OCIO_CHECK_ASSERT(!cs->hasCategory("log"));
 
-    OIIO_CHECK_EQUAL(std::string(cs->getCategory(0)), std::string("linear"));
-    OIIO_CHECK_EQUAL(std::string(cs->getCategory(1)), std::string("rendering"));
+    OCIO_CHECK_EQUAL(std::string(cs->getCategory(0)), std::string("linear"));
+    OCIO_CHECK_EQUAL(std::string(cs->getCategory(1)), std::string("rendering"));
     // Check with an invalid index.
-    OIIO_CHECK_NO_THROW(cs->getCategory(2));
-    OIIO_CHECK_ASSERT(cs->getCategory(2) == nullptr);
+    OCIO_CHECK_NO_THROW(cs->getCategory(2));
+    OCIO_CHECK_ASSERT(cs->getCategory(2) == nullptr);
 
-    OIIO_CHECK_NO_THROW(cs->removeCategory("linear"));
-    OIIO_CHECK_EQUAL(cs->getNumCategories(), 1);
-    OIIO_CHECK_ASSERT(!cs->hasCategory("linear"));
-    OIIO_CHECK_ASSERT(cs->hasCategory("rendering"));
-    OIIO_CHECK_ASSERT(!cs->hasCategory("log"));
+    OCIO_CHECK_NO_THROW(cs->removeCategory("linear"));
+    OCIO_CHECK_EQUAL(cs->getNumCategories(), 1);
+    OCIO_CHECK_ASSERT(!cs->hasCategory("linear"));
+    OCIO_CHECK_ASSERT(cs->hasCategory("rendering"));
+    OCIO_CHECK_ASSERT(!cs->hasCategory("log"));
 
     // Remove a category not in the color space.
-    OIIO_CHECK_NO_THROW(cs->removeCategory("log"));
-    OIIO_CHECK_EQUAL(cs->getNumCategories(), 1);
-    OIIO_CHECK_ASSERT(cs->hasCategory("rendering"));
+    OCIO_CHECK_NO_THROW(cs->removeCategory("log"));
+    OCIO_CHECK_EQUAL(cs->getNumCategories(), 1);
+    OCIO_CHECK_ASSERT(cs->hasCategory("rendering"));
 
-    OIIO_CHECK_NO_THROW(cs->clearCategories());
-    OIIO_CHECK_EQUAL(cs->getNumCategories(), 0);
+    OCIO_CHECK_NO_THROW(cs->clearCategories());
+    OCIO_CHECK_EQUAL(cs->getNumCategories(), 0);
 }
 
 #endif // OCIO_UNIT_TEST

--- a/src/OpenColorIO/ColorSpaceSet.cpp
+++ b/src/OpenColorIO/ColorSpaceSet.cpp
@@ -350,23 +350,23 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(ColorSpaceSet, basic)
+OCIO_ADD_TEST(ColorSpaceSet, basic)
 {
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
 
     OCIO::ConstColorSpaceSetRcPtr css1;
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces(nullptr));
-    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 0);
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces(nullptr));
+    OCIO_CHECK_EQUAL(css1->getNumColorSpaces(), 0);
 
     // No category.
 
     OCIO::ColorSpaceRcPtr cs1 = OCIO::ColorSpace::Create();
     cs1->setName("cs1");
-    OIIO_CHECK_ASSERT(!cs1->hasCategory("linear"));
-    OIIO_CHECK_ASSERT(!cs1->hasCategory("rendering"));
-    OIIO_CHECK_ASSERT(!cs1->hasCategory("log"));
+    OCIO_CHECK_ASSERT(!cs1->hasCategory("linear"));
+    OCIO_CHECK_ASSERT(!cs1->hasCategory("rendering"));
+    OCIO_CHECK_ASSERT(!cs1->hasCategory("log"));
 
     // Having categories to filter with.
 
@@ -374,136 +374,136 @@ OIIO_ADD_TEST(ColorSpaceSet, basic)
     cs2->setName("cs2");
     cs2->addCategory("linear");
     cs2->addCategory("rendering");
-    OIIO_CHECK_ASSERT(cs2->hasCategory("linear"));
-    OIIO_CHECK_ASSERT(cs2->hasCategory("rendering"));
-    OIIO_CHECK_ASSERT(!cs2->hasCategory("log"));
+    OCIO_CHECK_ASSERT(cs2->hasCategory("linear"));
+    OCIO_CHECK_ASSERT(cs2->hasCategory("rendering"));
+    OCIO_CHECK_ASSERT(!cs2->hasCategory("log"));
 
-    OIIO_CHECK_NO_THROW(cs2->addCategory("log"));
-    OIIO_CHECK_ASSERT(cs2->hasCategory("log"));
-    OIIO_CHECK_NO_THROW(cs2->removeCategory("log"));
-    OIIO_CHECK_ASSERT(!cs2->hasCategory("log"));
+    OCIO_CHECK_NO_THROW(cs2->addCategory("log"));
+    OCIO_CHECK_ASSERT(cs2->hasCategory("log"));
+    OCIO_CHECK_NO_THROW(cs2->removeCategory("log"));
+    OCIO_CHECK_ASSERT(!cs2->hasCategory("log"));
 
     // Update config.
 
-    OIIO_CHECK_NO_THROW(config->addColorSpace(cs1));
-    OIIO_CHECK_NO_THROW(config->addColorSpace(cs2));
+    OCIO_CHECK_NO_THROW(config->addColorSpace(cs1));
+    OCIO_CHECK_NO_THROW(config->addColorSpace(cs2));
 
     // Search some color spaces based on criteria.
 
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces(nullptr));
-    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 2);
-    OIIO_CHECK_EQUAL(config->getNumColorSpaces(), 2);
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces(nullptr));
+    OCIO_CHECK_EQUAL(css1->getNumColorSpaces(), 2);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(), 2);
 
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces(""));
-    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 2);
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces(""));
+    OCIO_CHECK_EQUAL(css1->getNumColorSpaces(), 2);
 
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("log"));
-    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 0);
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces("log"));
+    OCIO_CHECK_EQUAL(css1->getNumColorSpaces(), 0);
 
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("linear"));
-    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 1);
-    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs2"));
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces("linear"));
+    OCIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 1);
+    OCIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs2"));
 
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("LinEar"));
-    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 1);
-    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs2"));
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces("LinEar"));
+    OCIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 1);
+    OCIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs2"));
 
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces(" LinEar "));
-    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 1);
-    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs2"));
-    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceByIndex(0)->getName()), std::string("cs2"));
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces(" LinEar "));
+    OCIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 1);
+    OCIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs2"));
+    OCIO_CHECK_EQUAL(std::string(css1->getColorSpaceByIndex(0)->getName()), std::string("cs2"));
 
     // Test some faulty requests.
 
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("lin ear"));
-    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 0);
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces("lin ear"));
+    OCIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 0);
 
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("[linear]"));
-    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 0);
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces("[linear]"));
+    OCIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 0);
 
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("linear log"));
-    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 0);
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces("linear log"));
+    OCIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 0);
 
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("linearlog"));
-    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 0);
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces("linearlog"));
+    OCIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 0);
 
     // Empty the config.
 
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("linear"));
-    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 1);
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces("linear"));
+    OCIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 1);
 
-    OIIO_CHECK_NO_THROW(config->clearColorSpaces());
-    OIIO_CHECK_EQUAL(config->getNumColorSpaces(), 0);
+    OCIO_CHECK_NO_THROW(config->clearColorSpaces());
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(), 0);
     // But existing sets are preserved.
-    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 1);
+    OCIO_CHECK_EQUAL(css1->getNumColorSpaces(), 1);
 
     OCIO::ConstColorSpaceSetRcPtr css2;
-    OIIO_CHECK_NO_THROW(css2 = config->getColorSpaces(nullptr));
-    OIIO_CHECK_EQUAL(css2->getNumColorSpaces(), 0);
+    OCIO_CHECK_NO_THROW(css2 = config->getColorSpaces(nullptr));
+    OCIO_CHECK_EQUAL(css2->getNumColorSpaces(), 0);
 }
 
-OIIO_ADD_TEST(ColorSpaceSet, decoupled_sets)
+OCIO_ADD_TEST(ColorSpaceSet, decoupled_sets)
 {
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
 
     OCIO::ColorSpaceRcPtr cs1 = OCIO::ColorSpace::Create();
     cs1->setName("cs1");
-    OIIO_CHECK_NO_THROW(cs1->addCategory("linear"));
-    OIIO_CHECK_ASSERT(cs1->hasCategory("linear"));
-    OIIO_CHECK_NO_THROW(config->addColorSpace(cs1));
+    OCIO_CHECK_NO_THROW(cs1->addCategory("linear"));
+    OCIO_CHECK_ASSERT(cs1->hasCategory("linear"));
+    OCIO_CHECK_NO_THROW(config->addColorSpace(cs1));
 
     OCIO::ConstColorSpaceSetRcPtr css1;
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces(nullptr));
-    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 1);
-    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces(nullptr));
+    OCIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 1);
+    OCIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs1"));
 
     OCIO::ConstColorSpaceSetRcPtr css2;
-    OIIO_CHECK_NO_THROW(css2 = config->getColorSpaces("linear"));
-    OIIO_CHECK_EQUAL(css2->getNumColorSpaces(), 1);
-    OIIO_CHECK_EQUAL(std::string(css2->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OCIO_CHECK_NO_THROW(css2 = config->getColorSpaces("linear"));
+    OCIO_CHECK_EQUAL(css2->getNumColorSpaces(), 1);
+    OCIO_CHECK_EQUAL(std::string(css2->getColorSpaceNameByIndex(0)), std::string("cs1"));
 
     // Change the original color space.
 
     cs1->setName("new_cs1");
 
     // Check that color spaces in existing sets are not changed.
-    OIIO_CHECK_EQUAL(std::string(config->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OCIO_CHECK_EQUAL(std::string(config->getColorSpaceNameByIndex(0)), std::string("cs1"));
 
-    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 1);
-    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OCIO_CHECK_EQUAL(css1->getNumColorSpaces(), 1);
+    OCIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs1"));
 
-    OIIO_CHECK_EQUAL(css2->getNumColorSpaces(), 1);
-    OIIO_CHECK_EQUAL(std::string(css2->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OCIO_CHECK_EQUAL(css2->getNumColorSpaces(), 1);
+    OCIO_CHECK_EQUAL(std::string(css2->getColorSpaceNameByIndex(0)), std::string("cs1"));
 
     // Change the color space from the config instance.
 
-    OIIO_CHECK_ASSERT(!cs1->isData());
+    OCIO_CHECK_ASSERT(!cs1->isData());
     config->clearColorSpaces();
     config->addColorSpace(cs1);
     cs1->setIsData(true);
 
-    OIIO_CHECK_EQUAL(std::string(cs1->getName()), std::string("new_cs1"));
-    OIIO_CHECK_ASSERT(cs1->isData());
-    OIIO_CHECK_EQUAL(std::string(config->getColorSpaceNameByIndex(0)), std::string("new_cs1"));
+    OCIO_CHECK_EQUAL(std::string(cs1->getName()), std::string("new_cs1"));
+    OCIO_CHECK_ASSERT(cs1->isData());
+    OCIO_CHECK_EQUAL(std::string(config->getColorSpaceNameByIndex(0)), std::string("new_cs1"));
     // NB: ColorSpace would need to be re-added to the config to reflect the change to isData.
-    OIIO_CHECK_ASSERT(!config->getColorSpace("new_cs1")->isData());
+    OCIO_CHECK_ASSERT(!config->getColorSpace("new_cs1")->isData());
 
-    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 1);
-    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs1"));
-    OIIO_CHECK_ASSERT(!css1->getColorSpace("cs1")->isData());
+    OCIO_CHECK_EQUAL(css1->getNumColorSpaces(), 1);
+    OCIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OCIO_CHECK_ASSERT(!css1->getColorSpace("cs1")->isData());
 
-    OIIO_CHECK_EQUAL(css2->getNumColorSpaces(), 1);
-    OIIO_CHECK_EQUAL(std::string(css2->getColorSpaceNameByIndex(0)), std::string("cs1"));
-    OIIO_CHECK_ASSERT(!css2->getColorSpace("cs1")->isData());
+    OCIO_CHECK_EQUAL(css2->getNumColorSpaces(), 1);
+    OCIO_CHECK_EQUAL(std::string(css2->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OCIO_CHECK_ASSERT(!css2->getColorSpace("cs1")->isData());
 }
 
-OIIO_ADD_TEST(ColorSpaceSet, order_validation)
+OCIO_ADD_TEST(ColorSpaceSet, order_validation)
 {
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
 
     OCIO::ConstColorSpaceSetRcPtr css1;
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces(nullptr));
-    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 0);
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces(nullptr));
+    OCIO_CHECK_EQUAL(css1->getNumColorSpaces(), 0);
 
     // Create some color spaces.
 
@@ -523,29 +523,29 @@ OIIO_ADD_TEST(ColorSpaceSet, order_validation)
 
     // Add the color spaces.
 
-    OIIO_CHECK_NO_THROW(config->addColorSpace(cs1));
-    OIIO_CHECK_NO_THROW(config->addColorSpace(cs2));
-    OIIO_CHECK_NO_THROW(config->addColorSpace(cs3));
+    OCIO_CHECK_NO_THROW(config->addColorSpace(cs1));
+    OCIO_CHECK_NO_THROW(config->addColorSpace(cs2));
+    OCIO_CHECK_NO_THROW(config->addColorSpace(cs3));
 
     // Check the color space order for the category "linear".
 
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("linear"));
-    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 2);
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces("linear"));
+    OCIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 2);
 
-    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs1"));
-    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(1)), std::string("cs2"));
+    OCIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OCIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(1)), std::string("cs2"));
 
     // Check the color space order for the category "rendering".
 
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces("rendering"));
-    OIIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 3);
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces("rendering"));
+    OCIO_REQUIRE_EQUAL(css1->getNumColorSpaces(), 3);
 
-    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs1"));
-    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(1)), std::string("cs2"));
-    OIIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(2)), std::string("cs3"));
+    OCIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OCIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(1)), std::string("cs2"));
+    OCIO_CHECK_EQUAL(std::string(css1->getColorSpaceNameByIndex(2)), std::string("cs3"));
 }
 
-OIIO_ADD_TEST(ColorSpaceSet, operations_on_set)
+OCIO_ADD_TEST(ColorSpaceSet, operations_on_set)
 {
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
 
@@ -553,7 +553,7 @@ OIIO_ADD_TEST(ColorSpaceSet, operations_on_set)
 
     OCIO::ColorSpaceRcPtr cs1 = OCIO::ColorSpace::Create();
     cs1->setName("cs1");
-    OIIO_CHECK_NO_THROW(config->addColorSpace(cs1));
+    OCIO_CHECK_NO_THROW(config->addColorSpace(cs1));
 
     // Having categories to filter with.
 
@@ -561,13 +561,13 @@ OIIO_ADD_TEST(ColorSpaceSet, operations_on_set)
     cs2->setName("cs2");
     cs2->addCategory("linear");
     cs2->addCategory("rendering");
-    OIIO_CHECK_NO_THROW(config->addColorSpace(cs2));
+    OCIO_CHECK_NO_THROW(config->addColorSpace(cs2));
 
     OCIO::ColorSpaceRcPtr cs3 = OCIO::ColorSpace::Create();
     cs3->setName("cs3");
     cs3->addCategory("log");
     cs3->addCategory("rendering");
-    OIIO_CHECK_NO_THROW(config->addColorSpace(cs3));
+    OCIO_CHECK_NO_THROW(config->addColorSpace(cs3));
 
 
     // Recap. of the existing color spaces:
@@ -577,18 +577,18 @@ OIIO_ADD_TEST(ColorSpaceSet, operations_on_set)
 
 
     OCIO::ConstColorSpaceSetRcPtr css1;
-    OIIO_CHECK_NO_THROW(css1 = config->getColorSpaces(nullptr));
-    OIIO_CHECK_EQUAL(css1->getNumColorSpaces(), 3);
+    OCIO_CHECK_NO_THROW(css1 = config->getColorSpaces(nullptr));
+    OCIO_CHECK_EQUAL(css1->getNumColorSpaces(), 3);
 
     OCIO::ConstColorSpaceSetRcPtr css2;
-    OIIO_CHECK_NO_THROW(css2 = config->getColorSpaces("linear"));
-    OIIO_CHECK_EQUAL(css2->getNumColorSpaces(), 1);
-    OIIO_CHECK_EQUAL(std::string(css2->getColorSpaceNameByIndex(0)), std::string("cs2"));
+    OCIO_CHECK_NO_THROW(css2 = config->getColorSpaces("linear"));
+    OCIO_CHECK_EQUAL(css2->getNumColorSpaces(), 1);
+    OCIO_CHECK_EQUAL(std::string(css2->getColorSpaceNameByIndex(0)), std::string("cs2"));
 
     OCIO::ConstColorSpaceSetRcPtr css3;
-    OIIO_CHECK_NO_THROW(css3 = config->getColorSpaces("log"));
-    OIIO_CHECK_EQUAL(css3->getNumColorSpaces(), 1);
-    OIIO_CHECK_EQUAL(std::string(css3->getColorSpaceNameByIndex(0)), std::string("cs3"));
+    OCIO_CHECK_NO_THROW(css3 = config->getColorSpaces("log"));
+    OCIO_CHECK_EQUAL(css3->getNumColorSpaces(), 1);
+    OCIO_CHECK_EQUAL(std::string(css3->getColorSpaceNameByIndex(0)), std::string("cs3"));
 
 
     // Recap. of the existing color space sets:
@@ -600,62 +600,62 @@ OIIO_ADD_TEST(ColorSpaceSet, operations_on_set)
     // Test the union.
 
     OCIO::ConstColorSpaceSetRcPtr css4 = css2 || css3;
-    OIIO_CHECK_EQUAL(css4->getNumColorSpaces(), 2); // {cs2, cs3}
+    OCIO_CHECK_EQUAL(css4->getNumColorSpaces(), 2); // {cs2, cs3}
 
     css4 = css1 || css2;
-    OIIO_CHECK_EQUAL(css4->getNumColorSpaces(), 3); // no duplication i.e. all color spaces
+    OCIO_CHECK_EQUAL(css4->getNumColorSpaces(), 3); // no duplication i.e. all color spaces
 
     // Test the intersection.
 
     css4 = css2 && css3;
-    OIIO_CHECK_EQUAL(css4->getNumColorSpaces(), 0);
+    OCIO_CHECK_EQUAL(css4->getNumColorSpaces(), 0);
 
     css4 = css2 && css1;
-    OIIO_REQUIRE_EQUAL(css4->getNumColorSpaces(), 1); // {cs2}
-    OIIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(0)), std::string("cs2"));
-    OIIO_CHECK_EQUAL(std::string(css4->getColorSpaceByIndex(0)->getName()), std::string("cs2"));
+    OCIO_REQUIRE_EQUAL(css4->getNumColorSpaces(), 1); // {cs2}
+    OCIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(0)), std::string("cs2"));
+    OCIO_CHECK_EQUAL(std::string(css4->getColorSpaceByIndex(0)->getName()), std::string("cs2"));
 
     // Test the difference.
 
     css4 = css1 - css3;
-    OIIO_REQUIRE_EQUAL(css4->getNumColorSpaces(), 2); // {cs1, cs2}
-    OIIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(0)), std::string("cs1"));
-    OIIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(1)), std::string("cs2"));
+    OCIO_REQUIRE_EQUAL(css4->getNumColorSpaces(), 2); // {cs1, cs2}
+    OCIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OCIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(1)), std::string("cs2"));
 
     css4 = css1 - css2;
-    OIIO_REQUIRE_EQUAL(css4->getNumColorSpaces(), 2); // {cs1, cs3}
-    OIIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(0)), std::string("cs1"));
-    OIIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(1)), std::string("cs3"));
+    OCIO_REQUIRE_EQUAL(css4->getNumColorSpaces(), 2); // {cs1, cs3}
+    OCIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OCIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(1)), std::string("cs3"));
 
     // Test with several embedded operations.
 
     css4 = css1 - (css2 || css3);
-    OIIO_REQUIRE_EQUAL(css4->getNumColorSpaces(), 1); // {cs1}
-    OIIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(0)), std::string("cs1"));
+    OCIO_REQUIRE_EQUAL(css4->getNumColorSpaces(), 1); // {cs1}
+    OCIO_CHECK_EQUAL(std::string(css4->getColorSpaceNameByIndex(0)), std::string("cs1"));
 
     OCIO::ColorSpaceSetRcPtr css5;
-    OIIO_CHECK_NO_THROW(css5 = config->getColorSpaces("rendering"));
-    OIIO_CHECK_EQUAL(css5->getNumColorSpaces(), 2); // {cs2, cs3}
+    OCIO_CHECK_NO_THROW(css5 = config->getColorSpaces("rendering"));
+    OCIO_CHECK_EQUAL(css5->getNumColorSpaces(), 2); // {cs2, cs3}
     // Manipulate the result with few tests.
-    OIIO_CHECK_NO_THROW(css5->addColorSpace(cs1));
-    OIIO_CHECK_EQUAL(css5->getNumColorSpaces(), 3); // {cs1, cs2, cs3}
-    OIIO_CHECK_NO_THROW(css5->removeColorSpace("cs2"));
-    OIIO_CHECK_NO_THROW(css5->removeColorSpace("cs1"));
-    OIIO_CHECK_EQUAL(css5->getNumColorSpaces(), 1);
-    OIIO_CHECK_EQUAL(std::string(css5->getColorSpaceNameByIndex(0)), std::string("cs3"));
-    OIIO_CHECK_NO_THROW(css5->clearColorSpaces());
-    OIIO_CHECK_EQUAL(css5->getNumColorSpaces(), 0);
+    OCIO_CHECK_NO_THROW(css5->addColorSpace(cs1));
+    OCIO_CHECK_EQUAL(css5->getNumColorSpaces(), 3); // {cs1, cs2, cs3}
+    OCIO_CHECK_NO_THROW(css5->removeColorSpace("cs2"));
+    OCIO_CHECK_NO_THROW(css5->removeColorSpace("cs1"));
+    OCIO_CHECK_EQUAL(css5->getNumColorSpaces(), 1);
+    OCIO_CHECK_EQUAL(std::string(css5->getColorSpaceNameByIndex(0)), std::string("cs3"));
+    OCIO_CHECK_NO_THROW(css5->clearColorSpaces());
+    OCIO_CHECK_EQUAL(css5->getNumColorSpaces(), 0);
 
-    OIIO_CHECK_NO_THROW(css5 = config->getColorSpaces("rendering"));
-    OIIO_REQUIRE_EQUAL(css5->getNumColorSpaces(), 2); // {cs2, cs3}
-    OIIO_CHECK_EQUAL(std::string(css5->getColorSpaceNameByIndex(0)), std::string("cs2"));
-    OIIO_CHECK_EQUAL(std::string(css5->getColorSpaceNameByIndex(1)), std::string("cs3"));
+    OCIO_CHECK_NO_THROW(css5 = config->getColorSpaces("rendering"));
+    OCIO_REQUIRE_EQUAL(css5->getNumColorSpaces(), 2); // {cs2, cs3}
+    OCIO_CHECK_EQUAL(std::string(css5->getColorSpaceNameByIndex(0)), std::string("cs2"));
+    OCIO_CHECK_EQUAL(std::string(css5->getColorSpaceNameByIndex(1)), std::string("cs3"));
 
     css4 = (css1  - css5)  // ( {cs1, cs2, cs3} - {cs2, cs3} ) --> {cs1}
            && 
            (css2 || css3); // ( {cs2} || {cs3} )               --> {cs2, cs3}
 
-    OIIO_CHECK_EQUAL(css4->getNumColorSpaces(), 0);
+    OCIO_CHECK_EQUAL(css4->getNumColorSpaces(), 0);
 }
 
 #endif // OCIO_UNIT_TEST

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -1905,9 +1905,9 @@ OCIO_ADD_TEST(Config, serialize)
     "        - !<ExponentTransform> {value: [1, 1, 1, 1]}\n";
     
     std::vector<std::string> osvec;
-    pystring::splitlines(os.str(), osvec);
+    OCIO::pystring::splitlines(os.str(), osvec);
     std::vector<std::string> PROFILE_OUTvec;
-    pystring::splitlines(PROFILE_OUT, PROFILE_OUTvec);
+    OCIO::pystring::splitlines(PROFILE_OUT, PROFILE_OUTvec);
     
     OCIO_CHECK_EQUAL(osvec.size(), PROFILE_OUTvec.size());
     for(unsigned int i = 0; i < PROFILE_OUTvec.size(); ++i)
@@ -1942,9 +1942,9 @@ OCIO_ADD_TEST(Config, serialize_searchpath)
             "  []";
 
         std::vector<std::string> osvec;
-        pystring::splitlines(os.str(), osvec);
+        OCIO::pystring::splitlines(os.str(), osvec);
         std::vector<std::string> PROFILE_OUTvec;
-        pystring::splitlines(PROFILE_OUT, PROFILE_OUTvec);
+        OCIO::pystring::splitlines(PROFILE_OUT, PROFILE_OUTvec);
 
         OCIO_CHECK_EQUAL(osvec.size(), PROFILE_OUTvec.size());
         for (unsigned int i = 0; i < PROFILE_OUTvec.size(); ++i)
@@ -1961,7 +1961,7 @@ OCIO_ADD_TEST(Config, serialize_searchpath)
         config->serialize(os);
 
         std::vector<std::string> osvec;
-        pystring::splitlines(os.str(), osvec);
+        OCIO::pystring::splitlines(os.str(), osvec);
 
         const std::string expected1{ "search_path: a:b:c" };
         OCIO_CHECK_EQUAL(osvec[2], expected1);
@@ -1972,7 +1972,7 @@ OCIO_ADD_TEST(Config, serialize_searchpath)
         config->serialize(os);
 
         osvec.clear();
-        pystring::splitlines(os.str(), osvec);
+        OCIO::pystring::splitlines(os.str(), osvec);
 
         const std::string expected2[] = { "search_path:", "  - a", "  - b", "  - c" };
         OCIO_CHECK_EQUAL(osvec[2], expected2[0]);
@@ -2005,7 +2005,7 @@ OCIO_ADD_TEST(Config, serialize_searchpath)
         config->serialize(os);
 
         osvec.clear();
-        pystring::splitlines(os.str(), osvec);
+        OCIO::pystring::splitlines(os.str(), osvec);
 
         const std::string expected3[] = { "search_path:",
                                           "  - a path with a - in it/",
@@ -2329,8 +2329,8 @@ OCIO_ADD_TEST(Config, version)
 
         std::stringstream ss;
         ss << *config.get();   
-        pystring::startswith(
-            pystring::lower(ss.str()), "ocio_profile_version: 2.20");
+        OCIO::pystring::startswith(
+            OCIO::pystring::lower(ss.str()), "ocio_profile_version: 2.20");
     }
 
     {
@@ -2338,8 +2338,8 @@ OCIO_ADD_TEST(Config, version)
 
         std::stringstream ss;
         ss << *config.get();   
-        pystring::startswith(
-            pystring::lower(ss.str()), "ocio_profile_version: 2");
+        OCIO::pystring::startswith(
+            OCIO::pystring::lower(ss.str()), "ocio_profile_version: 2");
     }
 
     {
@@ -2347,8 +2347,8 @@ OCIO_ADD_TEST(Config, version)
 
         std::stringstream ss;
         ss << *config.get();   
-        pystring::startswith(
-            pystring::lower(ss.str()), "ocio_profile_version: 1");
+        OCIO::pystring::startswith(
+            OCIO::pystring::lower(ss.str()), "ocio_profile_version: 1");
     }
 }
 

--- a/src/OpenColorIO/Config.cpp
+++ b/src/OpenColorIO/Config.cpp
@@ -1637,13 +1637,13 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 #include <sys/stat.h>
 #include "pystring/pystring.h"
 
 #if 0
-OIIO_ADD_TEST(Config, test_searchpath_filesystem)
+OCIO_ADD_TEST(Config, test_searchpath_filesystem)
 {
     
     OCIO::EnvMap env = OCIO::GetEnvMap();
@@ -1657,9 +1657,9 @@ OIIO_ADD_TEST(Config, test_searchpath_filesystem)
                           ":$OCIO_TEST1"
                           ":/$OCIO_JOB/${OCIO_SEQ}/$OCIO_SHOT/ocio");
     
-    OIIO_CHECK_ASSERT(strcmp(config->getSearchPath(),
+    OCIO_CHECK_ASSERT(strcmp(config->getSearchPath(),
         ".:$OCIO_TEST1:/$OCIO_JOB/${OCIO_SEQ}/$OCIO_SHOT/ocio") == 0);
-    OIIO_CHECK_ASSERT(strcmp(config->getSearchPath(true),
+    OCIO_CHECK_ASSERT(strcmp(config->getSearchPath(true),
         ".:foobar:/meatballs/cheesecake/mb-cc-001/ocio") == 0);
     
     // find some files
@@ -1698,26 +1698,26 @@ OIIO_ADD_TEST(Config, test_searchpath_filesystem)
     somelutdotdot.close();
     
     // basic search test
-    OIIO_CHECK_ASSERT(strcmp(config->findFile("somelut1.lut"),
+    OCIO_CHECK_ASSERT(strcmp(config->findFile("somelut1.lut"),
         lut1.c_str()) == 0);
-    OIIO_CHECK_ASSERT(strcmp(config->findFile("somelut2.lut"),
+    OCIO_CHECK_ASSERT(strcmp(config->findFile("somelut2.lut"),
         lut2.c_str()) == 0);
-    OIIO_CHECK_ASSERT(strcmp(config->findFile("somelut3.lut"),
+    OCIO_CHECK_ASSERT(strcmp(config->findFile("somelut3.lut"),
         lut3.c_str()) == 0);
-    OIIO_CHECK_ASSERT(strcmp(config->findFile("lutdotdot.lut"),
+    OCIO_CHECK_ASSERT(strcmp(config->findFile("lutdotdot.lut"),
         lutdotdot.c_str()) == 0);
     
 }
 #endif
 
-OIIO_ADD_TEST(Config, internal_raw_profile)
+OCIO_ADD_TEST(Config, internal_raw_profile)
 {
     std::istringstream is;
     is.str(OCIO::INTERNAL_RAW_PROFILE);
-    OIIO_CHECK_NO_THROW(OCIO::ConstConfigRcPtr config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(OCIO::ConstConfigRcPtr config = OCIO::Config::CreateFromStream(is));
 }
 
-OIIO_ADD_TEST(Config, simple_config)
+OCIO_ADD_TEST(Config, simple_config)
 {
     
     std::string SIMPLE_PROFILE =
@@ -1788,10 +1788,10 @@ OIIO_ADD_TEST(Config, simple_config)
     std::istringstream is;
     is.str(SIMPLE_PROFILE);
     OCIO::ConstConfigRcPtr config;
-    OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
 }
 
-OIIO_ADD_TEST(Config, roles)
+OCIO_ADD_TEST(Config, roles)
 {
     
     std::string SIMPLE_PROFILE =
@@ -1813,23 +1813,23 @@ OIIO_ADD_TEST(Config, roles)
     std::istringstream is;
     is.str(SIMPLE_PROFILE);
     OCIO::ConstConfigRcPtr config;
-    OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
     
-    OIIO_CHECK_EQUAL(config->getNumRoles(), 3);
+    OCIO_CHECK_EQUAL(config->getNumRoles(), 3);
     
-    OIIO_CHECK_ASSERT(config->hasRole("compositing_log") == true);
-    OIIO_CHECK_ASSERT(config->hasRole("cheese") == false);
-    OIIO_CHECK_ASSERT(config->hasRole("") == false);
+    OCIO_CHECK_ASSERT(config->hasRole("compositing_log") == true);
+    OCIO_CHECK_ASSERT(config->hasRole("cheese") == false);
+    OCIO_CHECK_ASSERT(config->hasRole("") == false);
     
-    OIIO_CHECK_ASSERT(strcmp(config->getRoleName(2), "scene_linear") == 0);
-    OIIO_CHECK_ASSERT(strcmp(config->getRoleName(0), "compositing_log") == 0);
-    OIIO_CHECK_ASSERT(strcmp(config->getRoleName(1), "default") == 0);
-    OIIO_CHECK_ASSERT(strcmp(config->getRoleName(10), "") == 0);
-    OIIO_CHECK_ASSERT(strcmp(config->getRoleName(-4), "") == 0);
+    OCIO_CHECK_ASSERT(strcmp(config->getRoleName(2), "scene_linear") == 0);
+    OCIO_CHECK_ASSERT(strcmp(config->getRoleName(0), "compositing_log") == 0);
+    OCIO_CHECK_ASSERT(strcmp(config->getRoleName(1), "default") == 0);
+    OCIO_CHECK_ASSERT(strcmp(config->getRoleName(10), "") == 0);
+    OCIO_CHECK_ASSERT(strcmp(config->getRoleName(-4), "") == 0);
     
 }
 
-OIIO_ADD_TEST(Config, serialize)
+OCIO_ADD_TEST(Config, serialize)
 {
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
     {
@@ -1905,16 +1905,16 @@ OIIO_ADD_TEST(Config, serialize)
     "        - !<ExponentTransform> {value: [1, 1, 1, 1]}\n";
     
     std::vector<std::string> osvec;
-    OCIO::pystring::splitlines(os.str(), osvec);
+    pystring::splitlines(os.str(), osvec);
     std::vector<std::string> PROFILE_OUTvec;
-    OCIO::pystring::splitlines(PROFILE_OUT, PROFILE_OUTvec);
+    pystring::splitlines(PROFILE_OUT, PROFILE_OUTvec);
     
-    OIIO_CHECK_EQUAL(osvec.size(), PROFILE_OUTvec.size());
+    OCIO_CHECK_EQUAL(osvec.size(), PROFILE_OUTvec.size());
     for(unsigned int i = 0; i < PROFILE_OUTvec.size(); ++i)
-        OIIO_CHECK_EQUAL(osvec[i], PROFILE_OUTvec[i]);
+        OCIO_CHECK_EQUAL(osvec[i], PROFILE_OUTvec[i]);
 }
 
-OIIO_ADD_TEST(Config, serialize_searchpath)
+OCIO_ADD_TEST(Config, serialize_searchpath)
 {
     {
         OCIO::ConfigRcPtr config = OCIO::Config::Create();
@@ -1942,13 +1942,13 @@ OIIO_ADD_TEST(Config, serialize_searchpath)
             "  []";
 
         std::vector<std::string> osvec;
-        OCIO::pystring::splitlines(os.str(), osvec);
+        pystring::splitlines(os.str(), osvec);
         std::vector<std::string> PROFILE_OUTvec;
-        OCIO::pystring::splitlines(PROFILE_OUT, PROFILE_OUTvec);
+        pystring::splitlines(PROFILE_OUT, PROFILE_OUTvec);
 
-        OIIO_CHECK_EQUAL(osvec.size(), PROFILE_OUTvec.size());
+        OCIO_CHECK_EQUAL(osvec.size(), PROFILE_OUTvec.size());
         for (unsigned int i = 0; i < PROFILE_OUTvec.size(); ++i)
-            OIIO_CHECK_EQUAL(osvec[i], PROFILE_OUTvec[i]);
+            OCIO_CHECK_EQUAL(osvec[i], PROFILE_OUTvec[i]);
     }
 
     {
@@ -1961,10 +1961,10 @@ OIIO_ADD_TEST(Config, serialize_searchpath)
         config->serialize(os);
 
         std::vector<std::string> osvec;
-        OCIO::pystring::splitlines(os.str(), osvec);
+        pystring::splitlines(os.str(), osvec);
 
         const std::string expected1{ "search_path: a:b:c" };
-        OIIO_CHECK_EQUAL(osvec[2], expected1);
+        OCIO_CHECK_EQUAL(osvec[2], expected1);
 
         config->setMajorVersion(2);
         os.clear();
@@ -1972,24 +1972,24 @@ OIIO_ADD_TEST(Config, serialize_searchpath)
         config->serialize(os);
 
         osvec.clear();
-        OCIO::pystring::splitlines(os.str(), osvec);
+        pystring::splitlines(os.str(), osvec);
 
         const std::string expected2[] = { "search_path:", "  - a", "  - b", "  - c" };
-        OIIO_CHECK_EQUAL(osvec[2], expected2[0]);
-        OIIO_CHECK_EQUAL(osvec[3], expected2[1]);
-        OIIO_CHECK_EQUAL(osvec[4], expected2[2]);
-        OIIO_CHECK_EQUAL(osvec[5], expected2[3]);
+        OCIO_CHECK_EQUAL(osvec[2], expected2[0]);
+        OCIO_CHECK_EQUAL(osvec[3], expected2[1]);
+        OCIO_CHECK_EQUAL(osvec[4], expected2[2]);
+        OCIO_CHECK_EQUAL(osvec[5], expected2[3]);
 
         std::istringstream is;
         is.str(os.str());
         OCIO::ConstConfigRcPtr configRead;
-        OIIO_CHECK_NO_THROW(configRead = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(configRead = OCIO::Config::CreateFromStream(is));
 
-        OIIO_CHECK_EQUAL(configRead->getNumSearchPaths(), 3);
-        OIIO_CHECK_EQUAL(std::string(configRead->getSearchPath()), searchPath);
-        OIIO_CHECK_EQUAL(std::string(configRead->getSearchPath(0)), std::string("a"));
-        OIIO_CHECK_EQUAL(std::string(configRead->getSearchPath(1)), std::string("b"));
-        OIIO_CHECK_EQUAL(std::string(configRead->getSearchPath(2)), std::string("c"));
+        OCIO_CHECK_EQUAL(configRead->getNumSearchPaths(), 3);
+        OCIO_CHECK_EQUAL(std::string(configRead->getSearchPath()), searchPath);
+        OCIO_CHECK_EQUAL(std::string(configRead->getSearchPath(0)), std::string("a"));
+        OCIO_CHECK_EQUAL(std::string(configRead->getSearchPath(1)), std::string("b"));
+        OCIO_CHECK_EQUAL(std::string(configRead->getSearchPath(2)), std::string("c"));
 
         os.clear();
         os.str("");
@@ -2005,32 +2005,32 @@ OIIO_ADD_TEST(Config, serialize_searchpath)
         config->serialize(os);
 
         osvec.clear();
-        OCIO::pystring::splitlines(os.str(), osvec);
+        pystring::splitlines(os.str(), osvec);
 
         const std::string expected3[] = { "search_path:",
                                           "  - a path with a - in it/",
                                           "  - /absolute/linux/path",
                                           "  - C:\\absolute\\windows\\path",
                                           "  - \"!<path> usiing /yaml/symbols\"" };
-        OIIO_CHECK_EQUAL(osvec[2], expected3[0]);
-        OIIO_CHECK_EQUAL(osvec[3], expected3[1]);
-        OIIO_CHECK_EQUAL(osvec[4], expected3[2]);
-        OIIO_CHECK_EQUAL(osvec[5], expected3[3]);
-        OIIO_CHECK_EQUAL(osvec[6], expected3[4]);
+        OCIO_CHECK_EQUAL(osvec[2], expected3[0]);
+        OCIO_CHECK_EQUAL(osvec[3], expected3[1]);
+        OCIO_CHECK_EQUAL(osvec[4], expected3[2]);
+        OCIO_CHECK_EQUAL(osvec[5], expected3[3]);
+        OCIO_CHECK_EQUAL(osvec[6], expected3[4]);
 
         is.clear();
         is.str(os.str());
-        OIIO_CHECK_NO_THROW(configRead = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(configRead = OCIO::Config::CreateFromStream(is));
 
-        OIIO_CHECK_EQUAL(configRead->getNumSearchPaths(), 4);
-        OIIO_CHECK_EQUAL(std::string(configRead->getSearchPath(0)), sp0);
-        OIIO_CHECK_EQUAL(std::string(configRead->getSearchPath(1)), sp1);
-        OIIO_CHECK_EQUAL(std::string(configRead->getSearchPath(2)), sp2);
-        OIIO_CHECK_EQUAL(std::string(configRead->getSearchPath(3)), sp3);
+        OCIO_CHECK_EQUAL(configRead->getNumSearchPaths(), 4);
+        OCIO_CHECK_EQUAL(std::string(configRead->getSearchPath(0)), sp0);
+        OCIO_CHECK_EQUAL(std::string(configRead->getSearchPath(1)), sp1);
+        OCIO_CHECK_EQUAL(std::string(configRead->getSearchPath(2)), sp2);
+        OCIO_CHECK_EQUAL(std::string(configRead->getSearchPath(3)), sp3);
     }
 }
 
-OIIO_ADD_TEST(Config, sanity_check)
+OCIO_ADD_TEST(Config, sanity_check)
 {
     {
     std::string SIMPLE_PROFILE =
@@ -2051,7 +2051,7 @@ OIIO_ADD_TEST(Config, sanity_check)
     std::istringstream is;
     is.str(SIMPLE_PROFILE);
     OCIO::ConstConfigRcPtr config;
-    OIIO_CHECK_THROW(config = OCIO::Config::CreateFromStream(is), OCIO::Exception);
+    OCIO_CHECK_THROW(config = OCIO::Config::CreateFromStream(is), OCIO::Exception);
     }
     
     {
@@ -2071,14 +2071,14 @@ OIIO_ADD_TEST(Config, sanity_check)
     std::istringstream is;
     is.str(SIMPLE_PROFILE);
     OCIO::ConstConfigRcPtr config;
-    OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
     
-    OIIO_CHECK_NO_THROW(config->sanityCheck());
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
     }
 }
 
 
-OIIO_ADD_TEST(config, env_check)
+OCIO_ADD_TEST(config, env_check)
 {
     {
     std::string SIMPLE_PROFILE =
@@ -2122,26 +2122,26 @@ OIIO_ADD_TEST(config, env_check)
     std::istringstream is;
     is.str(SIMPLE_PROFILE);
     OCIO::ConstConfigRcPtr config;
-    OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-    OIIO_CHECK_EQUAL(config->getNumEnvironmentVars(), 5);
-    OIIO_CHECK_ASSERT(strcmp(config->getCurrentContext()->resolveStringVar("test${test}"),
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_EQUAL(config->getNumEnvironmentVars(), 5);
+    OCIO_CHECK_ASSERT(strcmp(config->getCurrentContext()->resolveStringVar("test${test}"),
         "testbarchedder") == 0);
-    OIIO_CHECK_ASSERT(strcmp(config->getCurrentContext()->resolveStringVar("${SHOW}"),
+    OCIO_CHECK_ASSERT(strcmp(config->getCurrentContext()->resolveStringVar("${SHOW}"),
         "bar") == 0);
-    OIIO_CHECK_ASSERT(strcmp(config->getEnvironmentVarDefault("SHOW"), "super") == 0);
+    OCIO_CHECK_ASSERT(strcmp(config->getEnvironmentVarDefault("SHOW"), "super") == 0);
     
     OCIO::ConfigRcPtr edit = config->createEditableCopy();
     edit->clearEnvironmentVars();
-    OIIO_CHECK_EQUAL(edit->getNumEnvironmentVars(), 0);
+    OCIO_CHECK_EQUAL(edit->getNumEnvironmentVars(), 0);
     
     edit->addEnvironmentVar("testing", "dupvar");
     edit->addEnvironmentVar("testing", "dupvar");
     edit->addEnvironmentVar("foobar", "testing");
     edit->addEnvironmentVar("blank", "");
     edit->addEnvironmentVar("dontadd", NULL);
-    OIIO_CHECK_EQUAL(edit->getNumEnvironmentVars(), 3);
+    OCIO_CHECK_EQUAL(edit->getNumEnvironmentVars(), 3);
     edit->addEnvironmentVar("foobar", NULL); // remove
-    OIIO_CHECK_EQUAL(edit->getNumEnvironmentVars(), 2);
+    OCIO_CHECK_EQUAL(edit->getNumEnvironmentVars(), 2);
     edit->clearEnvironmentVars();
     
     edit->addEnvironmentVar("SHOW", "super");
@@ -2155,28 +2155,28 @@ OIIO_ADD_TEST(config, env_check)
     OCIO::SetLoggingLevel(OCIO::LOGGING_LEVEL_DEBUG);
     is.str(SIMPLE_PROFILE2);
     OCIO::ConstConfigRcPtr noenv;
-    OIIO_CHECK_NO_THROW(noenv = OCIO::Config::CreateFromStream(is));
-    OIIO_CHECK_ASSERT(strcmp(noenv->getCurrentContext()->resolveStringVar("${TASK}"),
+    OCIO_CHECK_NO_THROW(noenv = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_ASSERT(strcmp(noenv->getCurrentContext()->resolveStringVar("${TASK}"),
         "lighting") == 0);
     OCIO::SetLoggingLevel(loglevel);
     
-    OIIO_CHECK_EQUAL(edit->getEnvironmentMode(), OCIO::ENV_ENVIRONMENT_LOAD_PREDEFINED);
+    OCIO_CHECK_EQUAL(edit->getEnvironmentMode(), OCIO::ENV_ENVIRONMENT_LOAD_PREDEFINED);
     edit->setEnvironmentMode(OCIO::ENV_ENVIRONMENT_LOAD_ALL);
-    OIIO_CHECK_EQUAL(edit->getEnvironmentMode(), OCIO::ENV_ENVIRONMENT_LOAD_ALL);
+    OCIO_CHECK_EQUAL(edit->getEnvironmentMode(), OCIO::ENV_ENVIRONMENT_LOAD_ALL);
     
     }
 }
 
-OIIO_ADD_TEST(Config, role_without_colorspace)
+OCIO_ADD_TEST(Config, role_without_colorspace)
 {
     OCIO::ConfigRcPtr config = OCIO::Config::Create()->createEditableCopy();
     config->setRole("reference", "UnknownColorSpace");
 
     std::ostringstream os;
-    OIIO_CHECK_THROW(config->serialize(os), OCIO::Exception);
+    OCIO_CHECK_THROW(config->serialize(os), OCIO::Exception);
 }
 
-OIIO_ADD_TEST(Config, env_colorspace_name)
+OCIO_ADD_TEST(Config, env_colorspace_name)
 {
     const std::string MY_OCIO_CONFIG =
         "ocio_profile_version: 1\n"
@@ -2235,9 +2235,9 @@ OIIO_ADD_TEST(Config, env_colorspace_name)
         is.str(myConfigStr);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_THROW(config->sanityCheck(), OCIO::Exception);
-        OIIO_CHECK_THROW(config->getProcessor("raw", "lgh"), OCIO::Exception);
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_THROW(config->sanityCheck(), OCIO::Exception);
+        OCIO_CHECK_THROW(config->getProcessor("raw", "lgh"), OCIO::Exception);
     }
 
     {
@@ -2253,9 +2253,9 @@ OIIO_ADD_TEST(Config, env_colorspace_name)
         is.str(myConfigStr);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_THROW(config->sanityCheck(), OCIO::Exception);
-        OIIO_CHECK_THROW(config->getProcessor("raw", "lgh"), OCIO::Exception);
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_THROW(config->sanityCheck(), OCIO::Exception);
+        OCIO_CHECK_THROW(config->getProcessor("raw", "lgh"), OCIO::Exception);
     }
 
     {
@@ -2271,9 +2271,9 @@ OIIO_ADD_TEST(Config, env_colorspace_name)
         is.str(myConfigStr);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
-        OIIO_CHECK_NO_THROW(config->getProcessor("raw", "lgh"));
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config->getProcessor("raw", "lgh"));
     }
 
     {
@@ -2289,16 +2289,16 @@ OIIO_ADD_TEST(Config, env_colorspace_name)
         is.str(myConfigStr);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), myConfigStr);
+        OCIO_CHECK_EQUAL(ss.str(), myConfigStr);
     }
 }
 
-OIIO_ADD_TEST(Config, version)
+OCIO_ADD_TEST(Config, version)
 {
     const std::string SIMPLE_PROFILE =
         "ocio_profile_version: 2\n"
@@ -2316,43 +2316,43 @@ OIIO_ADD_TEST(Config, version)
     std::istringstream is;
     is.str(SIMPLE_PROFILE);
     OCIO::ConfigRcPtr config;
-    OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is)->createEditableCopy());
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is)->createEditableCopy());
     
-    OIIO_CHECK_NO_THROW(config->sanityCheck());
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
 
-    OIIO_CHECK_NO_THROW(config->setMajorVersion(1));
-    OIIO_CHECK_THROW(config->setMajorVersion(20000), OCIO::Exception);
+    OCIO_CHECK_NO_THROW(config->setMajorVersion(1));
+    OCIO_CHECK_THROW(config->setMajorVersion(20000), OCIO::Exception);
 
     {
-        OIIO_CHECK_NO_THROW(config->setMinorVersion(2));
-        OIIO_CHECK_NO_THROW(config->setMinorVersion(20));
+        OCIO_CHECK_NO_THROW(config->setMinorVersion(2));
+        OCIO_CHECK_NO_THROW(config->setMinorVersion(20));
 
         std::stringstream ss;
         ss << *config.get();   
-        OCIO::pystring::startswith(
-            OCIO::pystring::lower(ss.str()), "ocio_profile_version: 2.20");
+        pystring::startswith(
+            pystring::lower(ss.str()), "ocio_profile_version: 2.20");
     }
 
     {
-        OIIO_CHECK_NO_THROW(config->setMinorVersion(0));
+        OCIO_CHECK_NO_THROW(config->setMinorVersion(0));
 
         std::stringstream ss;
         ss << *config.get();   
-        OCIO::pystring::startswith(
-            OCIO::pystring::lower(ss.str()), "ocio_profile_version: 2");
+        pystring::startswith(
+            pystring::lower(ss.str()), "ocio_profile_version: 2");
     }
 
     {
-        OIIO_CHECK_NO_THROW(config->setMinorVersion(1));
+        OCIO_CHECK_NO_THROW(config->setMinorVersion(1));
 
         std::stringstream ss;
         ss << *config.get();   
-        OCIO::pystring::startswith(
-            OCIO::pystring::lower(ss.str()), "ocio_profile_version: 1");
+        pystring::startswith(
+            pystring::lower(ss.str()), "ocio_profile_version: 1");
     }
 }
 
-OIIO_ADD_TEST(Config, version_faulty_1)
+OCIO_ADD_TEST(Config, version_faulty_1)
 {
     const std::string SIMPLE_PROFILE =
         "ocio_profile_version: 2.0.1\n"
@@ -2370,7 +2370,7 @@ OIIO_ADD_TEST(Config, version_faulty_1)
     std::istringstream is;
     is.str(SIMPLE_PROFILE);
     OCIO::ConstConfigRcPtr config;
-    OIIO_CHECK_THROW(config = OCIO::Config::CreateFromStream(is), OCIO::Exception);
+    OCIO_CHECK_THROW(config = OCIO::Config::CreateFromStream(is), OCIO::Exception);
 }
 
 namespace
@@ -2416,7 +2416,7 @@ const std::string SIMPLE_PROFILE =
 
 };
 
-OIIO_ADD_TEST(Config, range_serialization)
+OCIO_ADD_TEST(Config, range_serialization)
 {
     {
         const std::string strEnd =
@@ -2427,12 +2427,12 @@ OIIO_ADD_TEST(Config, range_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -2444,12 +2444,12 @@ OIIO_ADD_TEST(Config, range_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -2461,12 +2461,12 @@ OIIO_ADD_TEST(Config, range_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -2478,12 +2478,12 @@ OIIO_ADD_TEST(Config, range_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -2498,12 +2498,12 @@ OIIO_ADD_TEST(Config, range_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -2518,8 +2518,8 @@ OIIO_ADD_TEST(Config, range_serialization)
         is.str(in_str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         // Clamp style is not saved
         const std::string out_strEnd =
@@ -2530,7 +2530,7 @@ OIIO_ADD_TEST(Config, range_serialization)
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), out_str);
+        OCIO_CHECK_EQUAL(ss.str(), out_str);
     }
 
     {
@@ -2542,14 +2542,14 @@ OIIO_ADD_TEST(Config, range_serialization)
         std::istringstream is;
         is.str(str);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_THROW_WHAT(config->sanityCheck(), 
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_THROW_WHAT(config->sanityCheck(), 
                               OCIO::Exception, 
                               "must be both set or both missing");
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -2567,17 +2567,17 @@ OIIO_ADD_TEST(Config, range_serialization)
         std::istringstream is;
         is.str(str);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is),
+        OCIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is),
                               OCIO::Exception, "parsing double failed");
 
         is.str(strSaved);
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         // Re-serialize and test that it matches the expected text.
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), strSaved);
+        OCIO_CHECK_EQUAL(ss.str(), strSaved);
     }
 
     {
@@ -2594,13 +2594,13 @@ OIIO_ADD_TEST(Config, range_serialization)
         std::istringstream is;
         is.str(str);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         // Re-serialize and test that it matches the expected text.
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), strSaved);
+        OCIO_CHECK_EQUAL(ss.str(), strSaved);
     }
 
     {
@@ -2612,14 +2612,14 @@ OIIO_ADD_TEST(Config, range_serialization)
         std::istringstream is;
         is.str(str);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_THROW_WHAT(config->sanityCheck(),
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_THROW_WHAT(config->sanityCheck(),
             OCIO::Exception,
             "must be both set or both missing");
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -2631,13 +2631,13 @@ OIIO_ADD_TEST(Config, range_serialization)
         std::istringstream is;
         is.str(str);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         // Re-serialize and test that it matches the original text.
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -2649,14 +2649,14 @@ OIIO_ADD_TEST(Config, range_serialization)
         std::istringstream is;
         is.str(str);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_THROW_WHAT(config->sanityCheck(),
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_THROW_WHAT(config->sanityCheck(),
                               OCIO::Exception,
                               "must be both set or both missing");
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -2672,15 +2672,15 @@ OIIO_ADD_TEST(Config, range_serialization)
         std::istringstream is;
         is.str(str);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_THROW_WHAT(config->sanityCheck(),
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_THROW_WHAT(config->sanityCheck(),
                               OCIO::Exception,
                               "must be both set or both missing");
 
         // Re-serialize and test that it matches the original text.
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     // Some faulty cases
@@ -2696,7 +2696,7 @@ OIIO_ADD_TEST(Config, range_serialization)
 
         std::istringstream is;
         is.str(str);
-        OIIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is),
+        OCIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is),
                               OCIO::Exception,
                               "Loading the OCIO profile failed");
     }
@@ -2710,7 +2710,7 @@ OIIO_ADD_TEST(Config, range_serialization)
 
         std::istringstream is;
         is.str(str);
-        OIIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is),
+        OCIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is),
                               OCIO::Exception,
                               "Loading the OCIO profile failed");
     }
@@ -2725,13 +2725,13 @@ OIIO_ADD_TEST(Config, range_serialization)
 
         std::istringstream is;
         is.str(str);
-        OIIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is),
+        OCIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is),
                               OCIO::Exception,
                               "Loading the OCIO profile failed");
     }
 }
 
-OIIO_ADD_TEST(Config, exponent_serialization)   
+OCIO_ADD_TEST(Config, exponent_serialization)   
 {   
     {   
         const std::string strEnd =  
@@ -2742,12 +2742,12 @@ OIIO_ADD_TEST(Config, exponent_serialization)
         std::istringstream is; 
         is.str(str);    
         OCIO::ConstConfigRcPtr config;  
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));   
-        OIIO_CHECK_NO_THROW(config->sanityCheck()); 
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));   
+        OCIO_CHECK_NO_THROW(config->sanityCheck()); 
 
         std::stringstream ss;  
         ss << *config.get();    
-        OIIO_CHECK_EQUAL(ss.str(), str);    
+        OCIO_CHECK_EQUAL(ss.str(), str);    
     }   
 
      {  
@@ -2759,12 +2759,12 @@ OIIO_ADD_TEST(Config, exponent_serialization)
         std::istringstream is; 
         is.str(str);    
         OCIO::ConstConfigRcPtr config;  
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));   
-        OIIO_CHECK_NO_THROW(config->sanityCheck()); 
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));   
+        OCIO_CHECK_NO_THROW(config->sanityCheck()); 
 
         std::stringstream ss;  
         ss << *config.get();    
-        OIIO_CHECK_EQUAL(ss.str(), str);    
+        OCIO_CHECK_EQUAL(ss.str(), str);    
     }   
 
     // Errors
@@ -2779,13 +2779,13 @@ OIIO_ADD_TEST(Config, exponent_serialization)
         std::istringstream is;
         is.str(str);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
+        OCIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
                               OCIO::Exception,
                               "'value' values must be 4 floats. Found '3'");
     }
 }
 
-OIIO_ADD_TEST(Config, exponent_with_linear_serialization)
+OCIO_ADD_TEST(Config, exponent_with_linear_serialization)
 {
     {
         const std::string strEnd =
@@ -2796,12 +2796,12 @@ OIIO_ADD_TEST(Config, exponent_with_linear_serialization)
         std::istringstream is;
         is.str(str);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -2813,12 +2813,12 @@ OIIO_ADD_TEST(Config, exponent_with_linear_serialization)
         std::istringstream is;
         is.str(str);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     // Errors
@@ -2831,7 +2831,7 @@ OIIO_ADD_TEST(Config, exponent_with_linear_serialization)
         std::istringstream is;
         is.str(str);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
+        OCIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
                               OCIO::Exception,
                               "ExponentWithLinear parse error, gamma and offset fields are missing");
     }
@@ -2846,7 +2846,7 @@ OIIO_ADD_TEST(Config, exponent_with_linear_serialization)
         std::istringstream is;
         is.str(str);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
+        OCIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
                               OCIO::Exception,
                               "ExponentWithLinear parse error, offset field is missing");
     }
@@ -2861,7 +2861,7 @@ OIIO_ADD_TEST(Config, exponent_with_linear_serialization)
         std::istringstream is;
         is.str(str);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
+        OCIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
                               OCIO::Exception,
                               "ExponentWithLinear parse error, gamma field is missing");
     }
@@ -2876,7 +2876,7 @@ OIIO_ADD_TEST(Config, exponent_with_linear_serialization)
         std::istringstream is;
         is.str(str);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
+        OCIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
                               OCIO::Exception,
                               "ExponentWithLinear parse error, gamma field must be 4 floats");
     }
@@ -2890,13 +2890,13 @@ OIIO_ADD_TEST(Config, exponent_with_linear_serialization)
         std::istringstream is;
         is.str(str);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
+        OCIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
                               OCIO::Exception,
                               "ExponentWithLinear parse error, offset field must be 4 floats");
     }
 }
 
-OIIO_ADD_TEST(Config, exponent_vs_config_version)
+OCIO_ADD_TEST(Config, exponent_vs_config_version)
 {
     // The config i.e. SIMPLE_PROFILE is a version 2.
 
@@ -2911,18 +2911,18 @@ OIIO_ADD_TEST(Config, exponent_vs_config_version)
     const std::string str = PROFILE_V1 + SIMPLE_PROFILE + strEnd;
 
     is.str(str);
-    OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-    OIIO_CHECK_NO_THROW(config->sanityCheck());
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
 
-    OIIO_CHECK_NO_THROW(processor = config->getProcessor("raw", "lnh"));
+    OCIO_CHECK_NO_THROW(processor = config->getProcessor("raw", "lnh"));
 
     float img1[4] = { -0.5f, 0.0f, 1.0f, 1.0f };
-    OIIO_CHECK_NO_THROW(processor->applyRGBA(img1));
+    OCIO_CHECK_NO_THROW(processor->applyRGBA(img1));
 
-    OIIO_CHECK_EQUAL(img1[0], -0.5f);
-    OIIO_CHECK_EQUAL(img1[1],  0.0f);
-    OIIO_CHECK_EQUAL(img1[2],  1.0f);
-    OIIO_CHECK_EQUAL(img1[3],  1.0f);
+    OCIO_CHECK_EQUAL(img1[0], -0.5f);
+    OCIO_CHECK_EQUAL(img1[1],  0.0f);
+    OCIO_CHECK_EQUAL(img1[2],  1.0f);
+    OCIO_CHECK_EQUAL(img1[3],  1.0f);
 
     // OCIO config file version == 1  and exponent != 1
 
@@ -2931,52 +2931,52 @@ OIIO_ADD_TEST(Config, exponent_vs_config_version)
     const std::string str2 = PROFILE_V1 + SIMPLE_PROFILE + strEnd2;
 
     is.str(str2);
-    OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-    OIIO_CHECK_NO_THROW(config->sanityCheck());
-    OIIO_CHECK_NO_THROW(processor = config->getProcessor("raw", "lnh"));
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+    OCIO_CHECK_NO_THROW(processor = config->getProcessor("raw", "lnh"));
 
     float img2[4] = { -0.5f, 0.0f, 1.0f, 1.0f };
-    OIIO_CHECK_NO_THROW(processor->applyRGBA(img2));
+    OCIO_CHECK_NO_THROW(processor->applyRGBA(img2));
 
-    OIIO_CHECK_EQUAL(img2[0],  0.0f);
-    OIIO_CHECK_EQUAL(img2[1],  0.0f);
-    OIIO_CHECK_EQUAL(img2[2],  1.0f);
-    OIIO_CHECK_EQUAL(img2[3],  1.0f);
+    OCIO_CHECK_EQUAL(img2[0],  0.0f);
+    OCIO_CHECK_EQUAL(img2[1],  0.0f);
+    OCIO_CHECK_EQUAL(img2[2],  1.0f);
+    OCIO_CHECK_EQUAL(img2[3],  1.0f);
 
     // OCIO config file version > 1  and exponent == 1
 
     std::string str3 = PROFILE_V2 + SIMPLE_PROFILE + strEnd;
     is.str(str3);
-    OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-    OIIO_CHECK_NO_THROW(config->sanityCheck());
-    OIIO_CHECK_NO_THROW(processor = config->getProcessor("raw", "lnh"));
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+    OCIO_CHECK_NO_THROW(processor = config->getProcessor("raw", "lnh"));
 
     float img3[4] = { -0.5f, 0.0f, 1.0f, 1.0f };
-    OIIO_CHECK_NO_THROW(processor->applyRGBA(img3));
+    OCIO_CHECK_NO_THROW(processor->applyRGBA(img3));
 
-    OIIO_CHECK_EQUAL(img3[0], 0.0f);
-    OIIO_CHECK_EQUAL(img3[1], 0.0f);
-    OIIO_CHECK_CLOSE(img3[2], 1.0f, 2e-5f); // Because of SSE optimizations.
-    OIIO_CHECK_CLOSE(img3[3], 1.0f, 2e-5f); // Because of SSE optimizations.
+    OCIO_CHECK_EQUAL(img3[0], 0.0f);
+    OCIO_CHECK_EQUAL(img3[1], 0.0f);
+    OCIO_CHECK_CLOSE(img3[2], 1.0f, 2e-5f); // Because of SSE optimizations.
+    OCIO_CHECK_CLOSE(img3[3], 1.0f, 2e-5f); // Because of SSE optimizations.
 
     // OCIO config file version > 1  and exponent != 1
 
     std::string str4 = PROFILE_V2 + SIMPLE_PROFILE + strEnd2;
     is.str(str4);
-    OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-    OIIO_CHECK_NO_THROW(config->sanityCheck());
-    OIIO_CHECK_NO_THROW(processor = config->getProcessor("raw", "lnh"));
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
+    OCIO_CHECK_NO_THROW(processor = config->getProcessor("raw", "lnh"));
 
     float img4[4] = { -0.5f, 0.0f, 1.0f, 1.0f };
-    OIIO_CHECK_NO_THROW(processor->applyRGBA(img4));
+    OCIO_CHECK_NO_THROW(processor->applyRGBA(img4));
 
-    OIIO_CHECK_EQUAL(img4[0], 0.0f);
-    OIIO_CHECK_EQUAL(img4[1], 0.0f);
-    OIIO_CHECK_CLOSE(img4[2], 1.0f, 3e-5f); // Because of SSE optimizations.
-    OIIO_CHECK_CLOSE(img4[3], 1.0f, 2e-5f); // Because of SSE optimizations.
+    OCIO_CHECK_EQUAL(img4[0], 0.0f);
+    OCIO_CHECK_EQUAL(img4[1], 0.0f);
+    OCIO_CHECK_CLOSE(img4[2], 1.0f, 3e-5f); // Because of SSE optimizations.
+    OCIO_CHECK_CLOSE(img4[3], 1.0f, 2e-5f); // Because of SSE optimizations.
 }
 
-OIIO_ADD_TEST(Config, categories)
+OCIO_ADD_TEST(Config, categories)
 {
     static const std::string MY_OCIO_CONFIG =
         "ocio_profile_version: 1\n"
@@ -3021,46 +3021,46 @@ OIIO_ADD_TEST(Config, categories)
     is.str(MY_OCIO_CONFIG);
 
     OCIO::ConstConfigRcPtr config;
-    OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-    OIIO_CHECK_NO_THROW(config->sanityCheck());
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
 
     // Test the serialization & deserialization.
 
     std::stringstream ss;
     ss << *config.get();
-    OIIO_CHECK_EQUAL(ss.str(), MY_OCIO_CONFIG);
+    OCIO_CHECK_EQUAL(ss.str(), MY_OCIO_CONFIG);
 
     // Test the config content.
 
     OCIO::ColorSpaceSetRcPtr css = config->getColorSpaces(nullptr);
-    OIIO_CHECK_EQUAL(css->getNumColorSpaces(), 2);
+    OCIO_CHECK_EQUAL(css->getNumColorSpaces(), 2);
     OCIO::ConstColorSpaceRcPtr cs = css->getColorSpaceByIndex(0);
-    OIIO_CHECK_EQUAL(cs->getNumCategories(), 2);
-    OIIO_CHECK_EQUAL(std::string(cs->getCategory(0)), std::string("rendering"));
-    OIIO_CHECK_EQUAL(std::string(cs->getCategory(1)), std::string("linear"));
+    OCIO_CHECK_EQUAL(cs->getNumCategories(), 2);
+    OCIO_CHECK_EQUAL(std::string(cs->getCategory(0)), std::string("rendering"));
+    OCIO_CHECK_EQUAL(std::string(cs->getCategory(1)), std::string("linear"));
 
     css = config->getColorSpaces("linear");
-    OIIO_CHECK_EQUAL(css->getNumColorSpaces(), 1);
+    OCIO_CHECK_EQUAL(css->getNumColorSpaces(), 1);
     cs = css->getColorSpaceByIndex(0);
-    OIIO_CHECK_EQUAL(cs->getNumCategories(), 2);
-    OIIO_CHECK_EQUAL(std::string(cs->getCategory(0)), std::string("rendering"));
-    OIIO_CHECK_EQUAL(std::string(cs->getCategory(1)), std::string("linear"));
+    OCIO_CHECK_EQUAL(cs->getNumCategories(), 2);
+    OCIO_CHECK_EQUAL(std::string(cs->getCategory(0)), std::string("rendering"));
+    OCIO_CHECK_EQUAL(std::string(cs->getCategory(1)), std::string("linear"));
 
     css = config->getColorSpaces("rendering");
-    OIIO_CHECK_EQUAL(css->getNumColorSpaces(), 2);
+    OCIO_CHECK_EQUAL(css->getNumColorSpaces(), 2);
 
-    OIIO_CHECK_EQUAL(config->getNumColorSpaces(), 2);
-    OIIO_CHECK_EQUAL(std::string(config->getColorSpaceNameByIndex(0)), std::string("raw1"));
-    OIIO_CHECK_EQUAL(std::string(config->getColorSpaceNameByIndex(1)), std::string("raw2"));
-    OIIO_CHECK_EQUAL(config->getIndexForColorSpace("raw1"), 0);
-    OIIO_CHECK_EQUAL(config->getIndexForColorSpace("raw2"), 1);
+    OCIO_CHECK_EQUAL(config->getNumColorSpaces(), 2);
+    OCIO_CHECK_EQUAL(std::string(config->getColorSpaceNameByIndex(0)), std::string("raw1"));
+    OCIO_CHECK_EQUAL(std::string(config->getColorSpaceNameByIndex(1)), std::string("raw2"));
+    OCIO_CHECK_EQUAL(config->getIndexForColorSpace("raw1"), 0);
+    OCIO_CHECK_EQUAL(config->getIndexForColorSpace("raw2"), 1);
     cs = config->getColorSpace("raw1");
-    OIIO_CHECK_EQUAL(std::string(cs->getName()), std::string("raw1"));
+    OCIO_CHECK_EQUAL(std::string(cs->getName()), std::string("raw1"));
     cs = config->getColorSpace("raw2");
-    OIIO_CHECK_EQUAL(std::string(cs->getName()), std::string("raw2"));
+    OCIO_CHECK_EQUAL(std::string(cs->getName()), std::string("raw2"));
 }
 
-OIIO_ADD_TEST(Config, display)
+OCIO_ADD_TEST(Config, display)
 {
     static const std::string SIMPLE_PROFILE_HEADER =
         "ocio_profile_version: 1\n"
@@ -3111,12 +3111,12 @@ OIIO_ADD_TEST(Config, display)
 
         std::istringstream is(myProfile);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_EQUAL(config->getNumDisplays(), 3);
-        OIIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_1"));
-        OIIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_2"));
-        OIIO_CHECK_EQUAL(std::string(config->getDisplay(2)), std::string("sRGB_3"));
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_1");
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_EQUAL(config->getNumDisplays(), 3);
+        OCIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_1"));
+        OCIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_2"));
+        OCIO_CHECK_EQUAL(std::string(config->getDisplay(2)), std::string("sRGB_3"));
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_1");
     }
 
     {
@@ -3129,10 +3129,10 @@ OIIO_ADD_TEST(Config, display)
 
         std::istringstream is(myProfile);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_EQUAL(config->getNumDisplays(), 1);
-        OIIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_1"));
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_1");
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_EQUAL(config->getNumDisplays(), 1);
+        OCIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_1"));
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_1");
     }
 
     {
@@ -3145,11 +3145,11 @@ OIIO_ADD_TEST(Config, display)
 
         std::istringstream is(myProfile);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_EQUAL(config->getNumDisplays(), 2);
-        OIIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_2"));
-        OIIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_1"));
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_2");
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_EQUAL(config->getNumDisplays(), 2);
+        OCIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_2"));
+        OCIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_1"));
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_2");
     }
 
     {
@@ -3166,11 +3166,11 @@ OIIO_ADD_TEST(Config, display)
 
         std::istringstream is(myProfile);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_EQUAL(config->getNumDisplays(), 2);
-        OIIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_3"));
-        OIIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_2"));
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_3");
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_EQUAL(config->getNumDisplays(), 2);
+        OCIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_3"));
+        OCIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_2"));
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_3");
     }
 
     {
@@ -3187,11 +3187,11 @@ OIIO_ADD_TEST(Config, display)
 
         std::istringstream is(myProfile);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_EQUAL(config->getNumDisplays(), 2);
-        OIIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_3"));
-        OIIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_2"));
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_3");
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_EQUAL(config->getNumDisplays(), 2);
+        OCIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_3"));
+        OCIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_2"));
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_3");
     }
 
     {
@@ -3208,11 +3208,11 @@ OIIO_ADD_TEST(Config, display)
 
         std::istringstream is(myProfile);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_EQUAL(config->getNumDisplays(), 2);
-        OIIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_2"));
-        OIIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_1"));
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_2");
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_EQUAL(config->getNumDisplays(), 2);
+        OCIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_2"));
+        OCIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_1"));
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_2");
     }
 
     {
@@ -3229,15 +3229,15 @@ OIIO_ADD_TEST(Config, display)
 
         std::istringstream is(myProfile);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_EQUAL(config->getNumDisplays(), 2);
-        OIIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_2"));
-        OIIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_1"));
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_2");
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_EQUAL(config->getNumDisplays(), 2);
+        OCIO_CHECK_EQUAL(std::string(config->getDisplay(0)), std::string("sRGB_2"));
+        OCIO_CHECK_EQUAL(std::string(config->getDisplay(1)), std::string("sRGB_1"));
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultDisplay()), "sRGB_2");
     }
 }
 
-OIIO_ADD_TEST(Config, view)
+OCIO_ADD_TEST(Config, view)
 {
     static const std::string SIMPLE_PROFILE_HEADER =
         "ocio_profile_version: 1\n"
@@ -3291,16 +3291,16 @@ OIIO_ADD_TEST(Config, view)
 
         std::istringstream is(myProfile);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_1");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_1");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
     }
 
     {
@@ -3313,16 +3313,16 @@ OIIO_ADD_TEST(Config, view)
 
         std::istringstream is(myProfile);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_1");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_1");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
     }
 
     {
@@ -3335,16 +3335,16 @@ OIIO_ADD_TEST(Config, view)
 
         std::istringstream is(myProfile);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
     }
 
     {
@@ -3361,16 +3361,16 @@ OIIO_ADD_TEST(Config, view)
 
         std::istringstream is(myProfile);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
     }
 
     {
@@ -3387,16 +3387,16 @@ OIIO_ADD_TEST(Config, view)
 
         std::istringstream is(myProfile);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_1");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_1");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
     }
 
     {
@@ -3413,20 +3413,20 @@ OIIO_ADD_TEST(Config, view)
 
         std::istringstream is(myProfile);
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_1");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
-        OIIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_1")), "View_1");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 0)), "View_1");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_1", 1)), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_2")), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 0)), "View_2");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_2", 1)), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getDefaultView("sRGB_3")), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 0)), "View_3");
+        OCIO_CHECK_EQUAL(std::string(config->getView("sRGB_3", 1)), "View_1");
     }
 }
 
-OIIO_ADD_TEST(Config, log_serialization)
+OCIO_ADD_TEST(Config, log_serialization)
 {
     const std::string PROFILE_V1 = "ocio_profile_version: 1\n";
     const std::string PROFILE_V2 = "ocio_profile_version: 2\n";
@@ -3474,12 +3474,12 @@ OIIO_ADD_TEST(Config, log_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -3492,12 +3492,12 @@ OIIO_ADD_TEST(Config, log_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -3510,12 +3510,12 @@ OIIO_ADD_TEST(Config, log_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -3528,12 +3528,12 @@ OIIO_ADD_TEST(Config, log_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -3551,12 +3551,12 @@ OIIO_ADD_TEST(Config, log_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -3574,12 +3574,12 @@ OIIO_ADD_TEST(Config, log_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -3597,12 +3597,12 @@ OIIO_ADD_TEST(Config, log_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -3618,12 +3618,12 @@ OIIO_ADD_TEST(Config, log_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -3640,12 +3640,12 @@ OIIO_ADD_TEST(Config, log_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -3662,12 +3662,12 @@ OIIO_ADD_TEST(Config, log_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -3683,12 +3683,12 @@ OIIO_ADD_TEST(Config, log_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -3701,12 +3701,12 @@ OIIO_ADD_TEST(Config, log_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -3721,7 +3721,7 @@ OIIO_ADD_TEST(Config, log_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
+        OCIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
                               OCIO::Exception,
                               "logSideSlope value field must have 3 components");
     }
@@ -3738,13 +3738,13 @@ OIIO_ADD_TEST(Config, log_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
+        OCIO_CHECK_THROW_WHAT(config = OCIO::Config::CreateFromStream(is),
             OCIO::Exception,
             "base must be a single double");
     }
 }
 
-OIIO_ADD_TEST(Config, key_value_error)
+OCIO_ADD_TEST(Config, key_value_error)
 {
     // Check the line number contained in the parser error messages.
 
@@ -3770,7 +3770,7 @@ OIIO_ADD_TEST(Config, key_value_error)
     std::istringstream is;
     is.str(SHORT_PROFILE);
 
-    OIIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is),
+    OCIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is),
                           OCIO::Exception,
                           "Error: Loading the OCIO profile failed. At line 14, the value "
                           "parsing of the key 'matrix' from 'MatrixTransform' failed: "
@@ -3808,7 +3808,7 @@ private:
 
 };
 
-OIIO_ADD_TEST(Config, unknown_key_error)
+OCIO_ADD_TEST(Config, unknown_key_error)
 {
     const std::string SHORT_PROFILE =
         "ocio_profile_version: 2\n"
@@ -3831,12 +3831,12 @@ OIIO_ADD_TEST(Config, unknown_key_error)
     is.str(SHORT_PROFILE);
 
     Guard g;
-    OIIO_CHECK_NO_THROW(OCIO::Config::CreateFromStream(is));
-    OIIO_CHECK_EQUAL(g.output(), 
+    OCIO_CHECK_NO_THROW(OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_EQUAL(g.output(), 
                      "[OpenColorIO Warning]: At line 12, unknown key 'dummyKey' in 'ColorSpace'.\n");
 }
 
-OIIO_ADD_TEST(Config, fixed_function_serialization)
+OCIO_ADD_TEST(Config, fixed_function_serialization)
 {
     static const std::string SIMPLE_PROFILE =
         "ocio_profile_version: 2\n"
@@ -3888,12 +3888,12 @@ OIIO_ADD_TEST(Config, fixed_function_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -3908,8 +3908,8 @@ OIIO_ADD_TEST(Config, fixed_function_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_THROW_WHAT(config->sanityCheck(), OCIO::Exception,
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_THROW_WHAT(config->sanityCheck(), OCIO::Exception,
             "The style 'ACES_DarkToDim10 (Forward)' must have zero parameters but 1 found.");
     }
 
@@ -3925,14 +3925,14 @@ OIIO_ADD_TEST(Config, fixed_function_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_THROW_WHAT(config->sanityCheck(), OCIO::Exception, 
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_THROW_WHAT(config->sanityCheck(), OCIO::Exception, 
                               "The style 'REC2100_Surround' must "
                               "have one parameter but 0 found.");
     }
 }
 
-OIIO_ADD_TEST(Config, exposure_contrast_serialization)
+OCIO_ADD_TEST(Config, exposure_contrast_serialization)
 {
     static const std::string SIMPLE_PROFILE =
         "ocio_profile_version: 2\n"
@@ -3996,12 +3996,12 @@ OIIO_ADD_TEST(Config, exposure_contrast_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), str);
+        OCIO_CHECK_EQUAL(ss.str(), str);
     }
 
     {
@@ -4025,14 +4025,14 @@ OIIO_ADD_TEST(Config, exposure_contrast_serialization)
         is.str(str);
 
         OCIO::ConstConfigRcPtr config;
-        OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-        OIIO_CHECK_NO_THROW(config->sanityCheck());
+        OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+        OCIO_CHECK_NO_THROW(config->sanityCheck());
 
         const std::string strExpected = SIMPLE_PROFILE + strEnd + strEndECExpected;
 
         std::stringstream ss;
         ss << *config.get();
-        OIIO_CHECK_EQUAL(ss.str(), strExpected);
+        OCIO_CHECK_EQUAL(ss.str(), strExpected);
 
     }
 
@@ -4047,13 +4047,13 @@ OIIO_ADD_TEST(Config, exposure_contrast_serialization)
         std::istringstream is;
         is.str(str);
 
-        OIIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is),
+        OCIO_CHECK_THROW_WHAT(OCIO::Config::CreateFromStream(is),
                               OCIO::Exception,
                               "Unknown exposure contrast style");
     }
 }
 
-OIIO_ADD_TEST(Config, matrix_serialization)
+OCIO_ADD_TEST(Config, matrix_serialization)
 {
     const std::string strEnd =
         "    from_reference: !<GroupTransform>\n"
@@ -4073,12 +4073,12 @@ OIIO_ADD_TEST(Config, matrix_serialization)
     is.str(str);
 
     OCIO::ConstConfigRcPtr config;
-    OIIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
-    OIIO_CHECK_NO_THROW(config->sanityCheck());
+    OCIO_CHECK_NO_THROW(config = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(config->sanityCheck());
 
     std::stringstream ss;
     ss << *config.get();
-    OIIO_CHECK_EQUAL(ss.str(), str);
+    OCIO_CHECK_EQUAL(ss.str(), str);
 }
 
 #endif // OCIO_UNIT_TEST

--- a/src/OpenColorIO/Context.cpp
+++ b/src/OpenColorIO/Context.cpp
@@ -473,7 +473,7 @@ namespace OCIO = OCIO_NAMESPACE;
 #include <algorithm>
 #include "PathUtils.h"
 #include "Platform.h"
-#include "unittest.h"
+#include "UnitTest.h"
 
 #ifdef OCIO_SOURCE_DIR
 
@@ -485,54 +485,54 @@ static const std::string ociodir(STR(OCIO_SOURCE_DIR));
 // Method to compare paths.
 std::string SanitizePath(const char* path)
 {
-    std::string s{ OCIO::pystring::os::path::normpath(path) };
+    std::string s{ pystring::os::path::normpath(path) };
     return s;
 }
 
-OIIO_ADD_TEST(Context, search_paths)
+OCIO_ADD_TEST(Context, search_paths)
 {
     OCIO::ContextRcPtr con = OCIO::Context::Create();
-    OIIO_CHECK_EQUAL(con->getNumSearchPaths(), 0);
+    OCIO_CHECK_EQUAL(con->getNumSearchPaths(), 0);
     const std::string empty{ "" };
-    OIIO_CHECK_EQUAL(std::string(con->getSearchPath()), empty);
-    OIIO_CHECK_EQUAL(std::string(con->getSearchPath(42)), empty);
+    OCIO_CHECK_EQUAL(std::string(con->getSearchPath()), empty);
+    OCIO_CHECK_EQUAL(std::string(con->getSearchPath(42)), empty);
 
     con->addSearchPath(empty.c_str());
-    OIIO_CHECK_EQUAL(con->getNumSearchPaths(), 0);
+    OCIO_CHECK_EQUAL(con->getNumSearchPaths(), 0);
 
     const std::string first{ "First" };
     con->addSearchPath(first.c_str());
-    OIIO_CHECK_EQUAL(con->getNumSearchPaths(), 1);
-    OIIO_CHECK_EQUAL(std::string(con->getSearchPath()), first);
-    OIIO_CHECK_EQUAL(std::string(con->getSearchPath(0)), first);
+    OCIO_CHECK_EQUAL(con->getNumSearchPaths(), 1);
+    OCIO_CHECK_EQUAL(std::string(con->getSearchPath()), first);
+    OCIO_CHECK_EQUAL(std::string(con->getSearchPath(0)), first);
     con->clearSearchPaths();
-    OIIO_CHECK_EQUAL(con->getNumSearchPaths(), 0);
-    OIIO_CHECK_EQUAL(std::string(con->getSearchPath()), empty);
+    OCIO_CHECK_EQUAL(con->getNumSearchPaths(), 0);
+    OCIO_CHECK_EQUAL(std::string(con->getSearchPath()), empty);
 
     const std::string second{ "Second" };
     const std::string firstSecond{ first + ":" + second };
     con->addSearchPath(first.c_str());
     con->addSearchPath(second.c_str());
-    OIIO_CHECK_EQUAL(con->getNumSearchPaths(), 2);
-    OIIO_CHECK_EQUAL(std::string(con->getSearchPath()), firstSecond);
-    OIIO_CHECK_EQUAL(std::string(con->getSearchPath(0)), first);
-    OIIO_CHECK_EQUAL(std::string(con->getSearchPath(1)), second);
+    OCIO_CHECK_EQUAL(con->getNumSearchPaths(), 2);
+    OCIO_CHECK_EQUAL(std::string(con->getSearchPath()), firstSecond);
+    OCIO_CHECK_EQUAL(std::string(con->getSearchPath(0)), first);
+    OCIO_CHECK_EQUAL(std::string(con->getSearchPath(1)), second);
     con->addSearchPath(empty.c_str());
-    OIIO_CHECK_EQUAL(con->getNumSearchPaths(), 2);
+    OCIO_CHECK_EQUAL(con->getNumSearchPaths(), 2);
 
     con->setSearchPath(first.c_str());
-    OIIO_CHECK_EQUAL(con->getNumSearchPaths(), 1);
-    OIIO_CHECK_EQUAL(std::string(con->getSearchPath()), first);
-    OIIO_CHECK_EQUAL(std::string(con->getSearchPath(0)), first);
+    OCIO_CHECK_EQUAL(con->getNumSearchPaths(), 1);
+    OCIO_CHECK_EQUAL(std::string(con->getSearchPath()), first);
+    OCIO_CHECK_EQUAL(std::string(con->getSearchPath(0)), first);
 
     con->setSearchPath(firstSecond.c_str());
-    OIIO_CHECK_EQUAL(con->getNumSearchPaths(), 2);
-    OIIO_CHECK_EQUAL(std::string(con->getSearchPath()), firstSecond);
-    OIIO_CHECK_EQUAL(std::string(con->getSearchPath(0)), first);
-    OIIO_CHECK_EQUAL(std::string(con->getSearchPath(1)), second);
+    OCIO_CHECK_EQUAL(con->getNumSearchPaths(), 2);
+    OCIO_CHECK_EQUAL(std::string(con->getSearchPath()), firstSecond);
+    OCIO_CHECK_EQUAL(std::string(con->getSearchPath(0)), first);
+    OCIO_CHECK_EQUAL(std::string(con->getSearchPath(1)), second);
 }
 
-OIIO_ADD_TEST(Context, abs_path)
+OCIO_ADD_TEST(Context, abs_path)
 {
     const std::string contextpath(ociodir + std::string("/src/OpenColorIO/Context.cpp"));
 
@@ -541,17 +541,17 @@ OIIO_ADD_TEST(Context, abs_path)
     con->setStringVar("non_abs", "src/OpenColorIO/Context.cpp");
     con->setStringVar("is_abs", contextpath.c_str());
     
-    OIIO_CHECK_NO_THROW(con->resolveFileLocation("${non_abs}"));
+    OCIO_CHECK_NO_THROW(con->resolveFileLocation("${non_abs}"));
 
-    OIIO_CHECK_ASSERT(strcmp(SanitizePath(con->resolveFileLocation("${non_abs}")).c_str(),
+    OCIO_CHECK_ASSERT(strcmp(SanitizePath(con->resolveFileLocation("${non_abs}")).c_str(),
                              SanitizePath(contextpath.c_str()).c_str()) == 0);
     
-    OIIO_CHECK_NO_THROW(con->resolveFileLocation("${is_abs}"));
-    OIIO_CHECK_ASSERT(strcmp(con->resolveFileLocation("${is_abs}"),
+    OCIO_CHECK_NO_THROW(con->resolveFileLocation("${is_abs}"));
+    OCIO_CHECK_ASSERT(strcmp(con->resolveFileLocation("${is_abs}"),
                              SanitizePath(contextpath.c_str()).c_str()) == 0);
 }
 
-OIIO_ADD_TEST(Context, var_search_path)
+OCIO_ADD_TEST(Context, var_search_path)
 {
     OCIO::ContextRcPtr context = OCIO::Context::Create();
     const std::string contextpath(ociodir + std::string("/src/OpenColorIO/Context.cpp"));
@@ -560,12 +560,12 @@ OIIO_ADD_TEST(Context, var_search_path)
     context->addSearchPath("${SOURCE_DIR}/src/OpenColorIO");
 
     std::string resolvedSource;
-    OIIO_CHECK_NO_THROW(resolvedSource = context->resolveFileLocation("Context.cpp"));
-    OIIO_CHECK_ASSERT(strcmp(SanitizePath(resolvedSource.c_str()).c_str(),
+    OCIO_CHECK_NO_THROW(resolvedSource = context->resolveFileLocation("Context.cpp"));
+    OCIO_CHECK_ASSERT(strcmp(SanitizePath(resolvedSource.c_str()).c_str(),
                              SanitizePath(contextpath.c_str()).c_str()) == 0);
 }
 
-OIIO_ADD_TEST(Context, use_searchpaths)
+OCIO_ADD_TEST(Context, use_searchpaths)
 {
     OCIO::ContextRcPtr context = OCIO::Context::Create();
 
@@ -576,17 +576,17 @@ OIIO_ADD_TEST(Context, use_searchpaths)
     context->addSearchPath(searchPath2.c_str());
 
     std::string resolvedSource;
-    OIIO_CHECK_NO_THROW(resolvedSource = context->resolveFileLocation("Context.cpp"));
+    OCIO_CHECK_NO_THROW(resolvedSource = context->resolveFileLocation("Context.cpp"));
     const std::string res1 = searchPath1 + "/Context.cpp";
-    OIIO_CHECK_ASSERT(strcmp(SanitizePath(resolvedSource.c_str()).c_str(),
+    OCIO_CHECK_ASSERT(strcmp(SanitizePath(resolvedSource.c_str()).c_str(),
                              SanitizePath(res1.c_str()).c_str()) == 0);
-    OIIO_CHECK_NO_THROW(resolvedSource = context->resolveFileLocation("GPUHelpers.h"));
+    OCIO_CHECK_NO_THROW(resolvedSource = context->resolveFileLocation("GPUHelpers.h"));
     const std::string res2 = searchPath2 + "/GPUHelpers.h";
-    OIIO_CHECK_ASSERT(strcmp(SanitizePath(resolvedSource.c_str()).c_str(),
+    OCIO_CHECK_ASSERT(strcmp(SanitizePath(resolvedSource.c_str()).c_str(),
                              SanitizePath(res2.c_str()).c_str()) == 0);
 }
 
-OIIO_ADD_TEST(Context, use_searchpaths_workingdir)
+OCIO_ADD_TEST(Context, use_searchpaths_workingdir)
 {
     OCIO::ContextRcPtr context = OCIO::Context::Create();
 
@@ -598,13 +598,13 @@ OIIO_ADD_TEST(Context, use_searchpaths_workingdir)
     context->addSearchPath(searchPath2.c_str());
 
     std::string resolvedSource;
-    OIIO_CHECK_NO_THROW(resolvedSource = context->resolveFileLocation("Context.cpp"));
+    OCIO_CHECK_NO_THROW(resolvedSource = context->resolveFileLocation("Context.cpp"));
     const std::string res1 = ociodir + "/" + searchPath1 + "/Context.cpp";
-    OIIO_CHECK_ASSERT(strcmp(SanitizePath(resolvedSource.c_str()).c_str(),
+    OCIO_CHECK_ASSERT(strcmp(SanitizePath(resolvedSource.c_str()).c_str(),
                              SanitizePath(res1.c_str()).c_str()) == 0);
-    OIIO_CHECK_NO_THROW(resolvedSource = context->resolveFileLocation("GPUHelpers.h"));
+    OCIO_CHECK_NO_THROW(resolvedSource = context->resolveFileLocation("GPUHelpers.h"));
     const std::string res2 = ociodir + "/" + searchPath2 + "/GPUHelpers.h";
-    OIIO_CHECK_ASSERT(strcmp(SanitizePath(resolvedSource.c_str()).c_str(),
+    OCIO_CHECK_ASSERT(strcmp(SanitizePath(resolvedSource.c_str()).c_str(),
                              SanitizePath(res2.c_str()).c_str()) == 0);
 }
 

--- a/src/OpenColorIO/Context.cpp
+++ b/src/OpenColorIO/Context.cpp
@@ -485,7 +485,7 @@ static const std::string ociodir(STR(OCIO_SOURCE_DIR));
 // Method to compare paths.
 std::string SanitizePath(const char* path)
 {
-    std::string s{ pystring::os::path::normpath(path) };
+    std::string s{ OCIO::pystring::os::path::normpath(path) };
     return s;
 }
 

--- a/src/OpenColorIO/Display.cpp
+++ b/src/OpenColorIO/Display.cpp
@@ -135,9 +135,9 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(Display, Basic)
+OCIO_ADD_TEST(Display, Basic)
 {
     
 }

--- a/src/OpenColorIO/DynamicProperty.cpp
+++ b/src/OpenColorIO/DynamicProperty.cpp
@@ -93,31 +93,31 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 
 #include <sstream>
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
-OIIO_ADD_TEST(DynamicPropertyImpl, basic)
+OCIO_ADD_TEST(DynamicPropertyImpl, basic)
 {
     OCIO::DynamicPropertyRcPtr dp =
         std::make_shared<OCIO::DynamicPropertyImpl>(1.0, false);
-    OIIO_REQUIRE_ASSERT(dp);
-    OIIO_CHECK_EQUAL(dp->getDoubleValue(), 1.0);
+    OCIO_REQUIRE_ASSERT(dp);
+    OCIO_CHECK_EQUAL(dp->getDoubleValue(), 1.0);
     dp->setValue(2.0);
-    OIIO_CHECK_EQUAL(dp->getDoubleValue(), 2.0);
+    OCIO_CHECK_EQUAL(dp->getDoubleValue(), 2.0);
 
     OCIO::DynamicPropertyImplRcPtr dpImpl =
         std::make_shared<OCIO::DynamicPropertyImpl>(1.0, false);
-    OIIO_REQUIRE_ASSERT(dpImpl);
-    OIIO_CHECK_ASSERT(!dpImpl->isDynamic());
-    OIIO_CHECK_EQUAL(dpImpl->getDoubleValue(), 1.0);
+    OCIO_REQUIRE_ASSERT(dpImpl);
+    OCIO_CHECK_ASSERT(!dpImpl->isDynamic());
+    OCIO_CHECK_EQUAL(dpImpl->getDoubleValue(), 1.0);
 
     dpImpl->makeDynamic();
-    OIIO_CHECK_ASSERT(dpImpl->isDynamic());
+    OCIO_CHECK_ASSERT(dpImpl->isDynamic());
     dpImpl->setValue(2.0);
-    OIIO_CHECK_EQUAL(dpImpl->getDoubleValue(), 2.0);
+    OCIO_CHECK_EQUAL(dpImpl->getDoubleValue(), 2.0);
 }
 
-OIIO_ADD_TEST(DynamicPropertyImpl, equal)
+OCIO_ADD_TEST(DynamicPropertyImpl, equal)
 {
     OCIO::DynamicPropertyImplRcPtr dpImpl0 =
         std::make_shared<OCIO::DynamicPropertyImpl>(1.0, false);
@@ -128,27 +128,27 @@ OIIO_ADD_TEST(DynamicPropertyImpl, equal)
     OCIO::DynamicPropertyRcPtr dp1 = dpImpl1;
 
     // Both not dynamic, same value.
-    OIIO_CHECK_ASSERT(*dp0 == *dp1);
+    OCIO_CHECK_ASSERT(*dp0 == *dp1);
     
     // Both not dynamic, diff values.
     dp0->setValue(2.0);
-    OIIO_CHECK_ASSERT(!(*dp0 == *dp1));
+    OCIO_CHECK_ASSERT(!(*dp0 == *dp1));
     
     // Same value.
     dp1->setValue(2.0);
-    OIIO_CHECK_ASSERT(*dp0 == *dp1);
+    OCIO_CHECK_ASSERT(*dp0 == *dp1);
 
     // One dynamic, not the other, same value.
     dpImpl0->makeDynamic();
-    OIIO_CHECK_ASSERT(!(*dp0 == *dp1));
+    OCIO_CHECK_ASSERT(!(*dp0 == *dp1));
     
     // Both dynamic, same value.
     dpImpl1->makeDynamic();
-    OIIO_CHECK_ASSERT(*dp0 == *dp1);
+    OCIO_CHECK_ASSERT(*dp0 == *dp1);
     
     // Both dynamic, diffent values.
     dp1->setValue(3.0);
-    OIIO_CHECK_ASSERT(*dp0 == *dp1);
+    OCIO_CHECK_ASSERT(*dp0 == *dp1);
 }
 
 namespace
@@ -176,23 +176,23 @@ OCIO::ConstProcessorRcPtr LoadTransformFile(const std::string & fileName)
 
 // Test several aspects of dynamic properties, especially the ability to set
 // values via the processor.
-OIIO_ADD_TEST(DynamicProperty, get_dynamic_via_processor)
+OCIO_ADD_TEST(DynamicProperty, get_dynamic_via_processor)
 {
     const std::string ctfFile("exposure_contrast_video_dp.ctf");
     OCIO::ConstProcessorRcPtr processor;
-    OIIO_CHECK_NO_THROW(processor = LoadTransformFile(ctfFile));
+    OCIO_CHECK_NO_THROW(processor = LoadTransformFile(ctfFile));
 
     float pixel[3] = { 0.5f, 0.4f, 0.2f };
     processor->applyRGB(pixel);
 
     float error = 1e-5f;
-    OIIO_CHECK_CLOSE(pixel[0], 0.57495f, error);
-    OIIO_CHECK_CLOSE(pixel[1], 0.43988f, error);
-    OIIO_CHECK_CLOSE(pixel[2], 0.19147f, error);
+    OCIO_CHECK_CLOSE(pixel[0], 0.57495f, error);
+    OCIO_CHECK_CLOSE(pixel[1], 0.43988f, error);
+    OCIO_CHECK_CLOSE(pixel[2], 0.19147f, error);
 
     OCIO::DynamicPropertyType dpt = OCIO::DYNAMIC_PROPERTY_EXPOSURE;
     OCIO::DynamicPropertyRcPtr dp;
-    OIIO_CHECK_NO_THROW(dp = processor->getDynamicProperty(dpt));
+    OCIO_CHECK_NO_THROW(dp = processor->getDynamicProperty(dpt));
     const double fileValue = dp->getDoubleValue();
     dp->setValue(0.4);
 
@@ -202,9 +202,9 @@ OIIO_ADD_TEST(DynamicProperty, get_dynamic_via_processor)
     processor->applyRGB(pixel);
 
     // Adjust error for SSE approximation.
-    OIIO_CHECK_CLOSE(pixel[0], 0.62966f, error*2.0f);
-    OIIO_CHECK_CLOSE(pixel[1], 0.48175f, error);
-    OIIO_CHECK_CLOSE(pixel[2], 0.20969f, error);
+    OCIO_CHECK_CLOSE(pixel[0], 0.62966f, error*2.0f);
+    OCIO_CHECK_CLOSE(pixel[1], 0.48175f, error);
+    OCIO_CHECK_CLOSE(pixel[2], 0.20969f, error);
 
     // Restore file value.
     dp->setValue(fileValue);
@@ -214,12 +214,12 @@ OIIO_ADD_TEST(DynamicProperty, get_dynamic_via_processor)
     pixel[2] = 0.2f;
     processor->applyRGB(pixel);
 
-    OIIO_CHECK_CLOSE(pixel[0], 0.57495f, error);
-    OIIO_CHECK_CLOSE(pixel[1], 0.43988f, error);
-    OIIO_CHECK_CLOSE(pixel[2], 0.19147f, error);
+    OCIO_CHECK_CLOSE(pixel[0], 0.57495f, error);
+    OCIO_CHECK_CLOSE(pixel[1], 0.43988f, error);
+    OCIO_CHECK_CLOSE(pixel[2], 0.19147f, error);
 
     // Note: The CTF does not define gamma as being dynamic.
-    OIIO_CHECK_THROW_WHAT(processor->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_GAMMA),
+    OCIO_CHECK_THROW_WHAT(processor->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_GAMMA),
                           OCIO::Exception,
                           "Cannot find dynamic property");
 }

--- a/src/OpenColorIO/Exception.cpp
+++ b/src/OpenColorIO/Exception.cpp
@@ -69,12 +69,12 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 #include <string.h>
 
 
-OIIO_ADD_TEST(Exception, Basic)
+OCIO_ADD_TEST(Exception, Basic)
 {
     static const char* dummyErrorStr = "Dummy error";
 
@@ -86,11 +86,11 @@ OIIO_ADD_TEST(Exception, Basic)
     }
     catch(const OCIO::Exception& ex)
     {
-        OIIO_CHECK_EQUAL(strcmp(ex.what(), dummyErrorStr), 0);
+        OCIO_CHECK_EQUAL(strcmp(ex.what(), dummyErrorStr), 0);
     }
     catch(...)
     {
-        OIIO_CHECK_ASSERT(!"Wrong exception type");
+        OCIO_CHECK_ASSERT(!"Wrong exception type");
     }
 
     // Test 1
@@ -101,11 +101,11 @@ OIIO_ADD_TEST(Exception, Basic)
     }
     catch(const std::exception& ex)
     {
-        OIIO_CHECK_EQUAL(strcmp(ex.what(), dummyErrorStr), 0);
+        OCIO_CHECK_EQUAL(strcmp(ex.what(), dummyErrorStr), 0);
     }
     catch(...)
     {
-        OIIO_CHECK_ASSERT(!"Wrong exception type");
+        OCIO_CHECK_ASSERT(!"Wrong exception type");
     }
 
     // Test 2
@@ -117,16 +117,16 @@ OIIO_ADD_TEST(Exception, Basic)
     }
     catch(const std::exception& ex)
     {
-        OIIO_CHECK_EQUAL(strcmp(ex.what(), dummyErrorStr), 0);
+        OCIO_CHECK_EQUAL(strcmp(ex.what(), dummyErrorStr), 0);
     }
     catch(...)
     {
-        OIIO_CHECK_ASSERT(!"Wrong exception type");
+        OCIO_CHECK_ASSERT(!"Wrong exception type");
     }
 }
 
 
-OIIO_ADD_TEST(Exception, MissingFile)
+OCIO_ADD_TEST(Exception, MissingFile)
 {
     static const char* dummyErrorStr = "Dummy error";
 
@@ -136,11 +136,11 @@ OIIO_ADD_TEST(Exception, MissingFile)
     }
     catch(const std::exception& ex)
     {
-        OIIO_CHECK_EQUAL(strcmp(ex.what(), dummyErrorStr), 0);
+        OCIO_CHECK_EQUAL(strcmp(ex.what(), dummyErrorStr), 0);
     }
     catch(...)
     {
-        OIIO_CHECK_ASSERT(!"Wrong exception type");
+        OCIO_CHECK_ASSERT(!"Wrong exception type");
     }
 }
 

--- a/src/OpenColorIO/GpuShader.cpp
+++ b/src/OpenColorIO/GpuShader.cpp
@@ -703,37 +703,37 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 
-OIIO_ADD_TEST(GpuShader, generic_shader)
+OCIO_ADD_TEST(GpuShader, generic_shader)
 {
     OCIO::GpuShaderDescRcPtr shaderDesc = OCIO::GenericGpuShaderDesc::Create();
 
     {
-        OIIO_CHECK_NE(shaderDesc->getLanguage(), OCIO::GPU_LANGUAGE_GLSL_1_3);
-        OIIO_CHECK_NO_THROW(shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_3));
-        OIIO_CHECK_EQUAL(shaderDesc->getLanguage(), OCIO::GPU_LANGUAGE_GLSL_1_3);
+        OCIO_CHECK_NE(shaderDesc->getLanguage(), OCIO::GPU_LANGUAGE_GLSL_1_3);
+        OCIO_CHECK_NO_THROW(shaderDesc->setLanguage(OCIO::GPU_LANGUAGE_GLSL_1_3));
+        OCIO_CHECK_EQUAL(shaderDesc->getLanguage(), OCIO::GPU_LANGUAGE_GLSL_1_3);
 
-        OIIO_CHECK_NE(std::string(shaderDesc->getFunctionName()), "1sd234_");
-        OIIO_CHECK_NO_THROW(shaderDesc->setFunctionName("1sd234_"));
-        OIIO_CHECK_EQUAL(std::string(shaderDesc->getFunctionName()), "1sd234_");
+        OCIO_CHECK_NE(std::string(shaderDesc->getFunctionName()), "1sd234_");
+        OCIO_CHECK_NO_THROW(shaderDesc->setFunctionName("1sd234_"));
+        OCIO_CHECK_EQUAL(std::string(shaderDesc->getFunctionName()), "1sd234_");
 
-        OIIO_CHECK_NE(std::string(shaderDesc->getPixelName()), "pxl_1sd234_");
-        OIIO_CHECK_NO_THROW(shaderDesc->setPixelName("pxl_1sd234_"));
-        OIIO_CHECK_EQUAL(std::string(shaderDesc->getPixelName()), "pxl_1sd234_");
+        OCIO_CHECK_NE(std::string(shaderDesc->getPixelName()), "pxl_1sd234_");
+        OCIO_CHECK_NO_THROW(shaderDesc->setPixelName("pxl_1sd234_"));
+        OCIO_CHECK_EQUAL(std::string(shaderDesc->getPixelName()), "pxl_1sd234_");
 
-        OIIO_CHECK_NE(std::string(shaderDesc->getResourcePrefix()), "res_1sd234_");
-        OIIO_CHECK_NO_THROW(shaderDesc->setResourcePrefix("res_1sd234_"));
-        OIIO_CHECK_EQUAL(std::string(shaderDesc->getResourcePrefix()), "res_1sd234_");
+        OCIO_CHECK_NE(std::string(shaderDesc->getResourcePrefix()), "res_1sd234_");
+        OCIO_CHECK_NO_THROW(shaderDesc->setResourcePrefix("res_1sd234_"));
+        OCIO_CHECK_EQUAL(std::string(shaderDesc->getResourcePrefix()), "res_1sd234_");
 
-        OIIO_CHECK_NO_THROW(shaderDesc->finalize());
+        OCIO_CHECK_NO_THROW(shaderDesc->finalize());
         const std::string id(shaderDesc->getCacheID());
-        OIIO_CHECK_EQUAL(id, std::string("glsl_1.3 1sd234_ res_1sd234_ pxl_1sd234_ "
+        OCIO_CHECK_EQUAL(id, std::string("glsl_1.3 1sd234_ res_1sd234_ pxl_1sd234_ "
                                          "$664fefaf8040c8fae4a3b56f2239872d"));
-        OIIO_CHECK_NO_THROW(shaderDesc->setResourcePrefix("res_1"));
-        OIIO_CHECK_NO_THROW(shaderDesc->finalize());
-        OIIO_CHECK_NE(std::string(shaderDesc->getCacheID()), id);
+        OCIO_CHECK_NO_THROW(shaderDesc->setResourcePrefix("res_1"));
+        OCIO_CHECK_NO_THROW(shaderDesc->finalize());
+        OCIO_CHECK_NE(std::string(shaderDesc->getCacheID()), id);
     }
 
     {
@@ -745,13 +745,13 @@ OIIO_ADD_TEST(GpuShader, generic_shader)
             = { 0.1f, 0.2f, 0.3f,  0.4f, 0.5f, 0.6f,  0.7f, 0.8f, 0.9f,
                 0.1f, 0.2f, 0.3f,  0.4f, 0.5f, 0.6f,  0.7f, 0.8f, 0.9f };
 
-        OIIO_CHECK_EQUAL(shaderDesc->getNumTextures(), 0U);
-        OIIO_CHECK_NO_THROW(shaderDesc->addTexture("lut1", "1234", width, height, 
+        OCIO_CHECK_EQUAL(shaderDesc->getNumTextures(), 0U);
+        OCIO_CHECK_NO_THROW(shaderDesc->addTexture("lut1", "1234", width, height, 
                                                    OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL, 
                                                    OCIO::INTERP_TETRAHEDRAL,
                                                    &values[0]));
 
-        OIIO_CHECK_EQUAL(shaderDesc->getNumTextures(), 1U);
+        OCIO_CHECK_EQUAL(shaderDesc->getNumTextures(), 1U);
 
         const char * name = 0x0;
         const char * id = 0x0;
@@ -760,43 +760,43 @@ OIIO_ADD_TEST(GpuShader, generic_shader)
         OCIO::GpuShaderDesc::TextureType t = OCIO::GpuShaderDesc::TEXTURE_RED_CHANNEL;
         OCIO::Interpolation i = OCIO::INTERP_UNKNOWN;
 
-        OIIO_CHECK_NO_THROW(shaderDesc->getTexture(0, name, id, w, h, t, i));
+        OCIO_CHECK_NO_THROW(shaderDesc->getTexture(0, name, id, w, h, t, i));
 
-        OIIO_CHECK_EQUAL(std::string(name), "lut1");
-        OIIO_CHECK_EQUAL(std::string(id), "1234");
-        OIIO_CHECK_EQUAL(width, w);
-        OIIO_CHECK_EQUAL(height, h);
-        OIIO_CHECK_EQUAL(OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL, t);
-        OIIO_CHECK_EQUAL(OCIO::INTERP_TETRAHEDRAL, i);
+        OCIO_CHECK_EQUAL(std::string(name), "lut1");
+        OCIO_CHECK_EQUAL(std::string(id), "1234");
+        OCIO_CHECK_EQUAL(width, w);
+        OCIO_CHECK_EQUAL(height, h);
+        OCIO_CHECK_EQUAL(OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL, t);
+        OCIO_CHECK_EQUAL(OCIO::INTERP_TETRAHEDRAL, i);
 
-        OIIO_CHECK_THROW_WHAT(shaderDesc->getTexture(1, name, id, w, h, t, i),
+        OCIO_CHECK_THROW_WHAT(shaderDesc->getTexture(1, name, id, w, h, t, i),
                               OCIO::Exception,
                               "1D LUT access error");
 
         const float * vals = 0x0;
-        OIIO_CHECK_NO_THROW(shaderDesc->getTextureValues(0, vals));
-        OIIO_CHECK_NE(vals, 0x0);
+        OCIO_CHECK_NO_THROW(shaderDesc->getTextureValues(0, vals));
+        OCIO_CHECK_NE(vals, 0x0);
         for(unsigned idx=0; idx<size; ++idx)
         {
-            OIIO_CHECK_EQUAL(values[idx], vals[idx]);
+            OCIO_CHECK_EQUAL(values[idx], vals[idx]);
         }
 
-        OIIO_CHECK_THROW_WHAT(shaderDesc->getTextureValues(1, vals),
+        OCIO_CHECK_THROW_WHAT(shaderDesc->getTextureValues(1, vals),
                               OCIO::Exception,
                               "1D LUT access error");
 
         // Support several 1D LUTs
 
-        OIIO_CHECK_NO_THROW(shaderDesc->addTexture("lut2", "1234", width, height, 
+        OCIO_CHECK_NO_THROW(shaderDesc->addTexture("lut2", "1234", width, height, 
                                                    OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL, 
                                                    OCIO::INTERP_TETRAHEDRAL,
                                                    &values[0]));
 
-        OIIO_CHECK_EQUAL(shaderDesc->getNumTextures(), 2U);
+        OCIO_CHECK_EQUAL(shaderDesc->getNumTextures(), 2U);
 
-        OIIO_CHECK_NO_THROW(shaderDesc->getTextureValues(0, vals));
-        OIIO_CHECK_NO_THROW(shaderDesc->getTextureValues(1, vals));
-        OIIO_CHECK_THROW_WHAT(shaderDesc->getTextureValues(2, vals),
+        OCIO_CHECK_NO_THROW(shaderDesc->getTextureValues(0, vals));
+        OCIO_CHECK_NO_THROW(shaderDesc->getTextureValues(1, vals));
+        OCIO_CHECK_THROW_WHAT(shaderDesc->getTextureValues(2, vals),
                               OCIO::Exception,
                               "1D LUT access error");
     }
@@ -808,65 +808,65 @@ OIIO_ADD_TEST(GpuShader, generic_shader)
             = { 0.1f, 0.2f, 0.3f,  0.4f, 0.5f, 0.6f,  0.7f, 0.8f, 0.9f,  0.7f, 0.8f, 0.9f,
                 0.1f, 0.2f, 0.3f,  0.4f, 0.5f, 0.6f,  0.7f, 0.8f, 0.9f,  0.7f, 0.8f, 0.9f, };
 
-        OIIO_CHECK_EQUAL(shaderDesc->getNum3DTextures(), 0U);
-        OIIO_CHECK_NO_THROW(shaderDesc->add3DTexture("lut1", "1234", edgelen, 
+        OCIO_CHECK_EQUAL(shaderDesc->getNum3DTextures(), 0U);
+        OCIO_CHECK_NO_THROW(shaderDesc->add3DTexture("lut1", "1234", edgelen, 
                                                      OCIO::INTERP_TETRAHEDRAL,
                                                      &values[0]));
 
-        OIIO_CHECK_EQUAL(shaderDesc->getNum3DTextures(), 1U);
+        OCIO_CHECK_EQUAL(shaderDesc->getNum3DTextures(), 1U);
 
         const char * name = 0x0;
         const char * id = 0x0;
         unsigned e = 0;
         OCIO::Interpolation i = OCIO::INTERP_UNKNOWN;
 
-        OIIO_CHECK_NO_THROW(shaderDesc->get3DTexture(0, name, id, e, i));
+        OCIO_CHECK_NO_THROW(shaderDesc->get3DTexture(0, name, id, e, i));
 
-        OIIO_CHECK_EQUAL(std::string(name), "lut1");
-        OIIO_CHECK_EQUAL(std::string(id), "1234");
-        OIIO_CHECK_EQUAL(edgelen, e);
-        OIIO_CHECK_EQUAL(OCIO::INTERP_TETRAHEDRAL, i);
+        OCIO_CHECK_EQUAL(std::string(name), "lut1");
+        OCIO_CHECK_EQUAL(std::string(id), "1234");
+        OCIO_CHECK_EQUAL(edgelen, e);
+        OCIO_CHECK_EQUAL(OCIO::INTERP_TETRAHEDRAL, i);
 
-        OIIO_CHECK_THROW_WHAT(shaderDesc->get3DTexture(1, name, id, e, i),
+        OCIO_CHECK_THROW_WHAT(shaderDesc->get3DTexture(1, name, id, e, i),
                               OCIO::Exception,
                               "3D LUT access error");
 
         const float * vals = 0x0;
-        OIIO_CHECK_NO_THROW(shaderDesc->get3DTextureValues(0, vals));
-        OIIO_CHECK_NE(vals, 0x0);
+        OCIO_CHECK_NO_THROW(shaderDesc->get3DTextureValues(0, vals));
+        OCIO_CHECK_NE(vals, 0x0);
         for(unsigned idx=0; idx<size; ++idx)
         {
-            OIIO_CHECK_EQUAL(values[idx], vals[idx]);
+            OCIO_CHECK_EQUAL(values[idx], vals[idx]);
         }
 
-        OIIO_CHECK_THROW_WHAT(shaderDesc->get3DTextureValues(1, vals),
+        OCIO_CHECK_THROW_WHAT(shaderDesc->get3DTextureValues(1, vals),
                               OCIO::Exception,
                               "3D LUT access error");
 
         // Supports several 3D LUTs
 
-        OIIO_CHECK_NO_THROW(shaderDesc->add3DTexture("lut1", "1234", edgelen, 
+        OCIO_CHECK_NO_THROW(shaderDesc->add3DTexture("lut1", "1234", edgelen, 
                                                      OCIO::INTERP_TETRAHEDRAL,
                                                      &values[0]));
 
-        OIIO_CHECK_EQUAL(shaderDesc->getNum3DTextures(), 2U);
+        OCIO_CHECK_EQUAL(shaderDesc->getNum3DTextures(), 2U);
 
         // Check the 3D LUT limit
 
-        OIIO_CHECK_THROW(shaderDesc->add3DTexture("lut1", "1234", 130,
+        OCIO_CHECK_THROW(shaderDesc->add3DTexture("lut1", "1234", 130,
                                                   OCIO::INTERP_TETRAHEDRAL,
                                                   &values[0]),
                          OCIO::Exception);
     }
 
     {
-        OIIO_CHECK_NO_THROW(shaderDesc->addToDeclareShaderCode("vec2 coords;\n"));
-        OIIO_CHECK_NO_THROW(shaderDesc->addToHelperShaderCode("vec2 helpers() {}\n\n"));
-        OIIO_CHECK_NO_THROW(shaderDesc->addToFunctionHeaderShaderCode("void func() {\n"));
-        OIIO_CHECK_NO_THROW(shaderDesc->addToFunctionShaderCode("  int i;\n"));
-        OIIO_CHECK_NO_THROW(shaderDesc->addToFunctionFooterShaderCode("}\n"));
+        OCIO_CHECK_NO_THROW(shaderDesc->addToDeclareShaderCode("vec2 coords;\n"));
+        OCIO_CHECK_NO_THROW(shaderDesc->addToHelperShaderCode("vec2 helpers() {}\n\n"));
+        OCIO_CHECK_NO_THROW(shaderDesc->addToFunctionHeaderShaderCode("void func() {\n"));
+        OCIO_CHECK_NO_THROW(shaderDesc->addToFunctionShaderCode("  int i;\n"));
+        OCIO_CHECK_NO_THROW(shaderDesc->addToFunctionFooterShaderCode("}\n"));
 
-        OIIO_CHECK_NO_THROW(shaderDesc->finalize());
+        OCIO_CHECK_NO_THROW(shaderDesc->finalize());
 
         std::string fragText;
         fragText += "\n";
@@ -881,11 +881,11 @@ OIIO_ADD_TEST(GpuShader, generic_shader)
         fragText += "  int i;\n";
         fragText += "}\n";
 
-        OIIO_CHECK_EQUAL(fragText, shaderDesc->getShaderText());
+        OCIO_CHECK_EQUAL(fragText, shaderDesc->getShaderText());
     }
 }
 
-OIIO_ADD_TEST(GpuShader, legacy_shader)
+OCIO_ADD_TEST(GpuShader, legacy_shader)
 {
     const unsigned edgelen = 2;
 
@@ -897,8 +897,8 @@ OIIO_ADD_TEST(GpuShader, legacy_shader)
         const unsigned size = width*height*3;
         float values[size];
 
-        OIIO_CHECK_EQUAL(shaderDesc->getNumTextures(), 0U);
-        OIIO_CHECK_THROW_WHAT(shaderDesc->addTexture("lut1", "1234", width, height, 
+        OCIO_CHECK_EQUAL(shaderDesc->getNumTextures(), 0U);
+        OCIO_CHECK_THROW_WHAT(shaderDesc->addTexture("lut1", "1234", width, height, 
                                                      OCIO::GpuShaderDesc::TEXTURE_RGB_CHANNEL, 
                                                      OCIO::INTERP_TETRAHEDRAL,
                                                      &values[0]), 
@@ -912,7 +912,7 @@ OIIO_ADD_TEST(GpuShader, legacy_shader)
         OCIO::GpuShaderDesc::TextureType t = OCIO::GpuShaderDesc::TEXTURE_RED_CHANNEL;
         OCIO::Interpolation i = OCIO::INTERP_UNKNOWN;
 
-        OIIO_CHECK_THROW_WHAT(shaderDesc->getTexture(0, name, id, w, h, t, i),
+        OCIO_CHECK_THROW_WHAT(shaderDesc->getTexture(0, name, id, w, h, t, i),
                               OCIO::Exception,
                               "1D LUTs are not supported");
     }
@@ -923,44 +923,44 @@ OIIO_ADD_TEST(GpuShader, legacy_shader)
             = { 0.1f, 0.2f, 0.3f,  0.4f, 0.5f, 0.6f,  0.7f, 0.8f, 0.9f,  0.7f, 0.8f, 0.9f,
                 0.1f, 0.2f, 0.3f,  0.4f, 0.5f, 0.6f,  0.7f, 0.8f, 0.9f,  0.7f, 0.8f, 0.9f, };
 
-        OIIO_CHECK_EQUAL(shaderDesc->getNum3DTextures(), 0U);
-        OIIO_CHECK_NO_THROW(shaderDesc->add3DTexture("lut1", "1234", edgelen, 
+        OCIO_CHECK_EQUAL(shaderDesc->getNum3DTextures(), 0U);
+        OCIO_CHECK_NO_THROW(shaderDesc->add3DTexture("lut1", "1234", edgelen, 
                                                      OCIO::INTERP_TETRAHEDRAL,
                                                      &values[0]));
 
-        OIIO_CHECK_EQUAL(shaderDesc->getNum3DTextures(), 1U);
+        OCIO_CHECK_EQUAL(shaderDesc->getNum3DTextures(), 1U);
 
         const char * name = 0x0;
         const char * id = 0x0;
         unsigned e = 0;
         OCIO::Interpolation i = OCIO::INTERP_UNKNOWN;
 
-        OIIO_CHECK_NO_THROW(shaderDesc->get3DTexture(0, name, id, e, i));
+        OCIO_CHECK_NO_THROW(shaderDesc->get3DTexture(0, name, id, e, i));
 
-        OIIO_CHECK_EQUAL(std::string(name), "lut1");
-        OIIO_CHECK_EQUAL(std::string(id), "1234");
-        OIIO_CHECK_EQUAL(edgelen, e);
-        OIIO_CHECK_EQUAL(OCIO::INTERP_TETRAHEDRAL, i);
+        OCIO_CHECK_EQUAL(std::string(name), "lut1");
+        OCIO_CHECK_EQUAL(std::string(id), "1234");
+        OCIO_CHECK_EQUAL(edgelen, e);
+        OCIO_CHECK_EQUAL(OCIO::INTERP_TETRAHEDRAL, i);
 
-        OIIO_CHECK_THROW_WHAT(shaderDesc->get3DTexture(1, name, id, e, i),
+        OCIO_CHECK_THROW_WHAT(shaderDesc->get3DTexture(1, name, id, e, i),
                               OCIO::Exception,
                               "3D LUT access error");
 
         const float * vals = 0x0;
-        OIIO_CHECK_NO_THROW(shaderDesc->get3DTextureValues(0, vals));
-        OIIO_CHECK_NE(vals, 0x0);
+        OCIO_CHECK_NO_THROW(shaderDesc->get3DTextureValues(0, vals));
+        OCIO_CHECK_NE(vals, 0x0);
         for(unsigned idx=0; idx<size; ++idx)
         {
-            OIIO_CHECK_EQUAL(values[idx], vals[idx]);
+            OCIO_CHECK_EQUAL(values[idx], vals[idx]);
         }
 
-        OIIO_CHECK_THROW_WHAT(shaderDesc->get3DTextureValues(1, vals),
+        OCIO_CHECK_THROW_WHAT(shaderDesc->get3DTextureValues(1, vals),
                               OCIO::Exception,
                               "3D LUT access error");
 
         // Only one 3D LUT
 
-        OIIO_CHECK_THROW_WHAT(shaderDesc->add3DTexture("lut1", "1234", edgelen, 
+        OCIO_CHECK_THROW_WHAT(shaderDesc->add3DTexture("lut1", "1234", edgelen, 
                                                        OCIO::INTERP_TETRAHEDRAL,
                                                        &values[0]),
                               OCIO::Exception,

--- a/src/OpenColorIO/GpuShaderUtils.cpp
+++ b/src/OpenColorIO/GpuShaderUtils.cpp
@@ -723,15 +723,15 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(GpuShaderUtils, FloatToString)
+OCIO_ADD_TEST(GpuShaderUtils, FloatToString)
 {
-    OIIO_CHECK_EQUAL(OCIO::getFloatString(1.0f, OCIO::GPU_LANGUAGE_GLSL_1_3), "1.");
-    OIIO_CHECK_EQUAL(OCIO::getFloatString(-11.0f, OCIO::GPU_LANGUAGE_GLSL_1_3), "-11.");
-    OIIO_CHECK_EQUAL(OCIO::getFloatString(-1.0f, OCIO::GPU_LANGUAGE_GLSL_1_3), "-1.");
-    OIIO_CHECK_EQUAL(OCIO::getFloatString((float)-1, OCIO::GPU_LANGUAGE_GLSL_1_3), "-1.");
-    OIIO_CHECK_EQUAL(OCIO::getFloatString((float)1, OCIO::GPU_LANGUAGE_GLSL_1_3), "1.");
+    OCIO_CHECK_EQUAL(OCIO::getFloatString(1.0f, OCIO::GPU_LANGUAGE_GLSL_1_3), "1.");
+    OCIO_CHECK_EQUAL(OCIO::getFloatString(-11.0f, OCIO::GPU_LANGUAGE_GLSL_1_3), "-11.");
+    OCIO_CHECK_EQUAL(OCIO::getFloatString(-1.0f, OCIO::GPU_LANGUAGE_GLSL_1_3), "-1.");
+    OCIO_CHECK_EQUAL(OCIO::getFloatString((float)-1, OCIO::GPU_LANGUAGE_GLSL_1_3), "-1.");
+    OCIO_CHECK_EQUAL(OCIO::getFloatString((float)1, OCIO::GPU_LANGUAGE_GLSL_1_3), "1.");
 }
 
 #endif // OCIO_UNIT_TEST

--- a/src/OpenColorIO/LookParse.cpp
+++ b/src/OpenColorIO/LookParse.cpp
@@ -164,122 +164,122 @@ OCIO_NAMESPACE_EXIT
 
 OCIO_NAMESPACE_USING
 
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(LookParse, Parse)
+OCIO_ADD_TEST(LookParse, Parse)
 {
     LookParseResult r;
     
     {
     const LookParseResult::Options & options = r.parse("");
-    OIIO_CHECK_EQUAL(options.size(), 0);
-    OIIO_CHECK_EQUAL(options.empty(), true);
+    OCIO_CHECK_EQUAL(options.size(), 0);
+    OCIO_CHECK_EQUAL(options.empty(), true);
     }
     
     {
     const LookParseResult::Options & options = r.parse("  ");
-    OIIO_CHECK_EQUAL(options.size(), 0);
-    OIIO_CHECK_EQUAL(options.empty(), true);
+    OCIO_CHECK_EQUAL(options.size(), 0);
+    OCIO_CHECK_EQUAL(options.empty(), true);
     }
     
     {
     const LookParseResult::Options & options = r.parse("cc");
-    OIIO_CHECK_EQUAL(options.size(), 1);
-    OIIO_CHECK_EQUAL(options[0][0].name, "cc");
-    OIIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(options.empty(), false);
+    OCIO_CHECK_EQUAL(options.size(), 1);
+    OCIO_CHECK_EQUAL(options[0][0].name, "cc");
+    OCIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(options.empty(), false);
     }
     
     {
     const LookParseResult::Options & options = r.parse("+cc");
-    OIIO_CHECK_EQUAL(options.size(), 1);
-    OIIO_CHECK_EQUAL(options[0][0].name, "cc");
-    OIIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(options.empty(), false);
+    OCIO_CHECK_EQUAL(options.size(), 1);
+    OCIO_CHECK_EQUAL(options[0][0].name, "cc");
+    OCIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(options.empty(), false);
     }
     
     {
     const LookParseResult::Options & options = r.parse("  +cc");
-    OIIO_CHECK_EQUAL(options.size(), 1);
-    OIIO_CHECK_EQUAL(options[0][0].name, "cc");
-    OIIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(options.empty(), false);
+    OCIO_CHECK_EQUAL(options.size(), 1);
+    OCIO_CHECK_EQUAL(options[0][0].name, "cc");
+    OCIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(options.empty(), false);
     }
     
     {
     const LookParseResult::Options & options = r.parse("  +cc   ");
-    OIIO_CHECK_EQUAL(options.size(), 1);
-    OIIO_CHECK_EQUAL(options[0][0].name, "cc");
-    OIIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(options.empty(), false);
+    OCIO_CHECK_EQUAL(options.size(), 1);
+    OCIO_CHECK_EQUAL(options[0][0].name, "cc");
+    OCIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(options.empty(), false);
     }
     
     {
     const LookParseResult::Options & options = r.parse("+cc,-di");
-    OIIO_CHECK_EQUAL(options.size(), 1);
-    OIIO_CHECK_EQUAL(options[0].size(), 2);
-    OIIO_CHECK_EQUAL(options[0][0].name, "cc");
-    OIIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(options[0][1].name, "di");
-    OIIO_CHECK_EQUAL(options[0][1].dir, TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(options.empty(), false);
+    OCIO_CHECK_EQUAL(options.size(), 1);
+    OCIO_CHECK_EQUAL(options[0].size(), 2);
+    OCIO_CHECK_EQUAL(options[0][0].name, "cc");
+    OCIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(options[0][1].name, "di");
+    OCIO_CHECK_EQUAL(options[0][1].dir, TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(options.empty(), false);
     }
     
     {
     const LookParseResult::Options & options = r.parse("  +cc ,  -di");
-    OIIO_CHECK_EQUAL(options.size(), 1);
-    OIIO_CHECK_EQUAL(options[0].size(), 2);
-    OIIO_CHECK_EQUAL(options[0][0].name, "cc");
-    OIIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(options[0][1].name, "di");
-    OIIO_CHECK_EQUAL(options[0][1].dir, TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(options.empty(), false);
+    OCIO_CHECK_EQUAL(options.size(), 1);
+    OCIO_CHECK_EQUAL(options[0].size(), 2);
+    OCIO_CHECK_EQUAL(options[0][0].name, "cc");
+    OCIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(options[0][1].name, "di");
+    OCIO_CHECK_EQUAL(options[0][1].dir, TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(options.empty(), false);
     }
     
     {
     const LookParseResult::Options & options = r.parse("  +cc :  -di");
-    OIIO_CHECK_EQUAL(options.size(), 1);
-    OIIO_CHECK_EQUAL(options[0].size(), 2);
-    OIIO_CHECK_EQUAL(options[0][0].name, "cc");
-    OIIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(options[0][1].name, "di");
-    OIIO_CHECK_EQUAL(options[0][1].dir, TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(options.empty(), false);
+    OCIO_CHECK_EQUAL(options.size(), 1);
+    OCIO_CHECK_EQUAL(options[0].size(), 2);
+    OCIO_CHECK_EQUAL(options[0][0].name, "cc");
+    OCIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(options[0][1].name, "di");
+    OCIO_CHECK_EQUAL(options[0][1].dir, TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(options.empty(), false);
     }
     
     {
     const LookParseResult::Options & options = r.parse("+cc, -di |-cc");
-    OIIO_CHECK_EQUAL(options.size(), 2);
-    OIIO_CHECK_EQUAL(options[0].size(), 2);
-    OIIO_CHECK_EQUAL(options[0][0].name, "cc");
-    OIIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(options[0][1].name, "di");
-    OIIO_CHECK_EQUAL(options[0][1].dir, TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(options[1].size(), 1);
-    OIIO_CHECK_EQUAL(options.empty(), false);
-    OIIO_CHECK_EQUAL(options[1][0].name, "cc");
-    OIIO_CHECK_EQUAL(options[1][0].dir, TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(options.size(), 2);
+    OCIO_CHECK_EQUAL(options[0].size(), 2);
+    OCIO_CHECK_EQUAL(options[0][0].name, "cc");
+    OCIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(options[0][1].name, "di");
+    OCIO_CHECK_EQUAL(options[0][1].dir, TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(options[1].size(), 1);
+    OCIO_CHECK_EQUAL(options.empty(), false);
+    OCIO_CHECK_EQUAL(options[1][0].name, "cc");
+    OCIO_CHECK_EQUAL(options[1][0].dir, TRANSFORM_DIR_INVERSE);
     }
     
     {
     const LookParseResult::Options & options = r.parse("+cc, -di |-cc|   ");
-    OIIO_CHECK_EQUAL(options.size(), 3);
-    OIIO_CHECK_EQUAL(options[0].size(), 2);
-    OIIO_CHECK_EQUAL(options[0][0].name, "cc");
-    OIIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(options[0][1].name, "di");
-    OIIO_CHECK_EQUAL(options[0][1].dir, TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(options[1].size(), 1);
-    OIIO_CHECK_EQUAL(options.empty(), false);
-    OIIO_CHECK_EQUAL(options[1][0].name, "cc");
-    OIIO_CHECK_EQUAL(options[1][0].dir, TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(options[2].size(), 1);
-    OIIO_CHECK_EQUAL(options[2][0].name, "");
-    OIIO_CHECK_EQUAL(options[2][0].dir, TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(options.size(), 3);
+    OCIO_CHECK_EQUAL(options[0].size(), 2);
+    OCIO_CHECK_EQUAL(options[0][0].name, "cc");
+    OCIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(options[0][1].name, "di");
+    OCIO_CHECK_EQUAL(options[0][1].dir, TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(options[1].size(), 1);
+    OCIO_CHECK_EQUAL(options.empty(), false);
+    OCIO_CHECK_EQUAL(options[1][0].name, "cc");
+    OCIO_CHECK_EQUAL(options[1][0].dir, TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(options[2].size(), 1);
+    OCIO_CHECK_EQUAL(options[2][0].name, "");
+    OCIO_CHECK_EQUAL(options[2][0].dir, TRANSFORM_DIR_FORWARD);
     }
 }
 
-OIIO_ADD_TEST(LookParse, Reverse)
+OCIO_ADD_TEST(LookParse, Reverse)
 {
     LookParseResult r;
     
@@ -288,19 +288,19 @@ OIIO_ADD_TEST(LookParse, Reverse)
     r.reverse();
     const LookParseResult::Options & options = r.getOptions();
     
-    OIIO_CHECK_EQUAL(options.size(), 3);
-    OIIO_CHECK_EQUAL(options[0].size(), 2);
-    OIIO_CHECK_EQUAL(options[0][1].name, "cc");
-    OIIO_CHECK_EQUAL(options[0][1].dir, TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(options[0][0].name, "di");
-    OIIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(options[1].size(), 1);
-    OIIO_CHECK_EQUAL(options.empty(), false);
-    OIIO_CHECK_EQUAL(options[1][0].name, "cc");
-    OIIO_CHECK_EQUAL(options[1][0].dir, TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(options[2].size(), 1);
-    OIIO_CHECK_EQUAL(options[2][0].name, "");
-    OIIO_CHECK_EQUAL(options[2][0].dir, TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(options.size(), 3);
+    OCIO_CHECK_EQUAL(options[0].size(), 2);
+    OCIO_CHECK_EQUAL(options[0][1].name, "cc");
+    OCIO_CHECK_EQUAL(options[0][1].dir, TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(options[0][0].name, "di");
+    OCIO_CHECK_EQUAL(options[0][0].dir, TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(options[1].size(), 1);
+    OCIO_CHECK_EQUAL(options.empty(), false);
+    OCIO_CHECK_EQUAL(options[1][0].name, "cc");
+    OCIO_CHECK_EQUAL(options[1][0].dir, TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(options[2].size(), 1);
+    OCIO_CHECK_EQUAL(options[2][0].name, "");
+    OCIO_CHECK_EQUAL(options[2][0].dir, TRANSFORM_DIR_INVERSE);
     }
 
     

--- a/src/OpenColorIO/MathUtils.cpp
+++ b/src/OpenColorIO/MathUtils.cpp
@@ -616,7 +616,7 @@ OCIO_NAMESPACE_EXIT
 OCIO_NAMESPACE_USING
 
 #include <limits>
-#include "unittest.h"
+#include "UnitTest.h"
 
 namespace
 {
@@ -630,7 +630,7 @@ namespace
 }
 
    
-OIIO_ADD_TEST(MathUtils, M44_is_diagonal)
+OCIO_ADD_TEST(MathUtils, M44_is_diagonal)
 {
     {
         float m44[] = { 1.0f, 0.0f, 0.0f, 0.0f,
@@ -638,31 +638,31 @@ OIIO_ADD_TEST(MathUtils, M44_is_diagonal)
                         0.0f, 0.0f, 1.0f, 0.0f,
                         0.0f, 0.0f, 0.0f, 1.0f };
         bool isdiag = IsM44Diagonal(m44);
-        OIIO_CHECK_EQUAL(isdiag, true);
+        OCIO_CHECK_EQUAL(isdiag, true);
 
         m44[1] += 1e-8f;
         isdiag = IsM44Diagonal(m44);
-        OIIO_CHECK_EQUAL(isdiag, false);
+        OCIO_CHECK_EQUAL(isdiag, false);
     }
 }
 
 
-OIIO_ADD_TEST(MathUtils, IsScalarEqualToZero)
+OCIO_ADD_TEST(MathUtils, IsScalarEqualToZero)
 {
-        OIIO_CHECK_EQUAL(IsScalarEqualToZero(0.0f), true);
-        OIIO_CHECK_EQUAL(IsScalarEqualToZero(-0.0f), true);
+        OCIO_CHECK_EQUAL(IsScalarEqualToZero(0.0f), true);
+        OCIO_CHECK_EQUAL(IsScalarEqualToZero(-0.0f), true);
         
-        OIIO_CHECK_EQUAL(IsScalarEqualToZero(-1.072883670794056e-09f), false);
-        OIIO_CHECK_EQUAL(IsScalarEqualToZero(1.072883670794056e-09f), false);
+        OCIO_CHECK_EQUAL(IsScalarEqualToZero(-1.072883670794056e-09f), false);
+        OCIO_CHECK_EQUAL(IsScalarEqualToZero(1.072883670794056e-09f), false);
         
-        OIIO_CHECK_EQUAL(IsScalarEqualToZero(-1.072883670794056e-03f), false);
-        OIIO_CHECK_EQUAL(IsScalarEqualToZero(1.072883670794056e-03f), false);
+        OCIO_CHECK_EQUAL(IsScalarEqualToZero(-1.072883670794056e-03f), false);
+        OCIO_CHECK_EQUAL(IsScalarEqualToZero(1.072883670794056e-03f), false);
         
-        OIIO_CHECK_EQUAL(IsScalarEqualToZero(-1.072883670794056e-01f), false);
-        OIIO_CHECK_EQUAL(IsScalarEqualToZero(1.072883670794056e-01f), false);
+        OCIO_CHECK_EQUAL(IsScalarEqualToZero(-1.072883670794056e-01f), false);
+        OCIO_CHECK_EQUAL(IsScalarEqualToZero(1.072883670794056e-01f), false);
 }
 
-OIIO_ADD_TEST(MathUtils, GetM44Inverse)
+OCIO_ADD_TEST(MathUtils, GetM44Inverse)
 {
         // This is a degenerate matrix, and shouldnt be invertible.
         float m[] = { 0.3f, 0.3f, 0.3f, 0.0f,
@@ -672,11 +672,11 @@ OIIO_ADD_TEST(MathUtils, GetM44Inverse)
         
         float mout[16];
         bool invertsuccess = GetM44Inverse(mout, m);
-        OIIO_CHECK_EQUAL(invertsuccess, false);
+        OCIO_CHECK_EQUAL(invertsuccess, false);
 }
 
 
-OIIO_ADD_TEST(MathUtils, M44_M44_product)
+OCIO_ADD_TEST(MathUtils, M44_M44_product)
 {
     {
         float mout[16];
@@ -697,12 +697,12 @@ OIIO_ADD_TEST(MathUtils, M44_M44_product)
         
         for(int i=0; i<16; ++i)
         {
-            OIIO_CHECK_EQUAL(mout[i], mcorrect[i]);
+            OCIO_CHECK_EQUAL(mout[i], mcorrect[i]);
         }
     }
 }
 
-OIIO_ADD_TEST(MathUtils, M44_V4_product)
+OCIO_ADD_TEST(MathUtils, M44_V4_product)
 {
     {
         float vout[4];
@@ -717,12 +717,12 @@ OIIO_ADD_TEST(MathUtils, M44_V4_product)
         
         for(int i=0; i<4; ++i)
         {
-            OIIO_CHECK_EQUAL(vout[i], vcorrect[i]);
+            OCIO_CHECK_EQUAL(vout[i], vcorrect[i]);
         }
     }
 }
 
-OIIO_ADD_TEST(MathUtils, V4_add)
+OCIO_ADD_TEST(MathUtils, V4_add)
 {
     {
         float vout[4];
@@ -734,12 +734,12 @@ OIIO_ADD_TEST(MathUtils, V4_add)
         
         for(int i=0; i<4; ++i)
         {
-            OIIO_CHECK_EQUAL(vout[i], vcorrect[i]);
+            OCIO_CHECK_EQUAL(vout[i], vcorrect[i]);
         }
     }
 }
 
-OIIO_ADD_TEST(MathUtils, mxb_eval)
+OCIO_ADD_TEST(MathUtils, mxb_eval)
 {
     {
         float vout[4];
@@ -755,12 +755,12 @@ OIIO_ADD_TEST(MathUtils, mxb_eval)
         
         for(int i=0; i<4; ++i)
         {
-            OIIO_CHECK_EQUAL(vout[i], vcorrect[i]);
+            OCIO_CHECK_EQUAL(vout[i], vcorrect[i]);
         }
     }
 }
 
-OIIO_ADD_TEST(MathUtils, Combine_two_mxb)
+OCIO_ADD_TEST(MathUtils, Combine_two_mxb)
 {
     float m1[] = { 1.0f, 0.0f, 2.0f, 0.0f,
                    2.0f, 1.0f, 0.0f, 1.0f,
@@ -791,7 +791,7 @@ OIIO_ADD_TEST(MathUtils, Combine_two_mxb)
         // Compare outputs
         for(int i=0; i<4; ++i)
         {
-            OIIO_CHECK_CLOSE(vcombined[i], vout[i], tolerance);
+            OCIO_CHECK_CLOSE(vcombined[i], vout[i], tolerance);
         }
     }
     
@@ -809,7 +809,7 @@ OIIO_ADD_TEST(MathUtils, Combine_two_mxb)
         
         for(int i=0; i<4; ++i)
         {
-            OIIO_CHECK_CLOSE(vcombined[i], vout[i], tolerance);
+            OCIO_CHECK_CLOSE(vcombined[i], vout[i], tolerance);
         }
     }
     
@@ -829,12 +829,12 @@ OIIO_ADD_TEST(MathUtils, Combine_two_mxb)
         // large numbers, and the error for CHECK_CLOSE is absolute.
         for(int i=0; i<4; ++i)
         {
-            OIIO_CHECK_CLOSE(vcombined[i], vout[i], 1e-3);
+            OCIO_CHECK_CLOSE(vcombined[i], vout[i], 1e-3);
         }
     }
 }
 
-OIIO_ADD_TEST(MathUtils, mxb_invert)
+OCIO_ADD_TEST(MathUtils, mxb_invert)
 {
     {
         float m[] = { 1.0f, 2.0f, 0.0f, 0.0f,
@@ -850,14 +850,14 @@ OIIO_ADD_TEST(MathUtils, mxb_invert)
         
         GetMxbResult(vresult, m, x, v);
         bool invertsuccess = GetMxbInverse(mout, vout, m, v);
-        OIIO_CHECK_EQUAL(invertsuccess, true);
+        OCIO_CHECK_EQUAL(invertsuccess, true);
         
         GetMxbResult(vresult, mout, vresult, vout);
         
         float tolerance = 1e-9f;
         for(int i=0; i<4; ++i)
         {
-            OIIO_CHECK_CLOSE(vresult[i], x[i], tolerance);
+            OCIO_CHECK_CLOSE(vresult[i], x[i], tolerance);
         }
     }
     
@@ -872,7 +872,7 @@ OIIO_ADD_TEST(MathUtils, mxb_invert)
         float vout[4];
         
         bool invertsuccess = GetMxbInverse(mout, vout, m, v);
-        OIIO_CHECK_EQUAL(invertsuccess, false);
+        OCIO_CHECK_EQUAL(invertsuccess, false);
     }
 }
 
@@ -1239,7 +1239,7 @@ void checkFloatsDenormInvariant(const bool compressDenorms)
 
 } // anon
 
-OIIO_ADD_TEST(MathUtils, float_diff_keep_denorms_test)
+OCIO_ADD_TEST(MathUtils, float_diff_keep_denorms_test)
 {
     checkFloatsDenormInvariant(KEEP_DENORMS);
 
@@ -1339,7 +1339,7 @@ OIIO_ADD_TEST(MathUtils, float_diff_keep_denorms_test)
                             posminfloat_m8, posminfloat_m9, posminfloat_m16);
 }
 
-OIIO_ADD_TEST(MathUtils, float_diff_compress_denorms_test )
+OCIO_ADD_TEST(MathUtils, float_diff_compress_denorms_test )
 {
     checkFloatsDenormInvariant(COMPRESS_DENORMS);
 
@@ -1456,19 +1456,19 @@ OIIO_ADD_TEST(MathUtils, float_diff_compress_denorms_test )
                         posminfloat_m8, posminfloat_m9, posminfloat_m16);
 }
 
-OIIO_ADD_TEST(MathUtils, half_bits_test)
+OCIO_ADD_TEST(MathUtils, half_bits_test)
 {
     // Sanity check.
-    OIIO_CHECK_EQUAL(0.5f, ConvertHalfBitsToFloat(0x3800));
+    OCIO_CHECK_EQUAL(0.5f, ConvertHalfBitsToFloat(0x3800));
 
     // Preserve negatives.
-    OIIO_CHECK_EQUAL(-1.f, ConvertHalfBitsToFloat(0xbc00));
+    OCIO_CHECK_EQUAL(-1.f, ConvertHalfBitsToFloat(0xbc00));
 
     // Preserve values > 1.
-    OIIO_CHECK_EQUAL(1024.f, ConvertHalfBitsToFloat(0x6400));
+    OCIO_CHECK_EQUAL(1024.f, ConvertHalfBitsToFloat(0x6400));
 }
 
-OIIO_ADD_TEST(MathUtils, halfs_differ_test)
+OCIO_ADD_TEST(MathUtils, halfs_differ_test)
 {
     half pos_inf;   pos_inf.setBits(31744);   // +inf
     half neg_inf;   neg_inf.setBits(64512);   // -inf
@@ -1487,31 +1487,31 @@ OIIO_ADD_TEST(MathUtils, halfs_differ_test)
 
     int tol = 10;
 
-    OIIO_CHECK_ASSERT(HalfsDiffer(pos_inf, neg_inf, tol));
-    OIIO_CHECK_ASSERT(HalfsDiffer(pos_inf, pos_nan, tol));
-    OIIO_CHECK_ASSERT(HalfsDiffer(neg_inf, neg_nan, tol));
-    OIIO_CHECK_ASSERT(HalfsDiffer(pos_max, pos_inf, tol));
-    OIIO_CHECK_ASSERT(HalfsDiffer(neg_max, neg_inf, tol));
-    OIIO_CHECK_ASSERT(HalfsDiffer(pos_1, neg_1, tol));
-    OIIO_CHECK_ASSERT(HalfsDiffer(pos_2, pos_1, 0));
-    OIIO_CHECK_ASSERT(HalfsDiffer(neg_2, neg_1, 0));
+    OCIO_CHECK_ASSERT(HalfsDiffer(pos_inf, neg_inf, tol));
+    OCIO_CHECK_ASSERT(HalfsDiffer(pos_inf, pos_nan, tol));
+    OCIO_CHECK_ASSERT(HalfsDiffer(neg_inf, neg_nan, tol));
+    OCIO_CHECK_ASSERT(HalfsDiffer(pos_max, pos_inf, tol));
+    OCIO_CHECK_ASSERT(HalfsDiffer(neg_max, neg_inf, tol));
+    OCIO_CHECK_ASSERT(HalfsDiffer(pos_1, neg_1, tol));
+    OCIO_CHECK_ASSERT(HalfsDiffer(pos_2, pos_1, 0));
+    OCIO_CHECK_ASSERT(HalfsDiffer(neg_2, neg_1, 0));
 
-    OIIO_CHECK_ASSERT(!HalfsDiffer(pos_zero, neg_zero, 0));
-    OIIO_CHECK_ASSERT(!HalfsDiffer(pos_small, neg_small, tol));
-    OIIO_CHECK_ASSERT(!HalfsDiffer(pos_2, pos_1, tol));
-    OIIO_CHECK_ASSERT(!HalfsDiffer(neg_2, neg_1, tol));
+    OCIO_CHECK_ASSERT(!HalfsDiffer(pos_zero, neg_zero, 0));
+    OCIO_CHECK_ASSERT(!HalfsDiffer(pos_small, neg_small, tol));
+    OCIO_CHECK_ASSERT(!HalfsDiffer(pos_2, pos_1, tol));
+    OCIO_CHECK_ASSERT(!HalfsDiffer(neg_2, neg_1, tol));
 }
 
-OIIO_ADD_TEST(MathUtils, clamp)
+OCIO_ADD_TEST(MathUtils, clamp)
 {
-    OIIO_CHECK_EQUAL(-1.0f, Clamp(std::numeric_limits<float>::quiet_NaN(), -1.0f, 1.0f));
+    OCIO_CHECK_EQUAL(-1.0f, Clamp(std::numeric_limits<float>::quiet_NaN(), -1.0f, 1.0f));
 
-    OIIO_CHECK_EQUAL(10.0f, Clamp( std::numeric_limits<float>::infinity(),  5.0f, 10.0f));
-    OIIO_CHECK_EQUAL(5.0f, Clamp(-std::numeric_limits<float>::infinity(),  5.0f, 10.0f));
+    OCIO_CHECK_EQUAL(10.0f, Clamp( std::numeric_limits<float>::infinity(),  5.0f, 10.0f));
+    OCIO_CHECK_EQUAL(5.0f, Clamp(-std::numeric_limits<float>::infinity(),  5.0f, 10.0f));
 
-    OIIO_CHECK_EQUAL(0.0000005f, Clamp( 0.0000005f, 0.0f, 1.0f));
-    OIIO_CHECK_EQUAL(0.0f,       Clamp(-0.0000005f, 0.0f, 1.0f));
-    OIIO_CHECK_EQUAL(1.0f,       Clamp( 1.0000005f, 0.0f, 1.0f));
+    OCIO_CHECK_EQUAL(0.0000005f, Clamp( 0.0000005f, 0.0f, 1.0f));
+    OCIO_CHECK_EQUAL(0.0f,       Clamp(-0.0000005f, 0.0f, 1.0f));
+    OCIO_CHECK_EQUAL(1.0f,       Clamp( 1.0000005f, 0.0f, 1.0f));
 }
 
 #endif

--- a/src/OpenColorIO/Op.cpp
+++ b/src/OpenColorIO/Op.cpp
@@ -470,7 +470,7 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 #include "ops/Matrix/MatrixOps.h"
 #include "ops/Log/LogOps.h"
 #include "ops/NoOp/NoOps.h"
@@ -485,7 +485,7 @@ void Apply(const OpRcPtrVec & ops, float * source, long numPixels)
     }
 }
 
-OIIO_ADD_TEST(FinalizeOpVec, optimize_combine)
+OCIO_ADD_TEST(FinalizeOpVec, optimize_combine)
 {
     const float m1[16] = { 1.1f, 0.2f, 0.3f, 0.4f,
                            0.5f, 1.6f, 0.7f, 0.8f,
@@ -514,13 +514,13 @@ OIIO_ADD_TEST(FinalizeOpVec, optimize_combine)
     // Combining ops
     {
         OpRcPtrVec ops;
-        OIIO_CHECK_NO_THROW(CreateMatrixOffsetOp(ops, m1, v1, TRANSFORM_DIR_FORWARD));
-        OIIO_CHECK_NO_THROW(CreateMatrixOffsetOp(ops, m2, v2, TRANSFORM_DIR_FORWARD));
-        OIIO_CHECK_EQUAL(ops.size(), 2);
+        OCIO_CHECK_NO_THROW(CreateMatrixOffsetOp(ops, m1, v1, TRANSFORM_DIR_FORWARD));
+        OCIO_CHECK_NO_THROW(CreateMatrixOffsetOp(ops, m2, v2, TRANSFORM_DIR_FORWARD));
+        OCIO_CHECK_EQUAL(ops.size(), 2);
      
         // No optimize: keep both matrix ops
-        OIIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
-        OIIO_CHECK_EQUAL(ops.size(), 2);
+        OCIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
+        OCIO_CHECK_EQUAL(ops.size(), 2);
 
         // apply ops
         float tmp[12];
@@ -528,8 +528,8 @@ OIIO_ADD_TEST(FinalizeOpVec, optimize_combine)
         Apply(ops, tmp, 3);
 
         // Optimize: Combine 2 matrix ops
-        OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
-        OIIO_CHECK_EQUAL(ops.size(), 1);
+        OCIO_CHECK_NO_THROW(FinalizeOpVec(ops));
+        OCIO_CHECK_EQUAL(ops.size(), 1);
 
         // apply op
         float tmp2[12];
@@ -539,7 +539,7 @@ OIIO_ADD_TEST(FinalizeOpVec, optimize_combine)
         // compare results
         for (unsigned int i = 0; i<12; ++i)
         {
-            OIIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
+            OCIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
         }
     }
 
@@ -547,17 +547,17 @@ OIIO_ADD_TEST(FinalizeOpVec, optimize_combine)
     {
         OpRcPtrVec ops;
         // NoOp
-        OIIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
-        OIIO_CHECK_NO_THROW(CreateMatrixOffsetOp(ops, m1, v1, TRANSFORM_DIR_FORWARD));
-        OIIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
+        OCIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
+        OCIO_CHECK_NO_THROW(CreateMatrixOffsetOp(ops, m1, v1, TRANSFORM_DIR_FORWARD));
+        OCIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
                                         linSlope, linOffset,
                                         OCIO::TRANSFORM_DIR_FORWARD));
 
-        OIIO_CHECK_EQUAL(ops.size(), 3);
+        OCIO_CHECK_EQUAL(ops.size(), 3);
 
         // No optimize: keep both all ops
-        OIIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
-        OIIO_CHECK_EQUAL(ops.size(), 3);
+        OCIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
+        OCIO_CHECK_EQUAL(ops.size(), 3);
 
         // apply ops
         float tmp[12];
@@ -565,10 +565,10 @@ OIIO_ADD_TEST(FinalizeOpVec, optimize_combine)
         Apply(ops, tmp, 3);
 
         // Optimize: remove the no op
-        OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
-        OIIO_CHECK_EQUAL(ops.size(), 2);
-        OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
-        OIIO_CHECK_EQUAL(ops[1]->getInfo(), "<LogOp>");
+        OCIO_CHECK_NO_THROW(FinalizeOpVec(ops));
+        OCIO_CHECK_EQUAL(ops.size(), 2);
+        OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
+        OCIO_CHECK_EQUAL(ops[1]->getInfo(), "<LogOp>");
 
         // apply ops
         float tmp2[12];
@@ -578,25 +578,25 @@ OIIO_ADD_TEST(FinalizeOpVec, optimize_combine)
         // compare results
         for (unsigned int i = 0; i<12; ++i)
         {
-            OIIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
+            OCIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
         }
     }
 
     // remove NoOp in the middle
     {
         OpRcPtrVec ops;
-        OIIO_CHECK_NO_THROW(CreateMatrixOffsetOp(ops, m1, v1, TRANSFORM_DIR_FORWARD));
+        OCIO_CHECK_NO_THROW(CreateMatrixOffsetOp(ops, m1, v1, TRANSFORM_DIR_FORWARD));
         // NoOp
-        OIIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
-        OIIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
+        OCIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
+        OCIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
                                         linSlope, linOffset,
                                         OCIO::TRANSFORM_DIR_FORWARD));
 
-        OIIO_CHECK_EQUAL(ops.size(), 3);
+        OCIO_CHECK_EQUAL(ops.size(), 3);
 
         // No optimize: keep both all ops
-        OIIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
-        OIIO_CHECK_EQUAL(ops.size(), 3);
+        OCIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
+        OCIO_CHECK_EQUAL(ops.size(), 3);
 
         // apply ops
         float tmp[12];
@@ -604,10 +604,10 @@ OIIO_ADD_TEST(FinalizeOpVec, optimize_combine)
         Apply(ops, tmp, 3);
 
         // Optimize: remove the no op
-        OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
-        OIIO_CHECK_EQUAL(ops.size(), 2);
-        OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
-        OIIO_CHECK_EQUAL(ops[1]->getInfo(), "<LogOp>");
+        OCIO_CHECK_NO_THROW(FinalizeOpVec(ops));
+        OCIO_CHECK_EQUAL(ops.size(), 2);
+        OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
+        OCIO_CHECK_EQUAL(ops[1]->getInfo(), "<LogOp>");
 
         // apply ops
         float tmp2[12];
@@ -617,25 +617,25 @@ OIIO_ADD_TEST(FinalizeOpVec, optimize_combine)
         // compare results
         for (unsigned int i = 0; i<12; ++i)
         {
-            OIIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
+            OCIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
         }
     }
 
     // remove NoOp in the end
     {
         OpRcPtrVec ops;
-        OIIO_CHECK_NO_THROW(CreateMatrixOffsetOp(ops, m1, v1, TRANSFORM_DIR_FORWARD));
-        OIIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
+        OCIO_CHECK_NO_THROW(CreateMatrixOffsetOp(ops, m1, v1, TRANSFORM_DIR_FORWARD));
+        OCIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
                                         linSlope, linOffset,
                                         OCIO::TRANSFORM_DIR_FORWARD));
         // NoOp
-        OIIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
+        OCIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
 
-        OIIO_CHECK_EQUAL(ops.size(), 3);
+        OCIO_CHECK_EQUAL(ops.size(), 3);
 
         // No optimize: keep both all ops
-        OIIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
-        OIIO_CHECK_EQUAL(ops.size(), 3);
+        OCIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
+        OCIO_CHECK_EQUAL(ops.size(), 3);
 
         // apply ops
         float tmp[12];
@@ -643,10 +643,10 @@ OIIO_ADD_TEST(FinalizeOpVec, optimize_combine)
         Apply(ops, tmp, 3);
 
         // Optimize: remove the no op
-        OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
-        OIIO_CHECK_EQUAL(ops.size(), 2);
-        OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
-        OIIO_CHECK_EQUAL(ops[1]->getInfo(), "<LogOp>");
+        OCIO_CHECK_NO_THROW(FinalizeOpVec(ops));
+        OCIO_CHECK_EQUAL(ops.size(), 2);
+        OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
+        OCIO_CHECK_EQUAL(ops[1]->getInfo(), "<LogOp>");
 
         // apply ops
         float tmp2[12];
@@ -656,30 +656,30 @@ OIIO_ADD_TEST(FinalizeOpVec, optimize_combine)
         // compare results
         for (unsigned int i = 0; i<12; ++i)
         {
-            OIIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
+            OCIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
         }
     }
 
     // remove several NoOp
     {
         OpRcPtrVec ops;
-        OIIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
-        OIIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
-        OIIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
-        OIIO_CHECK_NO_THROW(CreateMatrixOffsetOp(ops, m1, v1, TRANSFORM_DIR_FORWARD));
-        OIIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
-        OIIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
-        OIIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
+        OCIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
+        OCIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
+        OCIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
+        OCIO_CHECK_NO_THROW(CreateMatrixOffsetOp(ops, m1, v1, TRANSFORM_DIR_FORWARD));
+        OCIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
+        OCIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
+        OCIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
                                         linSlope, linOffset,
                                         OCIO::TRANSFORM_DIR_FORWARD));
-        OIIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
-        OIIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
+        OCIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
+        OCIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
 
-        OIIO_CHECK_EQUAL(ops.size(), 9);
+        OCIO_CHECK_EQUAL(ops.size(), 9);
 
         // No optimize: keep both all ops
-        OIIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
-        OIIO_CHECK_EQUAL(ops.size(), 9);
+        OCIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
+        OCIO_CHECK_EQUAL(ops.size(), 9);
 
         // apply ops
         float tmp[12];
@@ -687,10 +687,10 @@ OIIO_ADD_TEST(FinalizeOpVec, optimize_combine)
         Apply(ops, tmp, 3);
 
         // Optimize: remove the no op
-        OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
-        OIIO_CHECK_EQUAL(ops.size(), 2);
-        OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
-        OIIO_CHECK_EQUAL(ops[1]->getInfo(), "<LogOp>");
+        OCIO_CHECK_NO_THROW(FinalizeOpVec(ops));
+        OCIO_CHECK_EQUAL(ops.size(), 2);
+        OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
+        OCIO_CHECK_EQUAL(ops[1]->getInfo(), "<LogOp>");
 
         // apply ops
         float tmp2[12];
@@ -700,33 +700,33 @@ OIIO_ADD_TEST(FinalizeOpVec, optimize_combine)
         // compare results
         for (unsigned int i = 0; i<12; ++i)
         {
-            OIIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
+            OCIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
         }
     }
 }
 
-OIIO_ADD_TEST(Descriptions, basic)
+OCIO_ADD_TEST(Descriptions, basic)
 {
     OpData::Descriptions desc1;
-    OIIO_CHECK_ASSERT( desc1 == desc1 );
+    OCIO_CHECK_ASSERT( desc1 == desc1 );
 
     OpData::Descriptions desc2("My dummy comment");
-    OIIO_CHECK_ASSERT( desc1 != desc2 );
-    OIIO_CHECK_ASSERT( desc2 != desc1 );
-    OIIO_REQUIRE_EQUAL( desc2.size(), 1);
-    OIIO_CHECK_EQUAL(desc2[0], std::string("My dummy comment"));
+    OCIO_CHECK_ASSERT( desc1 != desc2 );
+    OCIO_CHECK_ASSERT( desc2 != desc1 );
+    OCIO_REQUIRE_EQUAL( desc2.size(), 1);
+    OCIO_CHECK_EQUAL(desc2[0], std::string("My dummy comment"));
 
-    OIIO_CHECK_NO_THROW( desc1 = desc2 );
-    OIIO_CHECK_ASSERT( desc1 == desc2 );
-    OIIO_CHECK_ASSERT( desc2 == desc1 );
+    OCIO_CHECK_NO_THROW( desc1 = desc2 );
+    OCIO_CHECK_ASSERT( desc1 == desc2 );
+    OCIO_CHECK_ASSERT( desc2 == desc1 );
 
-    OIIO_CHECK_NO_THROW( desc2 += "My second dummy comment" );
-    OIIO_REQUIRE_EQUAL( desc2.size(), 2);
-    OIIO_CHECK_ASSERT( desc1 != desc2 );
-    OIIO_CHECK_ASSERT( desc2 != desc1 );
+    OCIO_CHECK_NO_THROW( desc2 += "My second dummy comment" );
+    OCIO_REQUIRE_EQUAL( desc2.size(), 2);
+    OCIO_CHECK_ASSERT( desc1 != desc2 );
+    OCIO_CHECK_ASSERT( desc2 != desc1 );
 }
 
-OIIO_ADD_TEST(CreateOpVecFromOpDataVec, basic)
+OCIO_ADD_TEST(CreateOpVecFromOpDataVec, basic)
 {
     OpDataVec opDataVec;
     auto mat = MatrixOpData::CreateDiagonalMatrix(BIT_DEPTH_F32,
@@ -740,57 +740,57 @@ OIIO_ADD_TEST(CreateOpVecFromOpDataVec, basic)
 
     opDataVec.push_back(range);
 
-    OIIO_REQUIRE_EQUAL(opDataVec.size(), 2);
+    OCIO_REQUIRE_EQUAL(opDataVec.size(), 2);
 
     {
         OpRcPtrVec ops;
-        OIIO_CHECK_NO_THROW(CreateOpVecFromOpDataVec(ops, opDataVec, TRANSFORM_DIR_FORWARD));
-        OIIO_REQUIRE_EQUAL(ops.size(), 2);
+        OCIO_CHECK_NO_THROW(CreateOpVecFromOpDataVec(ops, opDataVec, TRANSFORM_DIR_FORWARD));
+        OCIO_REQUIRE_EQUAL(ops.size(), 2);
 
-        OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
-        OIIO_CHECK_EQUAL(ops[1]->getInfo(), "<RangeOp>");
+        OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
+        OCIO_CHECK_EQUAL(ops[1]->getInfo(), "<RangeOp>");
     }
 
     {
         OpRcPtrVec ops;
-        OIIO_CHECK_NO_THROW(CreateOpVecFromOpDataVec(ops, opDataVec, TRANSFORM_DIR_INVERSE));
-        OIIO_REQUIRE_EQUAL(ops.size(), 2);
+        OCIO_CHECK_NO_THROW(CreateOpVecFromOpDataVec(ops, opDataVec, TRANSFORM_DIR_INVERSE));
+        OCIO_REQUIRE_EQUAL(ops.size(), 2);
 
-        OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<RangeOp>");
-        OIIO_CHECK_EQUAL(ops[1]->getInfo(), "<MatrixOffsetOp>");
+        OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<RangeOp>");
+        OCIO_CHECK_EQUAL(ops[1]->getInfo(), "<MatrixOffsetOp>");
     }
 }
 
-OIIO_ADD_TEST(Op, non_dynamic_ops)
+OCIO_ADD_TEST(Op, non_dynamic_ops)
 {
     float scale[4] = { 2.0f, 2.0f, 2.0f, 1.0f };
 
     OCIO::OpRcPtrVec ops;
     OCIO::CreateScaleOp(ops, scale, OCIO::TRANSFORM_DIR_FORWARD);
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_REQUIRE_ASSERT(ops[0]);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_ASSERT(ops[0]);
     
     // Test that non-dynamic ops such as matrix respond properly to dynamic
     // property requests.
-    OIIO_CHECK_ASSERT(!ops[0]->hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
-    OIIO_CHECK_ASSERT(!ops[0]->hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST));
-    OIIO_CHECK_ASSERT(!ops[0]->hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_GAMMA));
+    OCIO_CHECK_ASSERT(!ops[0]->hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
+    OCIO_CHECK_ASSERT(!ops[0]->hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST));
+    OCIO_CHECK_ASSERT(!ops[0]->hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_GAMMA));
 
-    OIIO_CHECK_THROW_WHAT(ops[0]->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_GAMMA),
+    OCIO_CHECK_THROW_WHAT(ops[0]->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_GAMMA),
                           OCIO::Exception, "does not implement dynamic property");
 }
 
-OIIO_ADD_TEST(OpRcPtrVec, bit_depth)
+OCIO_ADD_TEST(OpRcPtrVec, bit_depth)
 {
     OCIO::OpRcPtrVec ops;
     auto mat = OCIO::MatrixOpData::CreateDiagonalMatrix(OCIO::BIT_DEPTH_F32,
                                                         OCIO::BIT_DEPTH_UINT8,
                                                         1024.);
     OCIO::CreateMatrixOp(ops, mat, OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
 
     auto range = std::make_shared<OCIO::RangeOpData>(OCIO::BIT_DEPTH_F32,
                                                      OCIO::BIT_DEPTH_F32,
@@ -798,11 +798,11 @@ OIIO_ADD_TEST(OpRcPtrVec, bit_depth)
 
     OCIO::CreateRangeOp(ops, range, OCIO::TRANSFORM_DIR_FORWARD);
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     // Test push_back.
 
@@ -811,23 +811,23 @@ OIIO_ADD_TEST(OpRcPtrVec, bit_depth)
                                                    1.1);
     OCIO::CreateMatrixOp(ops, mat, OCIO::TRANSFORM_DIR_FORWARD);
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 3);
-    OIIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[2]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[2]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_REQUIRE_EQUAL(ops.size(), 3);
+    OCIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[2]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[2]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
 
     // Test erase.
 
     ops.erase(ops.begin()+1);
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
 
     // Test erase.
 
@@ -846,139 +846,139 @@ OIIO_ADD_TEST(OpRcPtrVec, bit_depth)
                                                    0.9);
     OCIO::CreateMatrixOp(ops, mat, OCIO::TRANSFORM_DIR_FORWARD);
 
-    OIIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[2]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[2]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL(ops[3]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL(ops[3]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT16);   
-    OIIO_CHECK_EQUAL(ops[4]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT16);
-    OIIO_CHECK_EQUAL(ops[4]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[2]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[2]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(ops[3]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(ops[3]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT16);   
+    OCIO_CHECK_EQUAL(ops[4]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT16);
+    OCIO_CHECK_EQUAL(ops[4]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 5);
+    OCIO_REQUIRE_EQUAL(ops.size(), 5);
     ops.erase(ops.begin()+1, ops.begin()+4);
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 
     // Test insert.
 
     OCIO::OpRcPtrVec ops1 = ops.clone();
 
-    OIIO_REQUIRE_EQUAL(ops1.size(), 2);
-    OIIO_CHECK_EQUAL(ops1[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops1[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops1[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops1[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_REQUIRE_EQUAL(ops1.size(), 2);
+    OCIO_CHECK_EQUAL(ops1[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops1[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops1[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops1[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 
     ops1.insert(ops1.begin()+1, ops.begin(), ops.begin()+1);
-    OIIO_REQUIRE_EQUAL(ops1.size(), 3);
-    OIIO_CHECK_EQUAL(ops1[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops1[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops1[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops1[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops1[2]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops1[2]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_REQUIRE_EQUAL(ops1.size(), 3);
+    OCIO_CHECK_EQUAL(ops1[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops1[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops1[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops1[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops1[2]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops1[2]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 
     // Test operator +=.
 
     OCIO::OpRcPtrVec ops2 = ops.clone();
 
-    OIIO_REQUIRE_EQUAL(ops2.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops2.size(), 2);
     ops2[0]->setInputBitDepth(OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_EQUAL(ops2[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops2[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops2[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops2[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(ops2[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops2[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops2[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops2[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 
     ops2 += ops2.clone();
 
-    OIIO_REQUIRE_EQUAL(ops2.size(), 4);
-    OIIO_CHECK_EQUAL(ops2[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops2[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops2[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops2[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL(ops2[2]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL(ops2[2]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops2[3]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops2[3]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_REQUIRE_EQUAL(ops2.size(), 4);
+    OCIO_CHECK_EQUAL(ops2[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops2[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops2[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops2[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(ops2[2]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(ops2[2]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops2[3]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops2[3]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 }
 
-OIIO_ADD_TEST(OpRcPtrVec, bit_depth_with_filenoop)
+OCIO_ADD_TEST(OpRcPtrVec, bit_depth_with_filenoop)
 {
     OCIO::OpRcPtrVec ops;
     auto mat = OCIO::MatrixOpData::CreateDiagonalMatrix(OCIO::BIT_DEPTH_F32,
                                                         OCIO::BIT_DEPTH_UINT8,
                                                         255.);
     OCIO::CreateMatrixOp(ops, mat, OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
 
-    OIIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
 
     auto range = std::make_shared<OCIO::RangeOpData>(OCIO::BIT_DEPTH_F32,
                                                      OCIO::BIT_DEPTH_F32,
                                                      0.0f, 1.0f, 0.5f, 1.5f);
     OCIO::CreateRangeOp(ops, range, OCIO::TRANSFORM_DIR_FORWARD);
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 3);
-    OIIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_REQUIRE_EQUAL(ops.size(), 3);
+    OCIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
     // FileNoOp should not change bit-depths.
-    OIIO_CHECK_EQUAL(ops[2]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[2]->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[2]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[2]->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_NO_THROW(ops.validate());
+    OCIO_CHECK_NO_THROW(ops.validate());
 
-    OIIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
-    OIIO_REQUIRE_EQUAL(ops.size(), 4);
+    OCIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
+    OCIO_REQUIRE_EQUAL(ops.size(), 4);
 
-    OIIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
-    OIIO_REQUIRE_EQUAL(ops.size(), 5);
+    OCIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
+    OCIO_REQUIRE_EQUAL(ops.size(), 5);
 
     auto mat2 = OCIO::MatrixOpData::CreateDiagonalMatrix(OCIO::BIT_DEPTH_F16,
                                                         OCIO::BIT_DEPTH_UINT12,
                                                         4095.);
     OCIO::CreateMatrixOp(ops, mat2, OCIO::TRANSFORM_DIR_FORWARD);
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 6);
-    OIIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_REQUIRE_EQUAL(ops.size(), 6);
+    OCIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
     // FileNoOp should not change bit-depths.
-    OIIO_CHECK_EQUAL(ops[2]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[2]->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[2]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[2]->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
     // FileNoOp should not change bit-depths.
     // FileNoOp should not change bit-depths.
-    OIIO_CHECK_EQUAL(ops[5]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[5]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(ops[5]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[5]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 
-    OIIO_CHECK_NO_THROW(ops.validate());
+    OCIO_CHECK_NO_THROW(ops.validate());
 
     // Remove FileNoOp and adjust the bit-depths.
 
-    OIIO_CHECK_NO_THROW(OptimizeOpVec(ops));
+    OCIO_CHECK_NO_THROW(OptimizeOpVec(ops));
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 3);
-    OIIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[2]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[2]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_REQUIRE_EQUAL(ops.size(), 3);
+    OCIO_CHECK_EQUAL(ops[0]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[1]->getInputBitDepth(),  OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[2]->getInputBitDepth(),  OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[2]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 
-    OIIO_CHECK_NO_THROW(ops.validate());
+    OCIO_CHECK_NO_THROW(ops.validate());
 
 }
 
-OIIO_ADD_TEST(OpData, equality)
+OCIO_ADD_TEST(OpData, equality)
 {
     auto mat1 = OCIO::MatrixOpData::CreateDiagonalMatrix(OCIO::BIT_DEPTH_F32,
                                                          OCIO::BIT_DEPTH_F32,
@@ -986,41 +986,41 @@ OIIO_ADD_TEST(OpData, equality)
     auto mat2 = mat1->clone();
 
     // Use the MatrixOpData::operator==().
-    OIIO_CHECK_ASSERT(*mat2==*mat1);
+    OCIO_CHECK_ASSERT(*mat2==*mat1);
 
     auto range = std::make_shared<RangeOpData>(BIT_DEPTH_F32,
                                                BIT_DEPTH_F32,
                                                0.0f, 1.0f, 0.5f, 1.5f);
 
     // Use the MatrixOpData::operator==().
-    OIIO_CHECK_ASSERT( !(*mat2==*range) );
+    OCIO_CHECK_ASSERT( !(*mat2==*range) );
 
     // Use the RangeOpData::operator==().
-    OIIO_CHECK_ASSERT( !(*range==*mat1) );
+    OCIO_CHECK_ASSERT( !(*range==*mat1) );
 
     // Use the OpData::operator==().
     auto op1 = DynamicPtrCast<OpData>(range);
-    OIIO_CHECK_ASSERT( !(*op1==*mat1) );    
+    OCIO_CHECK_ASSERT( !(*op1==*mat1) );    
 
     // Use the OpData::operator==().
     auto op2 = DynamicPtrCast<OpData>(mat2);
-    OIIO_CHECK_ASSERT( !(*op2==*op1) );
+    OCIO_CHECK_ASSERT( !(*op2==*op1) );
 
     // Change something.
 
     // Use the MatrixOpData::operator==().
-    OIIO_CHECK_ASSERT( *mat2==*mat1 );
+    OCIO_CHECK_ASSERT( *mat2==*mat1 );
 
     // Use the OpData::operator==().
-    OIIO_CHECK_ASSERT( *op2==*mat1 );
+    OCIO_CHECK_ASSERT( *op2==*mat1 );
 
     mat2->setOffsetValue(1, mat2->getOffsetValue(1) + 1.0);
 
     // Use the MatrixOpData::operator==().
-    OIIO_CHECK_ASSERT( !(*mat2==*mat1) );
+    OCIO_CHECK_ASSERT( !(*mat2==*mat1) );
 
     // Use the OpData::operator==().
-    OIIO_CHECK_ASSERT( !(*op2==*mat1) );
+    OCIO_CHECK_ASSERT( !(*op2==*mat1) );
 }
 
 #endif

--- a/src/OpenColorIO/OpOptimizers.cpp
+++ b/src/OpenColorIO/OpOptimizers.cpp
@@ -232,7 +232,7 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 #include "ops/Exponent/ExponentOps.h"
 #include "ops/Log/LogOps.h"
@@ -240,7 +240,7 @@ namespace OCIO = OCIO_NAMESPACE;
 #include "ops/Lut3D/Lut3DOp.h"
 #include "ops/Matrix/MatrixOps.h"
 
-OIIO_ADD_TEST(OpOptimizers, RemoveInverseOps)
+OCIO_ADD_TEST(OpOptimizers, RemoveInverseOps)
 {
     OCIO::OpRcPtrVec ops;
     
@@ -259,9 +259,9 @@ OIIO_ADD_TEST(OpOptimizers, RemoveInverseOps)
                       OCIO::TRANSFORM_DIR_INVERSE);
     OCIO::CreateExponentOp(ops, exp, OCIO::TRANSFORM_DIR_INVERSE);
     
-    OIIO_CHECK_EQUAL(ops.size(), 4);
+    OCIO_CHECK_EQUAL(ops.size(), 4);
     OCIO::RemoveInverseOps(ops);
-    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_EQUAL(ops.size(), 0);
     
     
     ops.clear();
@@ -273,13 +273,13 @@ OIIO_ADD_TEST(OpOptimizers, RemoveInverseOps)
                       OCIO::TRANSFORM_DIR_FORWARD);
     OCIO::CreateExponentOp(ops, exp, OCIO::TRANSFORM_DIR_FORWARD);
     
-    OIIO_CHECK_EQUAL(ops.size(), 5);
+    OCIO_CHECK_EQUAL(ops.size(), 5);
     OCIO::RemoveInverseOps(ops);
-    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops.size(), 1);
 }
 
 
-OIIO_ADD_TEST(OpOptimizers, CombineOps)
+OCIO_ADD_TEST(OpOptimizers, CombineOps)
 {
     float m1[4] = { 2.0f, 2.0f, 2.0f, 1.0f };
     float m2[4] = { 0.5f, 0.5f, 0.5f, 1.0f };
@@ -292,9 +292,9 @@ OIIO_ADD_TEST(OpOptimizers, CombineOps)
     OCIO::OpRcPtrVec ops;
     OCIO::CreateScaleOp(ops, m1, OCIO::TRANSFORM_DIR_FORWARD);
     
-    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops.size(), 1);
     OCIO::CombineOps(ops);
-    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops.size(), 1);
     }
     
     {
@@ -302,9 +302,9 @@ OIIO_ADD_TEST(OpOptimizers, CombineOps)
     OCIO::CreateScaleOp(ops, m1, OCIO::TRANSFORM_DIR_FORWARD);
     OCIO::CreateScaleOp(ops, m3, OCIO::TRANSFORM_DIR_FORWARD);
     
-    OIIO_CHECK_EQUAL(ops.size(), 2);
+    OCIO_CHECK_EQUAL(ops.size(), 2);
     OCIO::CombineOps(ops);
-    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops.size(), 1);
     }
     
     {
@@ -313,9 +313,9 @@ OIIO_ADD_TEST(OpOptimizers, CombineOps)
     OCIO::CreateScaleOp(ops, m3, OCIO::TRANSFORM_DIR_FORWARD);
     OCIO::CreateScaleOp(ops, m4, OCIO::TRANSFORM_DIR_FORWARD);
     
-    OIIO_CHECK_EQUAL(ops.size(), 3);
+    OCIO_CHECK_EQUAL(ops.size(), 3);
     OCIO::CombineOps(ops);
-    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops.size(), 1);
     }
     
     {
@@ -323,9 +323,9 @@ OIIO_ADD_TEST(OpOptimizers, CombineOps)
     OCIO::CreateScaleOp(ops, m1, OCIO::TRANSFORM_DIR_FORWARD);
     OCIO::CreateScaleOp(ops, m2, OCIO::TRANSFORM_DIR_FORWARD);
     
-    OIIO_CHECK_EQUAL(ops.size(), 2);
+    OCIO_CHECK_EQUAL(ops.size(), 2);
     OCIO::CombineOps(ops);
-    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_EQUAL(ops.size(), 0);
     }
     
     {
@@ -333,9 +333,9 @@ OIIO_ADD_TEST(OpOptimizers, CombineOps)
     OCIO::CreateScaleOp(ops, m1, OCIO::TRANSFORM_DIR_FORWARD);
     OCIO::CreateScaleOp(ops, m1, OCIO::TRANSFORM_DIR_INVERSE);
     
-    OIIO_CHECK_EQUAL(ops.size(), 2);
+    OCIO_CHECK_EQUAL(ops.size(), 2);
     OCIO::CombineOps(ops);
-    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_EQUAL(ops.size(), 0);
     }
     
     {
@@ -346,9 +346,9 @@ OIIO_ADD_TEST(OpOptimizers, CombineOps)
     OCIO::CreateScaleOp(ops, m1, OCIO::TRANSFORM_DIR_FORWARD);
     OCIO::CreateScaleOp(ops, m1, OCIO::TRANSFORM_DIR_FORWARD);
     
-    OIIO_CHECK_EQUAL(ops.size(), 5);
+    OCIO_CHECK_EQUAL(ops.size(), 5);
     OCIO::CombineOps(ops);
-    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops.size(), 1);
     }
     
     {
@@ -358,9 +358,9 @@ OIIO_ADD_TEST(OpOptimizers, CombineOps)
     OCIO::CreateScaleOp(ops, m2, OCIO::TRANSFORM_DIR_FORWARD);
     OCIO::CreateExponentOp(ops, exp, OCIO::TRANSFORM_DIR_INVERSE);
     
-    OIIO_CHECK_EQUAL(ops.size(), 4);
+    OCIO_CHECK_EQUAL(ops.size(), 4);
     OCIO::CombineOps(ops);
-    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_EQUAL(ops.size(), 0);
     }
 }
 

--- a/src/OpenColorIO/ParseUtils.cpp
+++ b/src/OpenColorIO/ParseUtils.cpp
@@ -607,371 +607,371 @@ OCIO_NAMESPACE_EXIT
 
 namespace OCIO = OCIO_NAMESPACE;
 
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(ParseUtils, XMLText)
+OCIO_ADD_TEST(ParseUtils, XMLText)
 {
     const std::string in("abc \" def ' ghi < jkl > mnop & efg");
     const std::string ref("abc &quot; def &apos; ghi &lt; jkl &gt; mnop &amp; efg");
 
     std::string out1 = OCIO::ConvertSpecialCharToXmlToken(in);
-    OIIO_CHECK_EQUAL(out1, ref);
+    OCIO_CHECK_EQUAL(out1, ref);
 }
 
-OIIO_ADD_TEST(ParseUtils, BoolString)
+OCIO_ADD_TEST(ParseUtils, BoolString)
 {
     std::string resStr = OCIO::BoolToString(true);
-    OIIO_CHECK_EQUAL("true", resStr);
+    OCIO_CHECK_EQUAL("true", resStr);
 
     resStr = OCIO::BoolToString(false);
-    OIIO_CHECK_EQUAL("false", resStr);
+    OCIO_CHECK_EQUAL("false", resStr);
 
     bool resBool = OCIO::BoolFromString("yes");
-    OIIO_CHECK_EQUAL(true, resBool);
+    OCIO_CHECK_EQUAL(true, resBool);
 
     resBool = OCIO::BoolFromString("Yes");
-    OIIO_CHECK_EQUAL(true, resBool);
+    OCIO_CHECK_EQUAL(true, resBool);
 
     resBool = OCIO::BoolFromString("YES");
-    OIIO_CHECK_EQUAL(true, resBool);
+    OCIO_CHECK_EQUAL(true, resBool);
 
     resBool = OCIO::BoolFromString("YeS");
-    OIIO_CHECK_EQUAL(true, resBool);
+    OCIO_CHECK_EQUAL(true, resBool);
 
     resBool = OCIO::BoolFromString("yEs");
-    OIIO_CHECK_EQUAL(true, resBool);
+    OCIO_CHECK_EQUAL(true, resBool);
 
     resBool = OCIO::BoolFromString("true");
-    OIIO_CHECK_EQUAL(true, resBool);
+    OCIO_CHECK_EQUAL(true, resBool);
 
     resBool = OCIO::BoolFromString("TRUE");
-    OIIO_CHECK_EQUAL(true, resBool);
+    OCIO_CHECK_EQUAL(true, resBool);
 
     resBool = OCIO::BoolFromString("True");
-    OIIO_CHECK_EQUAL(true, resBool);
+    OCIO_CHECK_EQUAL(true, resBool);
 
     resBool = OCIO::BoolFromString("tRUe");
-    OIIO_CHECK_EQUAL(true, resBool);
+    OCIO_CHECK_EQUAL(true, resBool);
 
     resBool = OCIO::BoolFromString("tRUE");
-    OIIO_CHECK_EQUAL(true, resBool);
+    OCIO_CHECK_EQUAL(true, resBool);
 
     resBool = OCIO::BoolFromString("yes ");
-    OIIO_CHECK_EQUAL(false, resBool);
+    OCIO_CHECK_EQUAL(false, resBool);
 
     resBool = OCIO::BoolFromString(" true ");
-    OIIO_CHECK_EQUAL(false, resBool);
+    OCIO_CHECK_EQUAL(false, resBool);
 
     resBool = OCIO::BoolFromString("false");
-    OIIO_CHECK_EQUAL(false, resBool);
+    OCIO_CHECK_EQUAL(false, resBool);
 
     resBool = OCIO::BoolFromString("");
-    OIIO_CHECK_EQUAL(false, resBool);
+    OCIO_CHECK_EQUAL(false, resBool);
 
     resBool = OCIO::BoolFromString("no");
-    OIIO_CHECK_EQUAL(false, resBool);
+    OCIO_CHECK_EQUAL(false, resBool);
 
     resBool = OCIO::BoolFromString("valid");
-    OIIO_CHECK_EQUAL(false, resBool);
+    OCIO_CHECK_EQUAL(false, resBool);
 
     resBool = OCIO::BoolFromString("success");
-    OIIO_CHECK_EQUAL(false, resBool);
+    OCIO_CHECK_EQUAL(false, resBool);
 
     resBool = OCIO::BoolFromString("anything");
-    OIIO_CHECK_EQUAL(false, resBool);
+    OCIO_CHECK_EQUAL(false, resBool);
 }
 
-OIIO_ADD_TEST(ParseUtils, TransformDirection)
+OCIO_ADD_TEST(ParseUtils, TransformDirection)
 {
     std::string resStr;
     resStr = OCIO::TransformDirectionToString(OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL("forward", resStr);
+    OCIO_CHECK_EQUAL("forward", resStr);
     resStr = OCIO::TransformDirectionToString(OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL("inverse", resStr);
+    OCIO_CHECK_EQUAL("inverse", resStr);
     resStr = OCIO::TransformDirectionToString(OCIO::TRANSFORM_DIR_UNKNOWN);
-    OIIO_CHECK_EQUAL("unknown", resStr);
+    OCIO_CHECK_EQUAL("unknown", resStr);
 
     OCIO::TransformDirection resDir;
     resDir = OCIO::TransformDirectionFromString("forward");
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
     resDir = OCIO::TransformDirectionFromString("inverse");
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
     resDir = OCIO::TransformDirectionFromString("Forward");
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
     resDir = OCIO::TransformDirectionFromString("Inverse");
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
     resDir = OCIO::TransformDirectionFromString("FORWARD");
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
     resDir = OCIO::TransformDirectionFromString("INVERSE");
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
     resDir = OCIO::TransformDirectionFromString("unknown");
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
     resDir = OCIO::TransformDirectionFromString("");
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
     resDir = OCIO::TransformDirectionFromString("anything");
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
 
     resDir = OCIO::CombineTransformDirections(OCIO::TRANSFORM_DIR_UNKNOWN,
         OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
     resDir = OCIO::CombineTransformDirections(OCIO::TRANSFORM_DIR_INVERSE,
         OCIO::TRANSFORM_DIR_UNKNOWN);
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
     resDir = OCIO::CombineTransformDirections(OCIO::TRANSFORM_DIR_UNKNOWN,
         OCIO::TRANSFORM_DIR_UNKNOWN);
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
     resDir = OCIO::CombineTransformDirections(OCIO::TRANSFORM_DIR_INVERSE,
         OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
     resDir = OCIO::CombineTransformDirections(OCIO::TRANSFORM_DIR_FORWARD,
         OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
     resDir = OCIO::CombineTransformDirections(OCIO::TRANSFORM_DIR_INVERSE,
         OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
     resDir = OCIO::CombineTransformDirections(OCIO::TRANSFORM_DIR_FORWARD,
         OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
 
     resDir = OCIO::GetInverseTransformDirection(OCIO::TRANSFORM_DIR_UNKNOWN);
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_UNKNOWN, resDir);
     resDir = OCIO::GetInverseTransformDirection(OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_FORWARD, resDir);
     resDir = OCIO::GetInverseTransformDirection(OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
+    OCIO_CHECK_EQUAL(OCIO::TRANSFORM_DIR_INVERSE, resDir);
 }
 
-OIIO_ADD_TEST(ParseUtils, ColorSpace)
+OCIO_ADD_TEST(ParseUtils, ColorSpace)
 {
     std::string resStr;
     resStr = OCIO::ColorSpaceDirectionToString(
         OCIO::COLORSPACE_DIR_TO_REFERENCE);
-    OIIO_CHECK_EQUAL("to_reference", resStr);
+    OCIO_CHECK_EQUAL("to_reference", resStr);
     resStr = OCIO::ColorSpaceDirectionToString(
         OCIO::COLORSPACE_DIR_FROM_REFERENCE);
-    OIIO_CHECK_EQUAL("from_reference", resStr);
+    OCIO_CHECK_EQUAL("from_reference", resStr);
     resStr = OCIO::ColorSpaceDirectionToString(
         OCIO::COLORSPACE_DIR_UNKNOWN);
-    OIIO_CHECK_EQUAL("unknown", resStr);
+    OCIO_CHECK_EQUAL("unknown", resStr);
 
     OCIO::ColorSpaceDirection resCSD;
     resCSD = OCIO::ColorSpaceDirectionFromString("to_reference");
-    OIIO_CHECK_EQUAL(OCIO::COLORSPACE_DIR_TO_REFERENCE, resCSD);
+    OCIO_CHECK_EQUAL(OCIO::COLORSPACE_DIR_TO_REFERENCE, resCSD);
     resCSD = OCIO::ColorSpaceDirectionFromString("from_reference");
-    OIIO_CHECK_EQUAL(OCIO::COLORSPACE_DIR_FROM_REFERENCE, resCSD);
+    OCIO_CHECK_EQUAL(OCIO::COLORSPACE_DIR_FROM_REFERENCE, resCSD);
     resCSD = OCIO::ColorSpaceDirectionFromString("unkwon");
-    OIIO_CHECK_EQUAL(OCIO::COLORSPACE_DIR_UNKNOWN, resCSD);
+    OCIO_CHECK_EQUAL(OCIO::COLORSPACE_DIR_UNKNOWN, resCSD);
     resCSD = OCIO::ColorSpaceDirectionFromString("");
-    OIIO_CHECK_EQUAL(OCIO::COLORSPACE_DIR_UNKNOWN, resCSD);
+    OCIO_CHECK_EQUAL(OCIO::COLORSPACE_DIR_UNKNOWN, resCSD);
 }
 
-OIIO_ADD_TEST(ParseUtils, BitDepth)
+OCIO_ADD_TEST(ParseUtils, BitDepth)
 {
     std::string resStr;
     resStr = OCIO::BitDepthToString(OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL("8ui", resStr);
+    OCIO_CHECK_EQUAL("8ui", resStr);
     resStr = OCIO::BitDepthToString(OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_EQUAL("10ui", resStr);
+    OCIO_CHECK_EQUAL("10ui", resStr);
     resStr = OCIO::BitDepthToString(OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL("12ui", resStr);
+    OCIO_CHECK_EQUAL("12ui", resStr);
     resStr = OCIO::BitDepthToString(OCIO::BIT_DEPTH_UINT14);
-    OIIO_CHECK_EQUAL("14ui", resStr);
+    OCIO_CHECK_EQUAL("14ui", resStr);
     resStr = OCIO::BitDepthToString(OCIO::BIT_DEPTH_UINT16);
-    OIIO_CHECK_EQUAL("16ui", resStr);
+    OCIO_CHECK_EQUAL("16ui", resStr);
     resStr = OCIO::BitDepthToString(OCIO::BIT_DEPTH_UINT32);
-    OIIO_CHECK_EQUAL("32ui", resStr);
+    OCIO_CHECK_EQUAL("32ui", resStr);
     resStr = OCIO::BitDepthToString(OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL("16f", resStr);
+    OCIO_CHECK_EQUAL("16f", resStr);
     resStr = OCIO::BitDepthToString(OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL("32f", resStr);
+    OCIO_CHECK_EQUAL("32f", resStr);
     resStr = OCIO::BitDepthToString(OCIO::BIT_DEPTH_UNKNOWN);
-    OIIO_CHECK_EQUAL("unknown", resStr);
+    OCIO_CHECK_EQUAL("unknown", resStr);
     
     OCIO::BitDepth resBD;
     resBD = OCIO::BitDepthFromString("8ui");
-    OIIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT8, resBD);
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT8, resBD);
     resBD = OCIO::BitDepthFromString("8Ui");
-    OIIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT8, resBD);
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT8, resBD);
     resBD = OCIO::BitDepthFromString("8UI");
-    OIIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT8, resBD);
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT8, resBD);
     resBD = OCIO::BitDepthFromString("8uI");
-    OIIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT8, resBD);
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT8, resBD);
     resBD = OCIO::BitDepthFromString("10ui");
-    OIIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT10, resBD);
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT10, resBD);
     resBD = OCIO::BitDepthFromString("12ui");
-    OIIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT12, resBD);
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT12, resBD);
     resBD = OCIO::BitDepthFromString("14ui");
-    OIIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT14, resBD);
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT14, resBD);
     resBD = OCIO::BitDepthFromString("16ui");
-    OIIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT16, resBD);
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT16, resBD);
     resBD = OCIO::BitDepthFromString("32ui");
-    OIIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT32, resBD);
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UINT32, resBD);
     resBD = OCIO::BitDepthFromString("16f");
-    OIIO_CHECK_EQUAL(OCIO::BIT_DEPTH_F16, resBD);
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_F16, resBD);
     resBD = OCIO::BitDepthFromString("32f");
-    OIIO_CHECK_EQUAL(OCIO::BIT_DEPTH_F32, resBD);
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_F32, resBD);
     resBD = OCIO::BitDepthFromString("7ui");
-    OIIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UNKNOWN, resBD);
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UNKNOWN, resBD);
     resBD = OCIO::BitDepthFromString("unknown");
-    OIIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UNKNOWN, resBD);
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UNKNOWN, resBD);
     resBD = OCIO::BitDepthFromString("");
-    OIIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UNKNOWN, resBD);
+    OCIO_CHECK_EQUAL(OCIO::BIT_DEPTH_UNKNOWN, resBD);
 
 
     bool resBool;
     resBool = OCIO::BitDepthIsFloat(OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(true, resBool);
+    OCIO_CHECK_EQUAL(true, resBool);
     resBool = OCIO::BitDepthIsFloat(OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(true, resBool);
+    OCIO_CHECK_EQUAL(true, resBool);
     resBool = OCIO::BitDepthIsFloat(OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(false, resBool);
+    OCIO_CHECK_EQUAL(false, resBool);
     resBool = OCIO::BitDepthIsFloat(OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_EQUAL(false, resBool);
+    OCIO_CHECK_EQUAL(false, resBool);
     resBool = OCIO::BitDepthIsFloat(OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL(false, resBool);
+    OCIO_CHECK_EQUAL(false, resBool);
     resBool = OCIO::BitDepthIsFloat(OCIO::BIT_DEPTH_UINT14);
-    OIIO_CHECK_EQUAL(false, resBool);
+    OCIO_CHECK_EQUAL(false, resBool);
     resBool = OCIO::BitDepthIsFloat(OCIO::BIT_DEPTH_UINT16);
-    OIIO_CHECK_EQUAL(false, resBool);
+    OCIO_CHECK_EQUAL(false, resBool);
     resBool = OCIO::BitDepthIsFloat(OCIO::BIT_DEPTH_UINT32);
-    OIIO_CHECK_EQUAL(false, resBool);
+    OCIO_CHECK_EQUAL(false, resBool);
     resBool = OCIO::BitDepthIsFloat(OCIO::BIT_DEPTH_UNKNOWN);
-    OIIO_CHECK_EQUAL(false, resBool);
+    OCIO_CHECK_EQUAL(false, resBool);
 
     int resInt;
     resInt = OCIO::BitDepthToInt(OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(8, resInt);
+    OCIO_CHECK_EQUAL(8, resInt);
     resInt = OCIO::BitDepthToInt(OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_EQUAL(10, resInt);
+    OCIO_CHECK_EQUAL(10, resInt);
     resInt = OCIO::BitDepthToInt(OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL(12, resInt);
+    OCIO_CHECK_EQUAL(12, resInt);
     resInt = OCIO::BitDepthToInt(OCIO::BIT_DEPTH_UINT14);
-    OIIO_CHECK_EQUAL(14, resInt);
+    OCIO_CHECK_EQUAL(14, resInt);
     resInt = OCIO::BitDepthToInt(OCIO::BIT_DEPTH_UINT16);
-    OIIO_CHECK_EQUAL(16, resInt);
+    OCIO_CHECK_EQUAL(16, resInt);
     resInt = OCIO::BitDepthToInt(OCIO::BIT_DEPTH_UINT32);
-    OIIO_CHECK_EQUAL(32, resInt);
+    OCIO_CHECK_EQUAL(32, resInt);
     resInt = OCIO::BitDepthToInt(OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(0, resInt);
+    OCIO_CHECK_EQUAL(0, resInt);
     resInt = OCIO::BitDepthToInt(OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(0, resInt);
+    OCIO_CHECK_EQUAL(0, resInt);
     resInt = OCIO::BitDepthToInt(OCIO::BIT_DEPTH_UNKNOWN);
-    OIIO_CHECK_EQUAL(0, resInt);
+    OCIO_CHECK_EQUAL(0, resInt);
 
 }
 
-OIIO_ADD_TEST(ParseUtils, StringToInt)
+OCIO_ADD_TEST(ParseUtils, StringToInt)
 {
     int ival = 0;
     bool success = false;
     
     success = OCIO::StringToInt(&ival, "", false);
-    OIIO_CHECK_EQUAL(success, false);
+    OCIO_CHECK_EQUAL(success, false);
     
     success = OCIO::StringToInt(&ival, "9", false);
-    OIIO_CHECK_EQUAL(success, true);
-    OIIO_CHECK_EQUAL(ival, 9);
+    OCIO_CHECK_EQUAL(success, true);
+    OCIO_CHECK_EQUAL(ival, 9);
     
     success = OCIO::StringToInt(&ival, " 10 ", false);
-    OIIO_CHECK_EQUAL(success, true);
-    OIIO_CHECK_EQUAL(ival, 10);
+    OCIO_CHECK_EQUAL(success, true);
+    OCIO_CHECK_EQUAL(ival, 10);
     
     success = OCIO::StringToInt(&ival, " 101", true);
-    OIIO_CHECK_EQUAL(success, true);
-    OIIO_CHECK_EQUAL(ival, 101);
+    OCIO_CHECK_EQUAL(success, true);
+    OCIO_CHECK_EQUAL(ival, 101);
     
     success = OCIO::StringToInt(&ival, " 11x ", false);
-    OIIO_CHECK_EQUAL(success, true);
-    OIIO_CHECK_EQUAL(ival, 11);
+    OCIO_CHECK_EQUAL(success, true);
+    OCIO_CHECK_EQUAL(ival, 11);
     
     success = OCIO::StringToInt(&ival, " 12x ", true);
-    OIIO_CHECK_EQUAL(success, false);
+    OCIO_CHECK_EQUAL(success, false);
     
     success = OCIO::StringToInt(&ival, "13", true);
-    OIIO_CHECK_EQUAL(success, true);
-    OIIO_CHECK_EQUAL(ival, 13);
+    OCIO_CHECK_EQUAL(success, true);
+    OCIO_CHECK_EQUAL(ival, 13);
     
     success = OCIO::StringToInt(&ival, "-14", true);
-    OIIO_CHECK_EQUAL(success, true);
-    OIIO_CHECK_EQUAL(ival, -14);
+    OCIO_CHECK_EQUAL(success, true);
+    OCIO_CHECK_EQUAL(ival, -14);
     
     success = OCIO::StringToInt(&ival, "x-15", false);
-    OIIO_CHECK_EQUAL(success, false);
+    OCIO_CHECK_EQUAL(success, false);
     
     success = OCIO::StringToInt(&ival, "x-16", false);
-    OIIO_CHECK_EQUAL(success, false);
+    OCIO_CHECK_EQUAL(success, false);
 }
 
-OIIO_ADD_TEST(ParseUtils, StringToFloat)
+OCIO_ADD_TEST(ParseUtils, StringToFloat)
 {
     float fval = 0;
     bool success = false;
 
     success = OCIO::StringToFloat(&fval, "");
-    OIIO_CHECK_EQUAL(success, false);
+    OCIO_CHECK_EQUAL(success, false);
 
     success = OCIO::StringToFloat(&fval, "1.0");
-    OIIO_CHECK_EQUAL(success, true);
-    OIIO_CHECK_EQUAL(fval, 1.0f);
+    OCIO_CHECK_EQUAL(success, true);
+    OCIO_CHECK_EQUAL(fval, 1.0f);
 
     success = OCIO::StringToFloat(&fval, "1");
-    OIIO_CHECK_EQUAL(success, true);
-    OIIO_CHECK_EQUAL(fval, 1.0f);
+    OCIO_CHECK_EQUAL(success, true);
+    OCIO_CHECK_EQUAL(fval, 1.0f);
 
     success = OCIO::StringToFloat(&fval, "a1");
-    OIIO_CHECK_EQUAL(success, false);
+    OCIO_CHECK_EQUAL(success, false);
 
     success = OCIO::StringToFloat(&fval,
         "1 do we really want this to succeed?");
-    OIIO_CHECK_EQUAL(success, true);
-    OIIO_CHECK_EQUAL(fval, 1.0f);
+    OCIO_CHECK_EQUAL(success, true);
+    OCIO_CHECK_EQUAL(fval, 1.0f);
 
     success = OCIO::StringToFloat(&fval, "1Success");
-    OIIO_CHECK_EQUAL(success, true);
-    OIIO_CHECK_EQUAL(fval, 1.0f);
+    OCIO_CHECK_EQUAL(success, true);
+    OCIO_CHECK_EQUAL(fval, 1.0f);
 
     success = OCIO::StringToFloat(&fval,
         "1.0000000000000000000000000000000000000000000001");
-    OIIO_CHECK_EQUAL(success, true);
-    OIIO_CHECK_EQUAL(fval, 1.0f);
+    OCIO_CHECK_EQUAL(success, true);
+    OCIO_CHECK_EQUAL(fval, 1.0f);
 }
 
-OIIO_ADD_TEST(ParseUtils, FloatDouble)
+OCIO_ADD_TEST(ParseUtils, FloatDouble)
 {
     std::string resStr;
     resStr = OCIO::FloatToString(0.0f);
-    OIIO_CHECK_EQUAL("0", resStr);
+    OCIO_CHECK_EQUAL("0", resStr);
 
     resStr = OCIO::FloatToString(0.1111001f);
-    OIIO_CHECK_EQUAL("0.1111001", resStr);
+    OCIO_CHECK_EQUAL("0.1111001", resStr);
 
     resStr = OCIO::FloatToString(0.11000001f);
-    OIIO_CHECK_EQUAL("0.11", resStr);
+    OCIO_CHECK_EQUAL("0.11", resStr);
 
     resStr = OCIO::DoubleToString(0.11000001);
-    OIIO_CHECK_EQUAL("0.11000001", resStr);
+    OCIO_CHECK_EQUAL("0.11000001", resStr);
 
     resStr = OCIO::DoubleToString(0.1100000000000001);
-    OIIO_CHECK_EQUAL("0.1100000000000001", resStr);
+    OCIO_CHECK_EQUAL("0.1100000000000001", resStr);
 
     resStr = OCIO::DoubleToString(0.11000000000000001);
-    OIIO_CHECK_EQUAL("0.11", resStr);
+    OCIO_CHECK_EQUAL("0.11", resStr);
 }
 
-OIIO_ADD_TEST(ParseUtils, StringVecToIntVec)
+OCIO_ADD_TEST(ParseUtils, StringVecToIntVec)
 {
     std::vector<int> intArray;
     std::vector<std::string> lineParts;
     bool success = OCIO::StringVecToIntVec(intArray, lineParts);
-    OIIO_CHECK_EQUAL(true, success);
-    OIIO_CHECK_EQUAL(0, intArray.size());
+    OCIO_CHECK_EQUAL(true, success);
+    OCIO_CHECK_EQUAL(0, intArray.size());
 
     lineParts.push_back("42");
     lineParts.push_back("");
 
     success = OCIO::StringVecToIntVec(intArray, lineParts);
-    OIIO_CHECK_EQUAL(false, success);
-    OIIO_CHECK_EQUAL(2, intArray.size());
+    OCIO_CHECK_EQUAL(false, success);
+    OCIO_CHECK_EQUAL(2, intArray.size());
 
     intArray.clear();
     lineParts.clear();
@@ -980,10 +980,10 @@ OIIO_ADD_TEST(ParseUtils, StringVecToIntVec)
     lineParts.push_back("0");
 
     success = OCIO::StringVecToIntVec(intArray, lineParts);
-    OIIO_CHECK_EQUAL(true, success);
-    OIIO_CHECK_EQUAL(2, intArray.size());
-    OIIO_CHECK_EQUAL(42, intArray[0]);
-    OIIO_CHECK_EQUAL(0, intArray[1]);
+    OCIO_CHECK_EQUAL(true, success);
+    OCIO_CHECK_EQUAL(2, intArray.size());
+    OCIO_CHECK_EQUAL(42, intArray[0]);
+    OCIO_CHECK_EQUAL(0, intArray[1]);
 
     intArray.clear();
     lineParts.clear();
@@ -992,10 +992,10 @@ OIIO_ADD_TEST(ParseUtils, StringVecToIntVec)
     lineParts.push_back("021");
 
     success = OCIO::StringVecToIntVec(intArray, lineParts);
-    OIIO_CHECK_EQUAL(true, success);
-    OIIO_CHECK_EQUAL(2, intArray.size());
-    OIIO_CHECK_EQUAL(42, intArray[0]);
-    OIIO_CHECK_EQUAL(21, intArray[1]);
+    OCIO_CHECK_EQUAL(true, success);
+    OCIO_CHECK_EQUAL(2, intArray.size());
+    OCIO_CHECK_EQUAL(42, intArray[0]);
+    OCIO_CHECK_EQUAL(21, intArray[1]);
 
     intArray.clear();
     lineParts.clear();
@@ -1004,8 +1004,8 @@ OIIO_ADD_TEST(ParseUtils, StringVecToIntVec)
     lineParts.push_back("0x21");
 
     success = OCIO::StringVecToIntVec(intArray, lineParts);
-    OIIO_CHECK_EQUAL(false, success);
-    OIIO_CHECK_EQUAL(2, intArray.size());
+    OCIO_CHECK_EQUAL(false, success);
+    OCIO_CHECK_EQUAL(2, intArray.size());
 
     intArray.clear();
     lineParts.clear();
@@ -1014,47 +1014,47 @@ OIIO_ADD_TEST(ParseUtils, StringVecToIntVec)
     lineParts.push_back("21");
 
     success = OCIO::StringVecToIntVec(intArray, lineParts);
-    OIIO_CHECK_EQUAL(false, success);
-    OIIO_CHECK_EQUAL(2, intArray.size());
+    OCIO_CHECK_EQUAL(false, success);
+    OCIO_CHECK_EQUAL(2, intArray.size());
 }
 
-OIIO_ADD_TEST(ParseUtils, SplitStringEnvStyle)
+OCIO_ADD_TEST(ParseUtils, SplitStringEnvStyle)
 {
     std::vector<std::string> outputvec;
     OCIO::SplitStringEnvStyle(outputvec, "This:is:a:test");
-    OIIO_CHECK_EQUAL(4, outputvec.size());
-    OIIO_CHECK_EQUAL("This", outputvec[0]);
-    OIIO_CHECK_EQUAL("is", outputvec[1]);
-    OIIO_CHECK_EQUAL("a", outputvec[2]);
-    OIIO_CHECK_EQUAL("test", outputvec[3]);
+    OCIO_CHECK_EQUAL(4, outputvec.size());
+    OCIO_CHECK_EQUAL("This", outputvec[0]);
+    OCIO_CHECK_EQUAL("is", outputvec[1]);
+    OCIO_CHECK_EQUAL("a", outputvec[2]);
+    OCIO_CHECK_EQUAL("test", outputvec[3]);
     outputvec.clear();
     OCIO::SplitStringEnvStyle(outputvec, "   This  : is   :   a:   test  ");
-    OIIO_CHECK_EQUAL(4, outputvec.size());
-    OIIO_CHECK_EQUAL("This", outputvec[0]);
-    OIIO_CHECK_EQUAL("is", outputvec[1]);
-    OIIO_CHECK_EQUAL("a", outputvec[2]);
-    OIIO_CHECK_EQUAL("test", outputvec[3]);
+    OCIO_CHECK_EQUAL(4, outputvec.size());
+    OCIO_CHECK_EQUAL("This", outputvec[0]);
+    OCIO_CHECK_EQUAL("is", outputvec[1]);
+    OCIO_CHECK_EQUAL("a", outputvec[2]);
+    OCIO_CHECK_EQUAL("test", outputvec[3]);
     outputvec.clear();
     OCIO::SplitStringEnvStyle(outputvec, "   This  , is   ,   a,   test  ");
-    OIIO_CHECK_EQUAL(4, outputvec.size());
-    OIIO_CHECK_EQUAL("This", outputvec[0]);
-    OIIO_CHECK_EQUAL("is", outputvec[1]);
-    OIIO_CHECK_EQUAL("a", outputvec[2]);
-    OIIO_CHECK_EQUAL("test", outputvec[3]);
+    OCIO_CHECK_EQUAL(4, outputvec.size());
+    OCIO_CHECK_EQUAL("This", outputvec[0]);
+    OCIO_CHECK_EQUAL("is", outputvec[1]);
+    OCIO_CHECK_EQUAL("a", outputvec[2]);
+    OCIO_CHECK_EQUAL("test", outputvec[3]);
     outputvec.clear();
     OCIO::SplitStringEnvStyle(outputvec, "This:is   ,   a:test  ");
-    OIIO_CHECK_EQUAL(2, outputvec.size());
-    OIIO_CHECK_EQUAL("This:is", outputvec[0]);
-    OIIO_CHECK_EQUAL("a:test", outputvec[1]);
+    OCIO_CHECK_EQUAL(2, outputvec.size());
+    OCIO_CHECK_EQUAL("This:is", outputvec[0]);
+    OCIO_CHECK_EQUAL("a:test", outputvec[1]);
     outputvec.clear();
     OCIO::SplitStringEnvStyle(outputvec, ",,");
-    OIIO_CHECK_EQUAL(3, outputvec.size());
-    OIIO_CHECK_EQUAL("", outputvec[0]);
-    OIIO_CHECK_EQUAL("", outputvec[1]);
-    OIIO_CHECK_EQUAL("", outputvec[2]);
+    OCIO_CHECK_EQUAL(3, outputvec.size());
+    OCIO_CHECK_EQUAL("", outputvec[0]);
+    OCIO_CHECK_EQUAL("", outputvec[1]);
+    OCIO_CHECK_EQUAL("", outputvec[2]);
 }
 
-OIIO_ADD_TEST(ParseUtils, IntersectStringVecsCaseIgnore)
+OCIO_ADD_TEST(ParseUtils, IntersectStringVecsCaseIgnore)
 {
     std::vector<std::string> source1;
     std::vector<std::string> source2;
@@ -1073,11 +1073,11 @@ OIIO_ADD_TEST(ParseUtils, IntersectStringVecsCaseIgnore)
     source2.push_back("IS");
 
     std::vector<std::string> resInter = OCIO::IntersectStringVecsCaseIgnore(source1, source2);
-    OIIO_CHECK_EQUAL(4, resInter.size());
-    OIIO_CHECK_EQUAL("This", resInter[0]);
-    OIIO_CHECK_EQUAL("is", resInter[1]);
-    OIIO_CHECK_EQUAL("a", resInter[2]);
-    OIIO_CHECK_EQUAL("test", resInter[3]);
+    OCIO_CHECK_EQUAL(4, resInter.size());
+    OCIO_CHECK_EQUAL("This", resInter[0]);
+    OCIO_CHECK_EQUAL("is", resInter[1]);
+    OCIO_CHECK_EQUAL("a", resInter[2]);
+    OCIO_CHECK_EQUAL("test", resInter[3]);
 }
 
 #endif // OCIO_UNIT_TEST

--- a/src/OpenColorIO/PathUtils.cpp
+++ b/src/OpenColorIO/PathUtils.cpp
@@ -258,9 +258,9 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(PathUtils, EnvExpand)
+OCIO_ADD_TEST(PathUtils, EnvExpand)
 {
     // build env by hand for unit test
     OCIO::EnvMap env_map; // = OCIO::GetEnvMap();
@@ -274,7 +274,7 @@ OIIO_ADD_TEST(PathUtils, EnvExpand)
     std::string foo = "/a/b/${TEST1}/${TEST1NG}/$TEST1/$TEST1NG/${FOO_${TEST1}}/";
     std::string foo_result = "/a/b/foo.bar/bar.foo/foo.bar/bar.foo/cheese/";
     std::string testresult = OCIO::EnvExpand(foo, env_map);
-    OIIO_CHECK_ASSERT( testresult == foo_result );
+    OCIO_CHECK_ASSERT( testresult == foo_result );
 }
 
 #endif // OCIO_BUILD_TESTS

--- a/src/OpenColorIO/Platform.cpp
+++ b/src/OpenColorIO/Platform.cpp
@@ -137,112 +137,112 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(Platform, getenv)
+OCIO_ADD_TEST(Platform, getenv)
 {
     std::string env;
     OCIO::Platform::Getenv("NotExistingEnvVariable", env);
-    OIIO_CHECK_ASSERT(env.empty());
+    OCIO_CHECK_ASSERT(env.empty());
 
     OCIO::Platform::Getenv("PATH", env);
-    OIIO_CHECK_ASSERT(!env.empty());
+    OCIO_CHECK_ASSERT(!env.empty());
 
     OCIO::Platform::Getenv("NotExistingEnvVariable", env);
-    OIIO_CHECK_ASSERT(env.empty());
+    OCIO_CHECK_ASSERT(env.empty());
 
     OCIO::Platform::Getenv("PATH", env);
-    OIIO_CHECK_ASSERT(!env.empty());
+    OCIO_CHECK_ASSERT(!env.empty());
 }
 
-OIIO_ADD_TEST(Platform, putenv)
+OCIO_ADD_TEST(Platform, putenv)
 {
     {
         const std::string value("MY_DUMMY_ENV=SomeValue");
         ::putenv(const_cast<char*>(value.c_str()));
         std::string env;
         OCIO::Platform::Getenv("MY_DUMMY_ENV", env);
-        OIIO_CHECK_ASSERT(!env.empty());
+        OCIO_CHECK_ASSERT(!env.empty());
 
-        OIIO_CHECK_ASSERT(0==strcmp("SomeValue", env.c_str()));
-        OIIO_CHECK_EQUAL(strlen("SomeValue"), env.size());
+        OCIO_CHECK_ASSERT(0==strcmp("SomeValue", env.c_str()));
+        OCIO_CHECK_EQUAL(strlen("SomeValue"), env.size());
     }
     {
         const std::string value("MY_DUMMY_ENV= ");
         ::putenv(const_cast<char*>(value.c_str()));
         std::string env;
         OCIO::Platform::Getenv("MY_DUMMY_ENV", env);
-        OIIO_CHECK_ASSERT(!env.empty());
+        OCIO_CHECK_ASSERT(!env.empty());
 
-        OIIO_CHECK_ASSERT(0==strcmp(" ", env.c_str()));
-        OIIO_CHECK_EQUAL(strlen(" "), env.size());
+        OCIO_CHECK_ASSERT(0==strcmp(" ", env.c_str()));
+        OCIO_CHECK_EQUAL(strlen(" "), env.size());
     }
     {
         const std::string value("MY_DUMMY_ENV=");
         ::putenv(const_cast<char*>(value.c_str()));
         std::string env;
         OCIO::Platform::Getenv("MY_DUMMY_ENV", env);
-        OIIO_CHECK_ASSERT(env.empty());
+        OCIO_CHECK_ASSERT(env.empty());
     }
 #ifdef WINDOWS
     {
         SetEnvironmentVariable("MY_WINDOWS_DUMMY_ENV", "1");
         std::string env;
         OCIO::Platform::Getenv("MY_WINDOWS_DUMMY_ENV", env);
-        OIIO_CHECK_EQUAL(env, std::string("1"));
+        OCIO_CHECK_EQUAL(env, std::string("1"));
     }
     {
         SetEnvironmentVariable("MY_WINDOWS_DUMMY_ENV", " ");
         std::string env;
         OCIO::Platform::Getenv("MY_WINDOWS_DUMMY_ENV", env);
-        OIIO_CHECK_EQUAL(env, std::string(" "));
+        OCIO_CHECK_EQUAL(env, std::string(" "));
     }
     {
         SetEnvironmentVariable("MY_WINDOWS_DUMMY_ENV", "");
         std::string env;
         OCIO::Platform::Getenv("MY_WINDOWS_DUMMY_ENV", env);
-        OIIO_CHECK_ASSERT(env.empty());
+        OCIO_CHECK_ASSERT(env.empty());
     }
 #endif
 }
 
-OIIO_ADD_TEST(Platform, string_compare)
+OCIO_ADD_TEST(Platform, string_compare)
 {
-    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp("TtOoPp", "TtOoPp"));
-    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp("TtOoPp", "ttOoPp"));
-    OIIO_CHECK_NE(0, OCIO::Platform::Strcasecmp("TtOoPp", "tOoPp"));
-    OIIO_CHECK_NE(0, OCIO::Platform::Strcasecmp("TtOoPp", "TtOoPp1"));
+    OCIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp("TtOoPp", "TtOoPp"));
+    OCIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp("TtOoPp", "ttOoPp"));
+    OCIO_CHECK_NE(0, OCIO::Platform::Strcasecmp("TtOoPp", "tOoPp"));
+    OCIO_CHECK_NE(0, OCIO::Platform::Strcasecmp("TtOoPp", "TtOoPp1"));
 
-    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strncasecmp("TtOoPp", "TtOoPp", 2));
-    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strncasecmp("TtOoPp", "ttOoPp", 2));
-    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strncasecmp("TtOoPp", "ttOOOO", 2));
-    OIIO_CHECK_NE(0, OCIO::Platform::Strcasecmp("TtOoPp", "tOoPp"));
-    OIIO_CHECK_NE(0, OCIO::Platform::Strcasecmp("TtOoPp", "TOoPp"));
+    OCIO_CHECK_EQUAL(0, OCIO::Platform::Strncasecmp("TtOoPp", "TtOoPp", 2));
+    OCIO_CHECK_EQUAL(0, OCIO::Platform::Strncasecmp("TtOoPp", "ttOoPp", 2));
+    OCIO_CHECK_EQUAL(0, OCIO::Platform::Strncasecmp("TtOoPp", "ttOOOO", 2));
+    OCIO_CHECK_NE(0, OCIO::Platform::Strcasecmp("TtOoPp", "tOoPp"));
+    OCIO_CHECK_NE(0, OCIO::Platform::Strcasecmp("TtOoPp", "TOoPp"));
 }
 
-OIIO_ADD_TEST(Platform, aligned_memory_test)
+OCIO_ADD_TEST(Platform, aligned_memory_test)
 {
     size_t alignement = 16u;
     void* memBlock = OCIO::Platform::AlignedMalloc(1001, alignement);
 
-    OIIO_CHECK_ASSERT(memBlock);
-    OIIO_CHECK_EQUAL(((uintptr_t)memBlock) % alignement, 0);
+    OCIO_CHECK_ASSERT(memBlock);
+    OCIO_CHECK_EQUAL(((uintptr_t)memBlock) % alignement, 0);
 
     OCIO::Platform::AlignedFree(memBlock);
 }
 
 
-OIIO_ADD_TEST(Platform, CreateTempFilename)
+OCIO_ADD_TEST(Platform, CreateTempFilename)
 {
     std::string f1, f2;
 
-    OIIO_CHECK_NO_THROW(OCIO::Platform::CreateTempFilename(f1, ""));
-    OIIO_CHECK_NO_THROW(OCIO::Platform::CreateTempFilename(f2, ""));
-    OIIO_CHECK_ASSERT(f1!=f2);
+    OCIO_CHECK_NO_THROW(OCIO::Platform::CreateTempFilename(f1, ""));
+    OCIO_CHECK_NO_THROW(OCIO::Platform::CreateTempFilename(f2, ""));
+    OCIO_CHECK_ASSERT(f1!=f2);
 
-    OIIO_CHECK_NO_THROW(OCIO::Platform::CreateTempFilename(f1, ".ctf"));
-    OIIO_CHECK_NO_THROW(OCIO::Platform::CreateTempFilename(f2, ".ctf"));
-    OIIO_CHECK_ASSERT(f1!=f2);
+    OCIO_CHECK_NO_THROW(OCIO::Platform::CreateTempFilename(f1, ".ctf"));
+    OCIO_CHECK_NO_THROW(OCIO::Platform::CreateTempFilename(f2, ".ctf"));
+    OCIO_CHECK_ASSERT(f1!=f2);
 }
 
 #endif // OCIO_UNIT_TEST

--- a/src/OpenColorIO/Processor.cpp
+++ b/src/OpenColorIO/Processor.cpp
@@ -578,9 +578,9 @@ OCIO_NAMESPACE_EXIT
 
 namespace OCIO = OCIO_NAMESPACE;
 #include "ops/exposurecontrast/ExposureContrastOps.h"
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(Processor, shared_dynamic_properties)
+OCIO_ADD_TEST(Processor, shared_dynamic_properties)
 {
     OCIO::TransformDirection direction = OCIO::TRANSFORM_DIR_FORWARD;
     OCIO::ExposureContrastOpDataRcPtr data =
@@ -591,16 +591,16 @@ OIIO_ADD_TEST(Processor, shared_dynamic_properties)
     data->getExposureProperty()->makeDynamic();
 
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_REQUIRE_ASSERT(ops[0]);
+    OCIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_ASSERT(ops[0]);
 
     data = data->clone();
     data->setExposure(2.2);
 
-    OIIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_REQUIRE_ASSERT(ops[1]);
+    OCIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_ASSERT(ops[1]);
 
     OCIO::ConstOpRcPtr op0 = ops[0];
     OCIO::ConstOpRcPtr op1 = ops[1];
@@ -611,20 +611,20 @@ OIIO_ADD_TEST(Processor, shared_dynamic_properties)
     OCIO::DynamicPropertyImplRcPtr dp0 = data0->getExposureProperty();
     OCIO::DynamicPropertyImplRcPtr dp1 = data1->getExposureProperty();
 
-    OIIO_CHECK_NE(dp0->getDoubleValue(), dp1->getDoubleValue());
+    OCIO_CHECK_NE(dp0->getDoubleValue(), dp1->getDoubleValue());
 
     OCIO::UnifyDynamicProperties(ops);
 
     OCIO::DynamicPropertyImplRcPtr dp0_post = data0->getExposureProperty();
     OCIO::DynamicPropertyImplRcPtr dp1_post = data1->getExposureProperty();
 
-    OIIO_CHECK_EQUAL(dp0_post->getDoubleValue(), dp1_post->getDoubleValue());
+    OCIO_CHECK_EQUAL(dp0_post->getDoubleValue(), dp1_post->getDoubleValue());
 
     // Both share the same pointer.
-    OIIO_CHECK_EQUAL(dp0_post.get(), dp1_post.get());
+    OCIO_CHECK_EQUAL(dp0_post.get(), dp1_post.get());
 
     // The first pointer is the one that gets shared.
-    OIIO_CHECK_EQUAL(dp0.get(), dp0_post.get());
+    OCIO_CHECK_EQUAL(dp0.get(), dp0_post.get());
 }
 
 #endif

--- a/src/OpenColorIO/SSE.cpp
+++ b/src/OpenColorIO/SSE.cpp
@@ -40,12 +40,12 @@ namespace OCIO = OCIO_NAMESPACE;
 
 #include "MathUtils.h"
 #include "SSE.h"
-#include "unittest.h"
+#include "UnitTest.h"
 
 
 OCIO_NAMESPACE_USING
 
-OIIO_ADD_TEST(SSE, sse2_log2_test)
+OCIO_ADD_TEST(SSE, sse2_log2_test)
 {
     const float values[8] = { 1e-010f, .1f, .5f, 1.f,
                               11.f, 112.f, 2425.f, 2e015f };
@@ -64,7 +64,7 @@ OIIO_ADD_TEST(SSE, sse2_log2_test)
         mm_sseResult = OCIO::sseLog2(_mm_set1_ps(values[i]));
         _mm_storeu_ps(sseResult, mm_sseResult);
 
-        OIIO_CHECK_CLOSE(cpuResult, sseResult[0], rtol);
+        OCIO_CHECK_CLOSE(cpuResult, sseResult[0], rtol);
     }
 }
 
@@ -97,7 +97,7 @@ void CheckFloat(const std::string& operation,
     }
 
     const float rtol = powf(2.f, -((float)precision));
-    OIIO_CHECK_ASSERT_MESSAGE(OCIO::EqualWithAbsError(expected, actual, rtol),
+    OCIO_CHECK_ASSERT_MESSAGE(OCIO::EqualWithAbsError(expected, actual, rtol),
                               GetErrorMessage(operation, expected, actual));
 }
 
@@ -128,7 +128,7 @@ void CheckPower(const float base, const float exponent)
     CheckSSE(operation, cpuResult, sseResult, 12);
 }
 
-OIIO_ADD_TEST(SSE, sse2_power_test)
+OCIO_ADD_TEST(SSE, sse2_power_test)
 {
     const float values[] = {
         1e-010f, .1f, .5f, 1.f,
@@ -213,7 +213,7 @@ std::string GetErrorMessage(const std::string& operation, const float expected, 
     return oss.str();
 }
 
-OIIO_ADD_TEST(SSE, sse2_exp2_test)
+OCIO_ADD_TEST(SSE, sse2_exp2_test)
 {
     const unsigned ulp_tolerance = 50;
 
@@ -235,7 +235,7 @@ OIIO_ADD_TEST(SSE, sse2_exp2_test)
         const float expected = powf(2.0f, values[i]);
 
         EvaluateExp2(values[i], sseResult);
-        OIIO_CHECK_ASSERT_MESSAGE(AreAllClose(sseResult, expected, ulp_tolerance),
+        OCIO_CHECK_ASSERT_MESSAGE(AreAllClose(sseResult, expected, ulp_tolerance),
                                   GetErrorMessage(GetOperation("exp2", values[i]), expected, sseResult));
     }
 
@@ -245,7 +245,7 @@ OIIO_ADD_TEST(SSE, sse2_exp2_test)
         const float expected = powf(2.0f, -values[i]);
 
         EvaluateExp2(-values[i], sseResult);
-        OIIO_CHECK_ASSERT_MESSAGE(AreAllClose(sseResult, expected, ulp_tolerance),
+        OCIO_CHECK_ASSERT_MESSAGE(AreAllClose(sseResult, expected, ulp_tolerance),
                                   GetErrorMessage(GetOperation("exp2", -values[i]), expected, sseResult));
     }
 
@@ -262,10 +262,10 @@ OIIO_ADD_TEST(SSE, sse2_exp2_test)
     // Check the log2_max_float and log2_min_float limits
     {
         EvaluateExp2(log2_max_float, sseResult);
-        OIIO_CHECK_ASSERT(AreAllInfinity(sseResult));
+        OCIO_CHECK_ASSERT(AreAllInfinity(sseResult));
 
         EvaluateExp2(log2_min_float, sseResult);
-        OIIO_CHECK_ASSERT(AreAllZero(sseResult));
+        OCIO_CHECK_ASSERT(AreAllZero(sseResult));
     }
 
     // The valid domain of exp2 is actually reduced by one ULP
@@ -282,7 +282,7 @@ OIIO_ADD_TEST(SSE, sse2_exp2_test)
         const float large_threshold = (float)pow(2.0, (double)AddULP(log2_max_float, -2));
 
         EvaluateExp2(log2_max_float_inside_one_ulp, sseResult);
-        OIIO_CHECK_ASSERT(AreAllInRange(sseResult, large_threshold, 
+        OCIO_CHECK_ASSERT(AreAllInRange(sseResult, large_threshold, 
                                         std::numeric_limits<float>::infinity()));
 
         // The result should be a small number, but not zero
@@ -290,7 +290,7 @@ OIIO_ADD_TEST(SSE, sse2_exp2_test)
         const float small_threshold = (float)pow(2.0, (double)AddULP(log2_min_float, -2));
 
         EvaluateExp2(log2_min_float_inside_one_ulp, sseResult);
-        OIIO_CHECK_ASSERT(AreAllInRange(sseResult, 0.0f, small_threshold));
+        OCIO_CHECK_ASSERT(AreAllInRange(sseResult, 0.0f, small_threshold));
     }
 
     // Verify that the log2_max_float and log2_min_float limits, expanded by one ULP,
@@ -303,10 +303,10 @@ OIIO_ADD_TEST(SSE, sse2_exp2_test)
     const float log2_min_float_outside_one_ulp = AddULP(log2_min_float, 1);
     {
         EvaluateExp2(log2_max_float_outside_one_ulp, sseResult);
-        OIIO_CHECK_ASSERT(AreAllInfinity(sseResult));
+        OCIO_CHECK_ASSERT(AreAllInfinity(sseResult));
 
         EvaluateExp2(log2_min_float_outside_one_ulp, sseResult);
-        OIIO_CHECK_ASSERT(AreAllZero(sseResult));
+        OCIO_CHECK_ASSERT(AreAllZero(sseResult));
     }
 }
 
@@ -316,7 +316,7 @@ void EvaluateAtan(const float x, float* result)
     _mm_storeu_ps(result, mm_sseResult);
 }
 
-OIIO_ADD_TEST(SSE, sse2_atan_test)
+OCIO_ADD_TEST(SSE, sse2_atan_test)
 {
     const float sign_values[] = { -1.0f, 1.0f };
 
@@ -353,7 +353,7 @@ OIIO_ADD_TEST(SSE, sse2_atan_test)
     }
 }
 
-OIIO_ADD_TEST(SSE, scalar_atan_test)
+OCIO_ADD_TEST(SSE, scalar_atan_test)
 {
     const float sign_values[] = { -1.0f, 1.0f };
 
@@ -394,7 +394,7 @@ void EvaluateAtan2(const float y, const float x, float* result)
     _mm_storeu_ps(result, mm_sseResult);
 }
 
-OIIO_ADD_TEST(SSE, sse2_atan2_test)
+OCIO_ADD_TEST(SSE, sse2_atan2_test)
 {
     const float sign_values[] = { -1.0f, 1.0f };
 
@@ -449,7 +449,7 @@ OIIO_ADD_TEST(SSE, sse2_atan2_test)
     }
 }
 
-OIIO_ADD_TEST(SSE, scalar_atan2_test)
+OCIO_ADD_TEST(SSE, scalar_atan2_test)
 {
     const float sign_values[] = { -1.0f, 1.0f };
 
@@ -508,7 +508,7 @@ void EvaluateCos(const float x, float* result)
     _mm_storeu_ps(result, mm_sseResult);
 }
 
-OIIO_ADD_TEST(SSE, sse2_cos_test)
+OCIO_ADD_TEST(SSE, sse2_cos_test)
 {
     const float sign_values[] = { -1.0f, 1.0f };
 
@@ -556,7 +556,7 @@ void EvaluateSin(const float x, float* result)
     _mm_storeu_ps(result, mm_sseResult);
 }
 
-OIIO_ADD_TEST(SSE, sse2_sin_test)
+OCIO_ADD_TEST(SSE, sse2_sin_test)
 {
     const float sign_values[] = { -1.0f, 1.0f };
 
@@ -606,7 +606,7 @@ void EvaluateSinCos(const float x, float* resultSin, float* resultCos)
     _mm_storeu_ps(resultCos, sseResultCos);
 }
 
-OIIO_ADD_TEST(SSE, sse2_sin_cos_test)
+OCIO_ADD_TEST(SSE, sse2_sin_cos_test)
 {
     const float sign_values[] = { -1.0f, 1.0f };
 
@@ -651,7 +651,7 @@ OIIO_ADD_TEST(SSE, sse2_sin_cos_test)
     }
 }
 
-OIIO_ADD_TEST(SSE, scalar_sin_cos_test)
+OCIO_ADD_TEST(SSE, scalar_sin_cos_test)
 {
     const float sign_values[] = { -1.0f, 1.0f };
 

--- a/src/OpenColorIO/UnitTest.cpp
+++ b/src/OpenColorIO/UnitTest.cpp
@@ -32,8 +32,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma GCC visibility push(default)
 #endif
 
-#include <unittest.h> // OIIO unit tests header
-OIIO_TEST_APP(OpenColorIO_Core_Unit_Tests)
+#include "UnitTest.h" // OIIO unit tests header
+OCIO_TEST_APP(OpenColorIO_Core_Unit_Tests)
 
 #ifndef WIN32
 #pragma GCC visibility pop

--- a/src/OpenColorIO/UnitTest.h
+++ b/src/OpenColorIO/UnitTest.h
@@ -28,8 +28,8 @@
   (This is the Modified BSD License)
 */
 
-#ifndef OPENCOLORIO_UNITTEST_H
-#define OPENCOLORIO_UNITTEST_H
+#ifndef INCLUDED_OCIO_UNITTEST_H
+#define INCLUDED_OCIO_UNITTEST_H
 
 #include <iostream>
 #include <cmath>
@@ -41,68 +41,68 @@ extern int unit_test_failures;
 
 void unittest_fail();
 
-typedef void (*OIIOTestFunc)();
+typedef void (*OCIOTestFunc)();
 
-struct OIIOTest
+struct OCIOTest
 {
-    OIIOTest(std::string testgroup, std::string testname, OIIOTestFunc test) :
+    OCIOTest(std::string testgroup, std::string testname, OCIOTestFunc test) :
         group(testgroup), name(testname), function(test) { };
     std::string group, name;
-    OIIOTestFunc function;
+    OCIOTestFunc function;
 };
 
-typedef std::vector<OIIOTest*> UnitTests;
+typedef std::vector<OCIOTest*> UnitTests;
 
 UnitTests& GetUnitTests();
 
-struct AddTest { AddTest(OIIOTest* test); };
+struct AddTest { AddTest(OCIOTest* test); };
 
-/// OIIO_CHECK_* macros checks if the conditions is met, and if not,
+/// OCIO_CHECK_* macros checks if the conditions is met, and if not,
 /// prints an error message indicating the module and line where the
 /// error occurred, but does NOT abort.  This is helpful for unit tests
 /// where we do not want one failure.
 /// 
-/// OIIO_REQUIRE_* macros checks if the conditions is met, and if not,
+/// OCIO_REQUIRE_* macros checks if the conditions is met, and if not,
 /// prints an error message indicating the module and line where the
 /// error occurred, but does abort.  This is helpful for unit tests
 /// where we have to fail as following code would be not testable.
 /// 
-#define OIIO_CHECK_ASSERT(x)                                            \
+#define OCIO_CHECK_ASSERT(x)                                            \
     ((x) ? ((void)0)                                                    \
          : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
                        << "FAILED: " << #x << "\n"),                    \
             (void)++unit_test_failures))
 
-#define OIIO_REQUIRE_ASSERT(x)                                          \
+#define OCIO_REQUIRE_ASSERT(x)                                          \
     if(!(x)) {                                                          \
         std::stringstream ss;                                           \
         ss <<  __FILE__ << ":" << __LINE__ << ":\n"                     \
            << "FAILED: " << #x << "\n";                                 \
         throw OCIO_NAMESPACE::Exception(ss.str().c_str()); }
 
-#define OIIO_CHECK_ASSERT_MESSAGE(x, M)                                 \
+#define OCIO_CHECK_ASSERT_MESSAGE(x, M)                                 \
     ((x) ? ((void)0)                                                    \
          : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
                        << "FAILED: " << M << "\n"),                     \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_EQUAL(x,y) OIIO_CHECK_EQUAL_FROM(x,y,__LINE__)
+#define OCIO_CHECK_EQUAL(x,y) OCIO_CHECK_EQUAL_FROM(x,y,__LINE__)
 
-// When using OIIO_CHECK_EQUAL in an helper method used by one or more
+// When using OCIO_CHECK_EQUAL in an helper method used by one or more
 // unit tests, the error message indicates the helper method line number
 // and not the unit test line number.
 // 
-// Use OIIO_CHECK_EQUAL_FROM to propagate the right line number
+// Use OCIO_CHECK_EQUAL_FROM to propagate the right line number
 // to the error message.
 // 
-#define OIIO_CHECK_EQUAL_FROM(x,y,line)                                 \
+#define OCIO_CHECK_EQUAL_FROM(x,y,line)                                 \
     (((x) == (y)) ? ((void)0)                                           \
          : ((std::cout << __FILE__ << ":" << line << ":\n"          \
              << "FAILED: " << #x << " == " << #y << "\n"                \
              << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
             (void)++unit_test_failures))
 
-#define OIIO_REQUIRE_EQUAL(x,y)                                         \
+#define OCIO_REQUIRE_EQUAL(x,y)                                         \
     if((x)!=(y)) {                                                      \
         std::stringstream ss;                                           \
         ss <<  __FILE__ << ":" << __LINE__ << ":\n"                     \
@@ -110,51 +110,51 @@ struct AddTest { AddTest(OIIOTest* test); };
            << "\tvalues were '" << (x) << "' and '" << (y) << "'\n";    \
         throw OCIO_NAMESPACE::Exception(ss.str().c_str()); }
 
-#define OIIO_CHECK_NE(x,y)                                              \
+#define OCIO_CHECK_NE(x,y)                                              \
     (((x) != (y)) ? ((void)0)                                           \
          : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
              << "FAILED: " << #x << " != " << #y << "\n"                \
              << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_LT(x,y)                                              \
+#define OCIO_CHECK_LT(x,y)                                              \
     (((x) < (y)) ? ((void)0)                                            \
          : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
              << "FAILED: " << #x << " < " << #y << "\n"                 \
              << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_GT(x,y)                                              \
+#define OCIO_CHECK_GT(x,y)                                              \
     (((x) > (y)) ? ((void)0)                                            \
          : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
              << "FAILED: " << #x << " > " << #y << "\n"                 \
              << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_LE(x,y)                                              \
+#define OCIO_CHECK_LE(x,y)                                              \
     (((x) <= (y)) ? ((void)0)                                           \
          : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
              << "FAILED: " << #x << " <= " << #y << "\n"                \
              << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_GE(x,y)                                              \
+#define OCIO_CHECK_GE(x,y)                                              \
     (((x) >= (y)) ? ((void)0)                                           \
          : ((std::cout << __FILE__ << ":" << __LINE__ << ":\n"          \
              << "FAILED: " << #x << " >= " << #y << "\n"                \
              << "\tvalues were '" << (x) << "' and '" << (y) << "'\n"), \
             (void)++unit_test_failures))
 
-#define OIIO_CHECK_CLOSE(x,y,tol) OIIO_CHECK_CLOSE_FROM(x,y,tol,__LINE__)
+#define OCIO_CHECK_CLOSE(x,y,tol) OCIO_CHECK_CLOSE_FROM(x,y,tol,__LINE__)
 
-// When using OIIO_CHECK_CLOSE in an helper method used by one or more
+// When using OCIO_CHECK_CLOSE in an helper method used by one or more
 // unit tests, the error message indicates the helper method line number
 // and not the unit test line number.
 // 
-// Use OIIO_CHECK_CLOSE_FROM to propagate the right line number
+// Use OCIO_CHECK_CLOSE_FROM to propagate the right line number
 // to the error message.
 // 
-#define OIIO_CHECK_CLOSE_FROM(x,y,tol,line)                             \
+#define OCIO_CHECK_CLOSE_FROM(x,y,tol,line)                             \
     ((std::abs((x) - (y)) < (tol)) ? ((void)0)                          \
          : ((std::cout << std::setprecision(10)                         \
              << __FILE__ << ":" << line << ":\n"                        \
@@ -163,7 +163,7 @@ struct AddTest { AddTest(OIIOTest* test); };
              << "\tvalues were '" << (x) << "', '" << (y) << "' and '"  \
              << (tol) << "'\n"), (void)++unit_test_failures))
 
-#define OIIO_CHECK_THROW(S, E)                                          \
+#define OCIO_CHECK_THROW(S, E)                                          \
     try { S; throw "throwanything"; } catch( E const& ) { } catch (...) { \
         std::cout << __FILE__ << ":" << __LINE__ << ":\n"               \
         << "FAILED: " << #E << " is expected to be thrown\n";           \
@@ -172,7 +172,7 @@ struct AddTest { AddTest(OIIOTest* test); };
 /// Check that an exception E is thrown and that what() contains W
 /// When a function can throw different exceptions this can be used
 /// to verify that the right one is thrown.
-#define OIIO_CHECK_THROW_WHAT(S, E, W)                                  \
+#define OCIO_CHECK_THROW_WHAT(S, E, W)                                  \
     try { S; throw "throwanything"; } catch (E const& ex) {             \
         const std::string what(ex.what());                              \
         if (std::string(W).empty() || what.empty()                      \
@@ -187,7 +187,7 @@ struct AddTest { AddTest(OIIOTest* test); };
         << "FAILED: " << #E << " is expected to be thrown\n";           \
         ++unit_test_failures; }
 
-#define OIIO_CHECK_NO_THROW(S)                                          \
+#define OCIO_CHECK_NO_THROW(S)                                          \
     try {                                                               \
         S;                                                              \
     } catch (std::exception & ex ) {                                    \
@@ -200,20 +200,20 @@ struct AddTest { AddTest(OIIOTest* test); };
         << "FAILED: exception thrown from " << #S <<"\n";               \
         ++unit_test_failures; }
 
-#define OIIO_ADD_TEST(group, name)                                      \
-    static void oiiotest_##group##_##name();                            \
-    AddTest oiioaddtest_##group##_##name(new OIIOTest(#group, #name, oiiotest_##group##_##name)); \
-    static void oiiotest_##group##_##name()
+#define OCIO_ADD_TEST(group, name)                                      \
+    static void ociotest_##group##_##name();                            \
+    AddTest oiioaddtest_##group##_##name(new OCIOTest(#group, #name, ociotest_##group##_##name)); \
+    static void ociotest_##group##_##name()
 
-#define OIIO_TEST_SETUP() \
+#define OCIO_TEST_SETUP() \
     int unit_test_failures = 0
 
-#define OIIO_TEST_APP(app)                                              \
-    std::vector<OIIOTest*>& GetUnitTests() {                            \
-        static std::vector<OIIOTest*> oiio_unit_tests;                  \
+#define OCIO_TEST_APP(app)                                              \
+    std::vector<OCIOTest*>& GetUnitTests() {                            \
+        static std::vector<OCIOTest*> oiio_unit_tests;                  \
         return oiio_unit_tests; }                                       \
-    AddTest::AddTest(OIIOTest* test){GetUnitTests().push_back(test);};  \
-    OIIO_TEST_SETUP();                                                  \
+    AddTest::AddTest(OCIOTest* test){GetUnitTests().push_back(test);};  \
+    OCIO_TEST_SETUP();                                                  \
     int main(int, char **) { std::cerr << "\n" << #app <<"\n\n";        \
         const size_t numTests = GetUnitTests().size();                  \
         for(size_t i = 0; i < numTests; ++i) {                          \
@@ -235,4 +235,4 @@ struct AddTest { AddTest(OIIOTest* test); };
         std::cerr << "\n" << unit_test_failures << " tests failed\n\n"; \
         return unit_test_failures; }
 
-#endif /* OPENCOLORIO_UNITTEST_H */
+#endif /* INCLUDED_OCIO_UNITTEST_H */

--- a/src/OpenColorIO/fileformats/FileFormat3DL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormat3DL.cpp
@@ -653,7 +653,7 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
 OCIO::LocalCachedFileRcPtr LoadLutFile(const std::string & fileName)
@@ -662,24 +662,24 @@ OCIO::LocalCachedFileRcPtr LoadLutFile(const std::string & fileName)
         fileName, std::ios_base::in);
 }
 
-OIIO_ADD_TEST(FileFormat3DL, FormatInfo)
+OCIO_ADD_TEST(FileFormat3DL, FormatInfo)
 {
     OCIO::FormatInfoVec formatInfoVec;
     OCIO::LocalFileFormat tester;
     tester.GetFormatInfo(formatInfoVec);
 
-    OIIO_CHECK_EQUAL(2, formatInfoVec.size());
-    OIIO_CHECK_EQUAL("flame", formatInfoVec[0].name);
-    OIIO_CHECK_EQUAL("lustre", formatInfoVec[1].name);
-    OIIO_CHECK_EQUAL("3dl", formatInfoVec[0].extension);
-    OIIO_CHECK_EQUAL("3dl", formatInfoVec[1].extension);
-    OIIO_CHECK_EQUAL((OCIO::FORMAT_CAPABILITY_READ
+    OCIO_CHECK_EQUAL(2, formatInfoVec.size());
+    OCIO_CHECK_EQUAL("flame", formatInfoVec[0].name);
+    OCIO_CHECK_EQUAL("lustre", formatInfoVec[1].name);
+    OCIO_CHECK_EQUAL("3dl", formatInfoVec[0].extension);
+    OCIO_CHECK_EQUAL("3dl", formatInfoVec[1].extension);
+    OCIO_CHECK_EQUAL((OCIO::FORMAT_CAPABILITY_READ
         | OCIO::FORMAT_CAPABILITY_WRITE), formatInfoVec[0].capabilities);
-    OIIO_CHECK_EQUAL((OCIO::FORMAT_CAPABILITY_READ
+    OCIO_CHECK_EQUAL((OCIO::FORMAT_CAPABILITY_READ
         | OCIO::FORMAT_CAPABILITY_WRITE), formatInfoVec[1].capabilities);
 }
 
-OIIO_ADD_TEST(FileFormat3DL, Bake)
+OCIO_ADD_TEST(FileFormat3DL, Bake)
 {
 
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
@@ -713,13 +713,13 @@ OIIO_ADD_TEST(FileFormat3DL, Bake)
     baker->bake(outputFlame);
 
     std::vector<std::string> osvecFlame;
-    OCIO::pystring::splitlines(outputFlame.str(), osvecFlame);
+    pystring::splitlines(outputFlame.str(), osvecFlame);
 
     std::ostringstream outputLustre;
     baker->setFormat("lustre");
     baker->bake(outputLustre);
     std::vector<std::string> osvecLustre;
-    OCIO::pystring::splitlines(outputLustre.str(), osvecLustre);
+    pystring::splitlines(outputLustre.str(), osvecLustre);
 
     std::ostringstream bout;
     bout << "3DMESH" << "\n";
@@ -738,20 +738,20 @@ OIIO_ADD_TEST(FileFormat3DL, Bake)
     bout << "gamma 1.0" << "\n";
 
     std::vector<std::string> resvec;
-    OCIO::pystring::splitlines(bout.str(), resvec);
-    OIIO_CHECK_EQUAL(resvec.size(), osvecLustre.size());
-    OIIO_CHECK_EQUAL(resvec.size() - 4, osvecFlame.size());
+    pystring::splitlines(bout.str(), resvec);
+    OCIO_CHECK_EQUAL(resvec.size(), osvecLustre.size());
+    OCIO_CHECK_EQUAL(resvec.size() - 4, osvecFlame.size());
 
-    OIIO_CHECK_EQUAL(resvec[0], osvecLustre[0]);
-    OIIO_CHECK_EQUAL(resvec[1], osvecLustre[1]);
+    OCIO_CHECK_EQUAL(resvec[0], osvecLustre[0]);
+    OCIO_CHECK_EQUAL(resvec[1], osvecLustre[1]);
     for (unsigned int i = 0; i < osvecFlame.size(); ++i)
     {
-        OIIO_CHECK_EQUAL(resvec[i+2], osvecFlame[i]);
-        OIIO_CHECK_EQUAL(resvec[i+2], osvecLustre[i+2]);
+        OCIO_CHECK_EQUAL(resvec[i+2], osvecFlame[i]);
+        OCIO_CHECK_EQUAL(resvec[i+2], osvecLustre[i+2]);
     }
     size_t last = resvec.size() - 2;
-    OIIO_CHECK_EQUAL(resvec[last], osvecLustre[last]);
-    OIIO_CHECK_EQUAL(resvec[last+1], osvecLustre[last+1]);
+    OCIO_CHECK_EQUAL(resvec[last], osvecLustre[last]);
+    OCIO_CHECK_EQUAL(resvec[last+1], osvecLustre[last+1]);
 
 
 }
@@ -763,69 +763,69 @@ OIIO_ADD_TEST(FileFormat3DL, Bake)
 // 14-bit    16383           [8192, 32767]
 // 16-bit    65535           [32768, 131071]
 
-OIIO_ADD_TEST(FileFormat3DL, GetLikelyLutBitDepth)
+OCIO_ADD_TEST(FileFormat3DL, GetLikelyLutBitDepth)
 {
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(-1), -1);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(-1), -1);
     
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(0), 8);
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(1), 8);
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(255), 8);
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(256), 8);
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(511), 8);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(0), 8);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(1), 8);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(255), 8);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(256), 8);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(511), 8);
     
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(512), 10);
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(1023), 10);
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(1024), 10);
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(2047), 10);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(512), 10);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(1023), 10);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(1024), 10);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(2047), 10);
     
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(2048), 12);
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(4095), 12);
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(4096), 12);
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(8191), 12);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(2048), 12);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(4095), 12);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(4096), 12);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(8191), 12);
     
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(16383), 14);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(16383), 14);
     
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(65535), 16);
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(65536), 16);
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(131071), 16);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(65535), 16);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(65536), 16);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(131071), 16);
     
-    OIIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(131072), 16);
+    OCIO_CHECK_EQUAL(OCIO::GetLikelyLutBitDepth(131072), 16);
 }
 
 
-OIIO_ADD_TEST(FileFormat3DL, TestLoad)
+OCIO_ADD_TEST(FileFormat3DL, TestLoad)
 {
     // Discreet 3D LUT file
     const std::string discree3DtLut("discreet-3d-lut.3dl");
 
     OCIO::LocalCachedFileRcPtr lutFile;
-    OIIO_CHECK_NO_THROW(lutFile = LoadLutFile(discree3DtLut));
+    OCIO_CHECK_NO_THROW(lutFile = LoadLutFile(discree3DtLut));
 
-    OIIO_CHECK_ASSERT(lutFile->has1D);
-    OIIO_CHECK_ASSERT(lutFile->has3D);
-    OIIO_CHECK_EQUAL(OCIO::Lut1D::ERROR_ABSOLUTE, lutFile->lut1D->errortype);
-    OIIO_CHECK_EQUAL(0.00195503421f, lutFile->lut1D->maxerror);
-    OIIO_CHECK_EQUAL(0.0f, lutFile->lut1D->from_min[1]);
-    OIIO_CHECK_EQUAL(1.0f, lutFile->lut1D->from_max[1]);
-    OIIO_CHECK_EQUAL(17, lutFile->lut1D->luts[0].size());
-    OIIO_CHECK_EQUAL(0.0f, lutFile->lut1D->luts[0][0]);
-    OIIO_CHECK_EQUAL(0.563049853f, lutFile->lut1D->luts[0][9]);
-    OIIO_CHECK_EQUAL(1.0f, lutFile->lut1D->luts[0][16]);
-    OIIO_CHECK_EQUAL(17, lutFile->lut3D->size[0]);
-    OIIO_CHECK_EQUAL(17, lutFile->lut3D->size[1]);
-    OIIO_CHECK_EQUAL(17, lutFile->lut3D->size[2]);
-    OIIO_CHECK_EQUAL(17*17*17*3, lutFile->lut3D->lut.size());
+    OCIO_CHECK_ASSERT(lutFile->has1D);
+    OCIO_CHECK_ASSERT(lutFile->has3D);
+    OCIO_CHECK_EQUAL(OCIO::Lut1D::ERROR_ABSOLUTE, lutFile->lut1D->errortype);
+    OCIO_CHECK_EQUAL(0.00195503421f, lutFile->lut1D->maxerror);
+    OCIO_CHECK_EQUAL(0.0f, lutFile->lut1D->from_min[1]);
+    OCIO_CHECK_EQUAL(1.0f, lutFile->lut1D->from_max[1]);
+    OCIO_CHECK_EQUAL(17, lutFile->lut1D->luts[0].size());
+    OCIO_CHECK_EQUAL(0.0f, lutFile->lut1D->luts[0][0]);
+    OCIO_CHECK_EQUAL(0.563049853f, lutFile->lut1D->luts[0][9]);
+    OCIO_CHECK_EQUAL(1.0f, lutFile->lut1D->luts[0][16]);
+    OCIO_CHECK_EQUAL(17, lutFile->lut3D->size[0]);
+    OCIO_CHECK_EQUAL(17, lutFile->lut3D->size[1]);
+    OCIO_CHECK_EQUAL(17, lutFile->lut3D->size[2]);
+    OCIO_CHECK_EQUAL(17*17*17*3, lutFile->lut3D->lut.size());
     // LUT is R fast, file is B fast ([3..5] is [867..869] in file)
-    OIIO_CHECK_EQUAL(0.00854700897f, lutFile->lut3D->lut[3]);
-    OIIO_CHECK_EQUAL(0.00244200253f, lutFile->lut3D->lut[4]);
-    OIIO_CHECK_EQUAL(0.00708180759f, lutFile->lut3D->lut[5]);
-    OIIO_CHECK_EQUAL(0.0f, lutFile->lut3D->lut[4335]);
-    OIIO_CHECK_EQUAL(0.0368742384f, lutFile->lut3D->lut[4336]);
-    OIIO_CHECK_EQUAL(0.0705738738f, lutFile->lut3D->lut[4337]);
+    OCIO_CHECK_EQUAL(0.00854700897f, lutFile->lut3D->lut[3]);
+    OCIO_CHECK_EQUAL(0.00244200253f, lutFile->lut3D->lut[4]);
+    OCIO_CHECK_EQUAL(0.00708180759f, lutFile->lut3D->lut[5]);
+    OCIO_CHECK_EQUAL(0.0f, lutFile->lut3D->lut[4335]);
+    OCIO_CHECK_EQUAL(0.0368742384f, lutFile->lut3D->lut[4336]);
+    OCIO_CHECK_EQUAL(0.0705738738f, lutFile->lut3D->lut[4337]);
 
     const std::string discree3DtLutFail("error_truncated_file.3dl");
 
-    OIIO_CHECK_THROW_WHAT(LoadLutFile(discree3DtLutFail),
+    OCIO_CHECK_THROW_WHAT(LoadLutFile(discree3DtLutFail),
                           OCIO::Exception,
                           "Cannot infer 3D LUT size");
 

--- a/src/OpenColorIO/fileformats/FileFormat3DL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormat3DL.cpp
@@ -713,13 +713,13 @@ OCIO_ADD_TEST(FileFormat3DL, Bake)
     baker->bake(outputFlame);
 
     std::vector<std::string> osvecFlame;
-    pystring::splitlines(outputFlame.str(), osvecFlame);
+    OCIO::pystring::splitlines(outputFlame.str(), osvecFlame);
 
     std::ostringstream outputLustre;
     baker->setFormat("lustre");
     baker->bake(outputLustre);
     std::vector<std::string> osvecLustre;
-    pystring::splitlines(outputLustre.str(), osvecLustre);
+    OCIO::pystring::splitlines(outputLustre.str(), osvecLustre);
 
     std::ostringstream bout;
     bout << "3DMESH" << "\n";
@@ -738,7 +738,7 @@ OCIO_ADD_TEST(FileFormat3DL, Bake)
     bout << "gamma 1.0" << "\n";
 
     std::vector<std::string> resvec;
-    pystring::splitlines(bout.str(), resvec);
+    OCIO::pystring::splitlines(bout.str(), resvec);
     OCIO_CHECK_EQUAL(resvec.size(), osvecLustre.size());
     OCIO_CHECK_EQUAL(resvec.size() - 4, osvecFlame.size());
 

--- a/src/OpenColorIO/fileformats/FileFormatCC.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCC.cpp
@@ -157,7 +157,7 @@ OCIO_NAMESPACE_EXIT
 
 namespace OCIO = OCIO_NAMESPACE;
 
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
 OCIO::LocalCachedFileRcPtr LoadCCFile(const std::string & fileName)
@@ -166,111 +166,111 @@ OCIO::LocalCachedFileRcPtr LoadCCFile(const std::string & fileName)
         fileName, std::ios_base::in);
 }
 
-OIIO_ADD_TEST(FileFormatCC, TestCC1)
+OCIO_ADD_TEST(FileFormatCC, TestCC1)
 {
     // CC file
     const std::string fileName("cdl_test1.cc");
 
     OCIO::LocalCachedFileRcPtr ccFile;
-    OIIO_CHECK_NO_THROW(ccFile = LoadCCFile(fileName));
+    OCIO_CHECK_NO_THROW(ccFile = LoadCCFile(fileName));
 
     std::string idStr(ccFile->transform->getID());
-    OIIO_CHECK_EQUAL("foo", idStr);
+    OCIO_CHECK_EQUAL("foo", idStr);
     std::string descStr(ccFile->transform->getDescription());
-    OIIO_CHECK_EQUAL("this is a description", descStr);
+    OCIO_CHECK_EQUAL("this is a description", descStr);
     float slope[3] = { 0.f, 0.f, 0.f };
-    OIIO_CHECK_NO_THROW(ccFile->transform->getSlope(slope));
-    OIIO_CHECK_EQUAL(1.1f, slope[0]);
-    OIIO_CHECK_EQUAL(1.2f, slope[1]);
-    OIIO_CHECK_EQUAL(1.3f, slope[2]);
+    OCIO_CHECK_NO_THROW(ccFile->transform->getSlope(slope));
+    OCIO_CHECK_EQUAL(1.1f, slope[0]);
+    OCIO_CHECK_EQUAL(1.2f, slope[1]);
+    OCIO_CHECK_EQUAL(1.3f, slope[2]);
     float offset[3] = { 0.f, 0.f, 0.f };
-    OIIO_CHECK_NO_THROW(ccFile->transform->getOffset(offset));
-    OIIO_CHECK_EQUAL(2.1f, offset[0]);
-    OIIO_CHECK_EQUAL(2.2f, offset[1]);
-    OIIO_CHECK_EQUAL(2.3f, offset[2]);
+    OCIO_CHECK_NO_THROW(ccFile->transform->getOffset(offset));
+    OCIO_CHECK_EQUAL(2.1f, offset[0]);
+    OCIO_CHECK_EQUAL(2.2f, offset[1]);
+    OCIO_CHECK_EQUAL(2.3f, offset[2]);
     float power[3] = { 0.f, 0.f, 0.f };
-    OIIO_CHECK_NO_THROW(ccFile->transform->getPower(power));
-    OIIO_CHECK_EQUAL(3.1f, power[0]);
-    OIIO_CHECK_EQUAL(3.2f, power[1]);
-    OIIO_CHECK_EQUAL(3.3f, power[2]);
-    OIIO_CHECK_EQUAL(0.7f, ccFile->transform->getSat());
+    OCIO_CHECK_NO_THROW(ccFile->transform->getPower(power));
+    OCIO_CHECK_EQUAL(3.1f, power[0]);
+    OCIO_CHECK_EQUAL(3.2f, power[1]);
+    OCIO_CHECK_EQUAL(3.3f, power[2]);
+    OCIO_CHECK_EQUAL(0.7f, ccFile->transform->getSat());
 }
 
-OIIO_ADD_TEST(FileFormatCC, TestCC2)
+OCIO_ADD_TEST(FileFormatCC, TestCC2)
 {
     // CC file using windows eol.
     const std::string fileName("cdl_test2.cc");
 
     OCIO::LocalCachedFileRcPtr ccFile;
-    OIIO_CHECK_NO_THROW(ccFile = LoadCCFile(fileName));
+    OCIO_CHECK_NO_THROW(ccFile = LoadCCFile(fileName));
 
     std::string idStr(ccFile->transform->getID());
-    OIIO_CHECK_EQUAL("cc0001", idStr);
+    OCIO_CHECK_EQUAL("cc0001", idStr);
     // OCIO keeps only the first SOPNode description
     std::string descStr(ccFile->transform->getDescription());
-    OIIO_CHECK_EQUAL("Example look", descStr);
+    OCIO_CHECK_EQUAL("Example look", descStr);
     float slope[3] = { 0.f, 0.f, 0.f };
-    OIIO_CHECK_NO_THROW(ccFile->transform->getSlope(slope));
-    OIIO_CHECK_EQUAL(1.0f, slope[0]);
-    OIIO_CHECK_EQUAL(1.0f, slope[1]);
-    OIIO_CHECK_EQUAL(0.9f, slope[2]);
+    OCIO_CHECK_NO_THROW(ccFile->transform->getSlope(slope));
+    OCIO_CHECK_EQUAL(1.0f, slope[0]);
+    OCIO_CHECK_EQUAL(1.0f, slope[1]);
+    OCIO_CHECK_EQUAL(0.9f, slope[2]);
     float offset[3] = { 0.f, 0.f, 0.f };
-    OIIO_CHECK_NO_THROW(ccFile->transform->getOffset(offset));
-    OIIO_CHECK_EQUAL(-0.03f, offset[0]);
-    OIIO_CHECK_EQUAL(-0.02f, offset[1]);
-    OIIO_CHECK_EQUAL(0.0f, offset[2]);
+    OCIO_CHECK_NO_THROW(ccFile->transform->getOffset(offset));
+    OCIO_CHECK_EQUAL(-0.03f, offset[0]);
+    OCIO_CHECK_EQUAL(-0.02f, offset[1]);
+    OCIO_CHECK_EQUAL(0.0f, offset[2]);
     float power[3] = { 0.f, 0.f, 0.f };
-    OIIO_CHECK_NO_THROW(ccFile->transform->getPower(power));
-    OIIO_CHECK_EQUAL(1.25f, power[0]);
-    OIIO_CHECK_EQUAL(1.0f, power[1]);
-    OIIO_CHECK_EQUAL(1.0f, power[2]);
-    OIIO_CHECK_EQUAL(1.7f, ccFile->transform->getSat());
+    OCIO_CHECK_NO_THROW(ccFile->transform->getPower(power));
+    OCIO_CHECK_EQUAL(1.25f, power[0]);
+    OCIO_CHECK_EQUAL(1.0f, power[1]);
+    OCIO_CHECK_EQUAL(1.0f, power[2]);
+    OCIO_CHECK_EQUAL(1.7f, ccFile->transform->getSat());
 }
 
-OIIO_ADD_TEST(FileFormatCC, TestCC_SATNode)
+OCIO_ADD_TEST(FileFormatCC, TestCC_SATNode)
 {
     // CC file
     const std::string fileName("cdl_test_SATNode.cc");
 
     OCIO::LocalCachedFileRcPtr ccFile;
-    OIIO_CHECK_NO_THROW(ccFile = LoadCCFile(fileName));
+    OCIO_CHECK_NO_THROW(ccFile = LoadCCFile(fileName));
 
     // "SATNode" is recognized.
-    OIIO_CHECK_EQUAL(0.42f, ccFile->transform->getSat());
+    OCIO_CHECK_EQUAL(0.42f, ccFile->transform->getSat());
 }
 
-OIIO_ADD_TEST(FileFormatCC, TestCC_ASC_SAT)
+OCIO_ADD_TEST(FileFormatCC, TestCC_ASC_SAT)
 {
     // CC file
     const std::string fileName("cdl_test_ASC_SAT.cc");
 
     OCIO::LocalCachedFileRcPtr ccFile;
-    OIIO_CHECK_NO_THROW(ccFile = LoadCCFile(fileName));
+    OCIO_CHECK_NO_THROW(ccFile = LoadCCFile(fileName));
 
     // "ASC_SAT" is not recognized. Default value is returned.
-    OIIO_CHECK_EQUAL(1.0f, ccFile->transform->getSat());
+    OCIO_CHECK_EQUAL(1.0f, ccFile->transform->getSat());
 }
 
-OIIO_ADD_TEST(FileFormatCC, TestCC_ASC_SOP)
+OCIO_ADD_TEST(FileFormatCC, TestCC_ASC_SOP)
 {
     // CC file
     const std::string fileName("cdl_test_ASC_SOP.cc");
 
     OCIO::LocalCachedFileRcPtr ccFile;
-    OIIO_CHECK_NO_THROW(ccFile = LoadCCFile(fileName));
+    OCIO_CHECK_NO_THROW(ccFile = LoadCCFile(fileName));
 
     // "ASC_SOP" is not recognized. Default values are used.
     std::string descStr(ccFile->transform->getDescription());
-    OIIO_CHECK_EQUAL("", descStr);
+    OCIO_CHECK_EQUAL("", descStr);
     float slope[3] = { 0.f, 0.f, 0.f };
-    OIIO_CHECK_NO_THROW(ccFile->transform->getSlope(slope));
-    OIIO_CHECK_EQUAL(1.0f, slope[0]);
+    OCIO_CHECK_NO_THROW(ccFile->transform->getSlope(slope));
+    OCIO_CHECK_EQUAL(1.0f, slope[0]);
     float offset[3] = { 1.f, 1.f, 1.f };
-    OIIO_CHECK_NO_THROW(ccFile->transform->getOffset(offset));
-    OIIO_CHECK_EQUAL(0.0f, offset[0]);
+    OCIO_CHECK_NO_THROW(ccFile->transform->getOffset(offset));
+    OCIO_CHECK_EQUAL(0.0f, offset[0]);
     float power[3] = { 0.f, 0.f, 0.f };
-    OIIO_CHECK_NO_THROW(ccFile->transform->getPower(power));
-    OIIO_CHECK_EQUAL(1.0f, power[0]);
+    OCIO_CHECK_NO_THROW(ccFile->transform->getPower(power));
+    OCIO_CHECK_EQUAL(1.0f, power[0]);
 }
 
 #endif

--- a/src/OpenColorIO/fileformats/FileFormatCCC.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCCC.cpp
@@ -218,7 +218,7 @@ OCIO_NAMESPACE_EXIT
 
 namespace OCIO = OCIO_NAMESPACE;
 
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
 OCIO::LocalCachedFileRcPtr LoadCCCFile(const std::string & fileName)
@@ -227,130 +227,130 @@ OCIO::LocalCachedFileRcPtr LoadCCCFile(const std::string & fileName)
         fileName, std::ios_base::in);
 }
 
-OIIO_ADD_TEST(FileFormatCCC, TestCCC)
+OCIO_ADD_TEST(FileFormatCCC, TestCCC)
 {
     // CCC file
     const std::string fileName("cdl_test1.ccc");
 
     OCIO::LocalCachedFileRcPtr cccFile;
-    OIIO_CHECK_NO_THROW(cccFile = LoadCCCFile(fileName));
+    OCIO_CHECK_NO_THROW(cccFile = LoadCCCFile(fileName));
     
-    OIIO_CHECK_EQUAL(5, cccFile->transformVec.size());
+    OCIO_CHECK_EQUAL(5, cccFile->transformVec.size());
     // Map key is the ID and 2 don't have an ID
-    OIIO_CHECK_EQUAL(3, cccFile->transformMap.size());
+    OCIO_CHECK_EQUAL(3, cccFile->transformMap.size());
     {
         std::string idStr(cccFile->transformVec[0]->getID());
-        OIIO_CHECK_EQUAL("cc0001", idStr);
+        OCIO_CHECK_EQUAL("cc0001", idStr);
         std::string descStr(cccFile->transformVec[0]->getDescription());
         // OCIO keeps only the first SOPNode description
-        OIIO_CHECK_EQUAL("Example look", descStr);
+        OCIO_CHECK_EQUAL("Example look", descStr);
         float slope[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cccFile->transformVec[0]->getSlope(slope));
-        OIIO_CHECK_EQUAL(1.0f, slope[0]);
-        OIIO_CHECK_EQUAL(1.0f, slope[1]);
-        OIIO_CHECK_EQUAL(0.9f, slope[2]);
+        OCIO_CHECK_NO_THROW(cccFile->transformVec[0]->getSlope(slope));
+        OCIO_CHECK_EQUAL(1.0f, slope[0]);
+        OCIO_CHECK_EQUAL(1.0f, slope[1]);
+        OCIO_CHECK_EQUAL(0.9f, slope[2]);
         float offset[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cccFile->transformVec[0]->getOffset(offset));
-        OIIO_CHECK_EQUAL(-0.03f, offset[0]);
-        OIIO_CHECK_EQUAL(-0.02f, offset[1]);
-        OIIO_CHECK_EQUAL(0.0f, offset[2]);
+        OCIO_CHECK_NO_THROW(cccFile->transformVec[0]->getOffset(offset));
+        OCIO_CHECK_EQUAL(-0.03f, offset[0]);
+        OCIO_CHECK_EQUAL(-0.02f, offset[1]);
+        OCIO_CHECK_EQUAL(0.0f, offset[2]);
         float power[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cccFile->transformVec[0]->getPower(power));
-        OIIO_CHECK_EQUAL(1.25f, power[0]);
-        OIIO_CHECK_EQUAL(1.0f, power[1]);
-        OIIO_CHECK_EQUAL(1.0f, power[2]);
-        OIIO_CHECK_EQUAL(1.7f, cccFile->transformVec[0]->getSat());
+        OCIO_CHECK_NO_THROW(cccFile->transformVec[0]->getPower(power));
+        OCIO_CHECK_EQUAL(1.25f, power[0]);
+        OCIO_CHECK_EQUAL(1.0f, power[1]);
+        OCIO_CHECK_EQUAL(1.0f, power[2]);
+        OCIO_CHECK_EQUAL(1.7f, cccFile->transformVec[0]->getSat());
     }
     {
         std::string idStr(cccFile->transformVec[1]->getID());
-        OIIO_CHECK_EQUAL("cc0002", idStr);
+        OCIO_CHECK_EQUAL("cc0002", idStr);
         std::string descStr(cccFile->transformVec[1]->getDescription());
-        OIIO_CHECK_EQUAL("pastel", descStr);
+        OCIO_CHECK_EQUAL("pastel", descStr);
         float slope[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cccFile->transformVec[1]->getSlope(slope));
-        OIIO_CHECK_EQUAL(0.9f, slope[0]);
-        OIIO_CHECK_EQUAL(0.7f, slope[1]);
-        OIIO_CHECK_EQUAL(0.6f, slope[2]);
+        OCIO_CHECK_NO_THROW(cccFile->transformVec[1]->getSlope(slope));
+        OCIO_CHECK_EQUAL(0.9f, slope[0]);
+        OCIO_CHECK_EQUAL(0.7f, slope[1]);
+        OCIO_CHECK_EQUAL(0.6f, slope[2]);
         float offset[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cccFile->transformVec[1]->getOffset(offset));
-        OIIO_CHECK_EQUAL(0.1f, offset[0]);
-        OIIO_CHECK_EQUAL(0.1f, offset[1]);
-        OIIO_CHECK_EQUAL(0.1f, offset[2]);
+        OCIO_CHECK_NO_THROW(cccFile->transformVec[1]->getOffset(offset));
+        OCIO_CHECK_EQUAL(0.1f, offset[0]);
+        OCIO_CHECK_EQUAL(0.1f, offset[1]);
+        OCIO_CHECK_EQUAL(0.1f, offset[2]);
         float power[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cccFile->transformVec[1]->getPower(power));
-        OIIO_CHECK_EQUAL(0.9f, power[0]);
-        OIIO_CHECK_EQUAL(0.9f, power[1]);
-        OIIO_CHECK_EQUAL(0.9f, power[2]);
-        OIIO_CHECK_EQUAL(0.7f, cccFile->transformVec[1]->getSat());
+        OCIO_CHECK_NO_THROW(cccFile->transformVec[1]->getPower(power));
+        OCIO_CHECK_EQUAL(0.9f, power[0]);
+        OCIO_CHECK_EQUAL(0.9f, power[1]);
+        OCIO_CHECK_EQUAL(0.9f, power[2]);
+        OCIO_CHECK_EQUAL(0.7f, cccFile->transformVec[1]->getSat());
     }
     {
         std::string idStr(cccFile->transformVec[2]->getID());
-        OIIO_CHECK_EQUAL("cc0003", idStr);
+        OCIO_CHECK_EQUAL("cc0003", idStr);
         std::string descStr(cccFile->transformVec[2]->getDescription());
-        OIIO_CHECK_EQUAL("golden", descStr);
+        OCIO_CHECK_EQUAL("golden", descStr);
         float slope[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cccFile->transformVec[2]->getSlope(slope));
-        OIIO_CHECK_EQUAL(1.2f, slope[0]);
-        OIIO_CHECK_EQUAL(1.1f, slope[1]);
-        OIIO_CHECK_EQUAL(1.0f, slope[2]);
+        OCIO_CHECK_NO_THROW(cccFile->transformVec[2]->getSlope(slope));
+        OCIO_CHECK_EQUAL(1.2f, slope[0]);
+        OCIO_CHECK_EQUAL(1.1f, slope[1]);
+        OCIO_CHECK_EQUAL(1.0f, slope[2]);
         float offset[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cccFile->transformVec[2]->getOffset(offset));
-        OIIO_CHECK_EQUAL(0.0f, offset[0]);
-        OIIO_CHECK_EQUAL(0.0f, offset[1]);
-        OIIO_CHECK_EQUAL(0.0f, offset[2]);
+        OCIO_CHECK_NO_THROW(cccFile->transformVec[2]->getOffset(offset));
+        OCIO_CHECK_EQUAL(0.0f, offset[0]);
+        OCIO_CHECK_EQUAL(0.0f, offset[1]);
+        OCIO_CHECK_EQUAL(0.0f, offset[2]);
         float power[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cccFile->transformVec[2]->getPower(power));
-        OIIO_CHECK_EQUAL(0.9f, power[0]);
-        OIIO_CHECK_EQUAL(1.0f, power[1]);
-        OIIO_CHECK_EQUAL(1.2f, power[2]);
-        OIIO_CHECK_EQUAL(1.0f, cccFile->transformVec[2]->getSat());
+        OCIO_CHECK_NO_THROW(cccFile->transformVec[2]->getPower(power));
+        OCIO_CHECK_EQUAL(0.9f, power[0]);
+        OCIO_CHECK_EQUAL(1.0f, power[1]);
+        OCIO_CHECK_EQUAL(1.2f, power[2]);
+        OCIO_CHECK_EQUAL(1.0f, cccFile->transformVec[2]->getSat());
     }
     {
         std::string idStr(cccFile->transformVec[3]->getID());
-        OIIO_CHECK_EQUAL("", idStr);
+        OCIO_CHECK_EQUAL("", idStr);
         std::string descStr(cccFile->transformVec[3]->getDescription());
-        OIIO_CHECK_EQUAL("", descStr);
+        OCIO_CHECK_EQUAL("", descStr);
         float slope[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cccFile->transformVec[3]->getSlope(slope));
-        OIIO_CHECK_EQUAL(4.0f, slope[0]);
-        OIIO_CHECK_EQUAL(5.0f, slope[1]);
-        OIIO_CHECK_EQUAL(6.0f, slope[2]);
+        OCIO_CHECK_NO_THROW(cccFile->transformVec[3]->getSlope(slope));
+        OCIO_CHECK_EQUAL(4.0f, slope[0]);
+        OCIO_CHECK_EQUAL(5.0f, slope[1]);
+        OCIO_CHECK_EQUAL(6.0f, slope[2]);
         float offset[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cccFile->transformVec[3]->getOffset(offset));
-        OIIO_CHECK_EQUAL(0.0f, offset[0]);
-        OIIO_CHECK_EQUAL(0.0f, offset[1]);
-        OIIO_CHECK_EQUAL(0.0f, offset[2]);
+        OCIO_CHECK_NO_THROW(cccFile->transformVec[3]->getOffset(offset));
+        OCIO_CHECK_EQUAL(0.0f, offset[0]);
+        OCIO_CHECK_EQUAL(0.0f, offset[1]);
+        OCIO_CHECK_EQUAL(0.0f, offset[2]);
         float power[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cccFile->transformVec[3]->getPower(power));
-        OIIO_CHECK_EQUAL(0.9f, power[0]);
-        OIIO_CHECK_EQUAL(1.0f, power[1]);
-        OIIO_CHECK_EQUAL(1.2f, power[2]);
+        OCIO_CHECK_NO_THROW(cccFile->transformVec[3]->getPower(power));
+        OCIO_CHECK_EQUAL(0.9f, power[0]);
+        OCIO_CHECK_EQUAL(1.0f, power[1]);
+        OCIO_CHECK_EQUAL(1.2f, power[2]);
         // SatNode missing from XML, uses a default of 1.0.
-        OIIO_CHECK_EQUAL(1.0f, cccFile->transformVec[3]->getSat());
+        OCIO_CHECK_EQUAL(1.0f, cccFile->transformVec[3]->getSat());
     }
     {
         std::string idStr(cccFile->transformVec[4]->getID());
-        OIIO_CHECK_EQUAL("", idStr);
+        OCIO_CHECK_EQUAL("", idStr);
         // SOPNode missing from XML, uses default values.
         std::string descStr(cccFile->transformVec[4]->getDescription());
-        OIIO_CHECK_EQUAL("", descStr);
+        OCIO_CHECK_EQUAL("", descStr);
         float slope[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cccFile->transformVec[4]->getSlope(slope));
-        OIIO_CHECK_EQUAL(1.0f, slope[0]);
-        OIIO_CHECK_EQUAL(1.0f, slope[1]);
-        OIIO_CHECK_EQUAL(1.0f, slope[2]);
+        OCIO_CHECK_NO_THROW(cccFile->transformVec[4]->getSlope(slope));
+        OCIO_CHECK_EQUAL(1.0f, slope[0]);
+        OCIO_CHECK_EQUAL(1.0f, slope[1]);
+        OCIO_CHECK_EQUAL(1.0f, slope[2]);
         float offset[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cccFile->transformVec[4]->getOffset(offset));
-        OIIO_CHECK_EQUAL(0.0f, offset[0]);
-        OIIO_CHECK_EQUAL(0.0f, offset[1]);
-        OIIO_CHECK_EQUAL(0.0f, offset[2]);
+        OCIO_CHECK_NO_THROW(cccFile->transformVec[4]->getOffset(offset));
+        OCIO_CHECK_EQUAL(0.0f, offset[0]);
+        OCIO_CHECK_EQUAL(0.0f, offset[1]);
+        OCIO_CHECK_EQUAL(0.0f, offset[2]);
         float power[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cccFile->transformVec[4]->getPower(power));
-        OIIO_CHECK_EQUAL(1.0f, power[0]);
-        OIIO_CHECK_EQUAL(1.0f, power[1]);
-        OIIO_CHECK_EQUAL(1.0f, power[2]);
+        OCIO_CHECK_NO_THROW(cccFile->transformVec[4]->getPower(power));
+        OCIO_CHECK_EQUAL(1.0f, power[0]);
+        OCIO_CHECK_EQUAL(1.0f, power[1]);
+        OCIO_CHECK_EQUAL(1.0f, power[2]);
 
-        OIIO_CHECK_EQUAL(0.0f, cccFile->transformVec[4]->getSat());
+        OCIO_CHECK_EQUAL(0.0f, cccFile->transformVec[4]->getSat());
     }
 
 }

--- a/src/OpenColorIO/fileformats/FileFormatCDL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCDL.cpp
@@ -217,7 +217,7 @@ OCIO_NAMESPACE_EXIT
 
 namespace OCIO = OCIO_NAMESPACE;
 
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
 OCIO::LocalCachedFileRcPtr LoadCDLFile(const std::string & fileName)
@@ -226,128 +226,128 @@ OCIO::LocalCachedFileRcPtr LoadCDLFile(const std::string & fileName)
         fileName, std::ios_base::in);
 }
 
-OIIO_ADD_TEST(FileFormatCDL, TestCDL)
+OCIO_ADD_TEST(FileFormatCDL, TestCDL)
 {
     // CDL file
     const std::string fileName("cdl_test1.cdl");
 
     OCIO::LocalCachedFileRcPtr cdlFile;
-    OIIO_CHECK_NO_THROW(cdlFile = LoadCDLFile(fileName));
-    OIIO_CHECK_EQUAL(5, cdlFile->transformVec.size());
+    OCIO_CHECK_NO_THROW(cdlFile = LoadCDLFile(fileName));
+    OCIO_CHECK_EQUAL(5, cdlFile->transformVec.size());
     // Map key is the ID and 2 don't have an ID
-    OIIO_CHECK_EQUAL(3, cdlFile->transformMap.size());
+    OCIO_CHECK_EQUAL(3, cdlFile->transformMap.size());
     {
         std::string idStr(cdlFile->transformVec[0]->getID());
-        OIIO_CHECK_EQUAL("cc0001", idStr);
+        OCIO_CHECK_EQUAL("cc0001", idStr);
         std::string descStr(cdlFile->transformVec[0]->getDescription());
         // OCIO keeps only the first SOPNode description
-        OIIO_CHECK_EQUAL("Example look", descStr);
+        OCIO_CHECK_EQUAL("Example look", descStr);
         float slope[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cdlFile->transformVec[0]->getSlope(slope));
-        OIIO_CHECK_EQUAL(1.0f, slope[0]);
-        OIIO_CHECK_EQUAL(1.0f, slope[1]);
-        OIIO_CHECK_EQUAL(0.9f, slope[2]);
+        OCIO_CHECK_NO_THROW(cdlFile->transformVec[0]->getSlope(slope));
+        OCIO_CHECK_EQUAL(1.0f, slope[0]);
+        OCIO_CHECK_EQUAL(1.0f, slope[1]);
+        OCIO_CHECK_EQUAL(0.9f, slope[2]);
         float offset[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cdlFile->transformVec[0]->getOffset(offset));
-        OIIO_CHECK_EQUAL(-0.03f, offset[0]);
-        OIIO_CHECK_EQUAL(-0.02f, offset[1]);
-        OIIO_CHECK_EQUAL(0.0f, offset[2]);
+        OCIO_CHECK_NO_THROW(cdlFile->transformVec[0]->getOffset(offset));
+        OCIO_CHECK_EQUAL(-0.03f, offset[0]);
+        OCIO_CHECK_EQUAL(-0.02f, offset[1]);
+        OCIO_CHECK_EQUAL(0.0f, offset[2]);
         float power[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cdlFile->transformVec[0]->getPower(power));
-        OIIO_CHECK_EQUAL(1.25f, power[0]);
-        OIIO_CHECK_EQUAL(1.0f, power[1]);
-        OIIO_CHECK_EQUAL(1.0f, power[2]);
-        OIIO_CHECK_EQUAL(1.7f, cdlFile->transformVec[0]->getSat());
+        OCIO_CHECK_NO_THROW(cdlFile->transformVec[0]->getPower(power));
+        OCIO_CHECK_EQUAL(1.25f, power[0]);
+        OCIO_CHECK_EQUAL(1.0f, power[1]);
+        OCIO_CHECK_EQUAL(1.0f, power[2]);
+        OCIO_CHECK_EQUAL(1.7f, cdlFile->transformVec[0]->getSat());
     }
     {
         std::string idStr(cdlFile->transformVec[1]->getID());
-        OIIO_CHECK_EQUAL("cc0002", idStr);
+        OCIO_CHECK_EQUAL("cc0002", idStr);
         std::string descStr(cdlFile->transformVec[1]->getDescription());
-        OIIO_CHECK_EQUAL("pastel", descStr);
+        OCIO_CHECK_EQUAL("pastel", descStr);
         float slope[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cdlFile->transformVec[1]->getSlope(slope));
-        OIIO_CHECK_EQUAL(0.9f, slope[0]);
-        OIIO_CHECK_EQUAL(0.7f, slope[1]);
-        OIIO_CHECK_EQUAL(0.6f, slope[2]);
+        OCIO_CHECK_NO_THROW(cdlFile->transformVec[1]->getSlope(slope));
+        OCIO_CHECK_EQUAL(0.9f, slope[0]);
+        OCIO_CHECK_EQUAL(0.7f, slope[1]);
+        OCIO_CHECK_EQUAL(0.6f, slope[2]);
         float offset[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cdlFile->transformVec[1]->getOffset(offset));
-        OIIO_CHECK_EQUAL(0.1f, offset[0]);
-        OIIO_CHECK_EQUAL(0.1f, offset[1]);
-        OIIO_CHECK_EQUAL(0.1f, offset[2]);
+        OCIO_CHECK_NO_THROW(cdlFile->transformVec[1]->getOffset(offset));
+        OCIO_CHECK_EQUAL(0.1f, offset[0]);
+        OCIO_CHECK_EQUAL(0.1f, offset[1]);
+        OCIO_CHECK_EQUAL(0.1f, offset[2]);
         float power[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cdlFile->transformVec[1]->getPower(power));
-        OIIO_CHECK_EQUAL(0.9f, power[0]);
-        OIIO_CHECK_EQUAL(0.9f, power[1]);
-        OIIO_CHECK_EQUAL(0.9f, power[2]);
-        OIIO_CHECK_EQUAL(0.7f, cdlFile->transformVec[1]->getSat());
+        OCIO_CHECK_NO_THROW(cdlFile->transformVec[1]->getPower(power));
+        OCIO_CHECK_EQUAL(0.9f, power[0]);
+        OCIO_CHECK_EQUAL(0.9f, power[1]);
+        OCIO_CHECK_EQUAL(0.9f, power[2]);
+        OCIO_CHECK_EQUAL(0.7f, cdlFile->transformVec[1]->getSat());
     }
     {
         std::string idStr(cdlFile->transformVec[2]->getID());
-        OIIO_CHECK_EQUAL("cc0003", idStr);
+        OCIO_CHECK_EQUAL("cc0003", idStr);
         std::string descStr(cdlFile->transformVec[2]->getDescription());
-        OIIO_CHECK_EQUAL("golden", descStr);
+        OCIO_CHECK_EQUAL("golden", descStr);
         float slope[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cdlFile->transformVec[2]->getSlope(slope));
-        OIIO_CHECK_EQUAL(1.2f, slope[0]);
-        OIIO_CHECK_EQUAL(1.1f, slope[1]);
-        OIIO_CHECK_EQUAL(1.0f, slope[2]);
+        OCIO_CHECK_NO_THROW(cdlFile->transformVec[2]->getSlope(slope));
+        OCIO_CHECK_EQUAL(1.2f, slope[0]);
+        OCIO_CHECK_EQUAL(1.1f, slope[1]);
+        OCIO_CHECK_EQUAL(1.0f, slope[2]);
         float offset[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cdlFile->transformVec[2]->getOffset(offset));
-        OIIO_CHECK_EQUAL(0.0f, offset[0]);
-        OIIO_CHECK_EQUAL(0.0f, offset[1]);
-        OIIO_CHECK_EQUAL(0.0f, offset[2]);
+        OCIO_CHECK_NO_THROW(cdlFile->transformVec[2]->getOffset(offset));
+        OCIO_CHECK_EQUAL(0.0f, offset[0]);
+        OCIO_CHECK_EQUAL(0.0f, offset[1]);
+        OCIO_CHECK_EQUAL(0.0f, offset[2]);
         float power[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cdlFile->transformVec[2]->getPower(power));
-        OIIO_CHECK_EQUAL(0.9f, power[0]);
-        OIIO_CHECK_EQUAL(1.0f, power[1]);
-        OIIO_CHECK_EQUAL(1.2f, power[2]);
-        OIIO_CHECK_EQUAL(1.0f, cdlFile->transformVec[2]->getSat());
+        OCIO_CHECK_NO_THROW(cdlFile->transformVec[2]->getPower(power));
+        OCIO_CHECK_EQUAL(0.9f, power[0]);
+        OCIO_CHECK_EQUAL(1.0f, power[1]);
+        OCIO_CHECK_EQUAL(1.2f, power[2]);
+        OCIO_CHECK_EQUAL(1.0f, cdlFile->transformVec[2]->getSat());
     }
     {
         std::string idStr(cdlFile->transformVec[3]->getID());
-        OIIO_CHECK_EQUAL("", idStr);
+        OCIO_CHECK_EQUAL("", idStr);
         std::string descStr(cdlFile->transformVec[3]->getDescription());
-        OIIO_CHECK_EQUAL("", descStr);
+        OCIO_CHECK_EQUAL("", descStr);
         float slope[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cdlFile->transformVec[3]->getSlope(slope));
-        OIIO_CHECK_EQUAL(1.2f, slope[0]);
-        OIIO_CHECK_EQUAL(1.1f, slope[1]);
-        OIIO_CHECK_EQUAL(1.0f, slope[2]);
+        OCIO_CHECK_NO_THROW(cdlFile->transformVec[3]->getSlope(slope));
+        OCIO_CHECK_EQUAL(1.2f, slope[0]);
+        OCIO_CHECK_EQUAL(1.1f, slope[1]);
+        OCIO_CHECK_EQUAL(1.0f, slope[2]);
         float offset[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cdlFile->transformVec[3]->getOffset(offset));
-        OIIO_CHECK_EQUAL(0.0f, offset[0]);
-        OIIO_CHECK_EQUAL(0.0f, offset[1]);
-        OIIO_CHECK_EQUAL(0.0f, offset[2]);
+        OCIO_CHECK_NO_THROW(cdlFile->transformVec[3]->getOffset(offset));
+        OCIO_CHECK_EQUAL(0.0f, offset[0]);
+        OCIO_CHECK_EQUAL(0.0f, offset[1]);
+        OCIO_CHECK_EQUAL(0.0f, offset[2]);
         float power[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cdlFile->transformVec[3]->getPower(power));
-        OIIO_CHECK_EQUAL(0.9f, power[0]);
-        OIIO_CHECK_EQUAL(1.0f, power[1]);
-        OIIO_CHECK_EQUAL(1.2f, power[2]);
+        OCIO_CHECK_NO_THROW(cdlFile->transformVec[3]->getPower(power));
+        OCIO_CHECK_EQUAL(0.9f, power[0]);
+        OCIO_CHECK_EQUAL(1.0f, power[1]);
+        OCIO_CHECK_EQUAL(1.2f, power[2]);
         // SatNode missing from XML, uses a default of 1.0.
-        OIIO_CHECK_EQUAL(1.0f, cdlFile->transformVec[3]->getSat());
+        OCIO_CHECK_EQUAL(1.0f, cdlFile->transformVec[3]->getSat());
     }
     {
         std::string idStr(cdlFile->transformVec[4]->getID());
-        OIIO_CHECK_EQUAL("", idStr);
+        OCIO_CHECK_EQUAL("", idStr);
         std::string descStr(cdlFile->transformVec[4]->getDescription());
-        OIIO_CHECK_EQUAL("", descStr);
+        OCIO_CHECK_EQUAL("", descStr);
         // SOPNode missing from XML, uses default values.
         float slope[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cdlFile->transformVec[4]->getSlope(slope));
-        OIIO_CHECK_EQUAL(1.0f, slope[0]);
-        OIIO_CHECK_EQUAL(1.0f, slope[1]);
-        OIIO_CHECK_EQUAL(1.0f, slope[2]);
+        OCIO_CHECK_NO_THROW(cdlFile->transformVec[4]->getSlope(slope));
+        OCIO_CHECK_EQUAL(1.0f, slope[0]);
+        OCIO_CHECK_EQUAL(1.0f, slope[1]);
+        OCIO_CHECK_EQUAL(1.0f, slope[2]);
         float offset[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cdlFile->transformVec[4]->getOffset(offset));
-        OIIO_CHECK_EQUAL(0.0f, offset[0]);
-        OIIO_CHECK_EQUAL(0.0f, offset[1]);
-        OIIO_CHECK_EQUAL(0.0f, offset[2]);
+        OCIO_CHECK_NO_THROW(cdlFile->transformVec[4]->getOffset(offset));
+        OCIO_CHECK_EQUAL(0.0f, offset[0]);
+        OCIO_CHECK_EQUAL(0.0f, offset[1]);
+        OCIO_CHECK_EQUAL(0.0f, offset[2]);
         float power[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(cdlFile->transformVec[4]->getPower(power));
-        OIIO_CHECK_EQUAL(1.0f, power[0]);
-        OIIO_CHECK_EQUAL(1.0f, power[1]);
-        OIIO_CHECK_EQUAL(1.0f, power[2]);
-        OIIO_CHECK_EQUAL(0.0f, cdlFile->transformVec[4]->getSat());
+        OCIO_CHECK_NO_THROW(cdlFile->transformVec[4]->getPower(power));
+        OCIO_CHECK_EQUAL(1.0f, power[0]);
+        OCIO_CHECK_EQUAL(1.0f, power[1]);
+        OCIO_CHECK_EQUAL(1.0f, power[2]);
+        OCIO_CHECK_EQUAL(0.0f, cdlFile->transformVec[4]->getSat());
     }
 }
 

--- a/src/OpenColorIO/fileformats/FileFormatCSP.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCSP.cpp
@@ -926,12 +926,12 @@ void compareFloats(const std::string& floats1, const std::string& floats2)
 {
     // number comparison
     std::vector<std::string> strings1;
-    pystring::split(pystring::strip(floats1), strings1);
+    OCIO::pystring::split(OCIO::pystring::strip(floats1), strings1);
     std::vector<float> numbers1;
     OCIO::StringVecToFloatVec(numbers1, strings1);
 
     std::vector<std::string> strings2;
-    pystring::split(pystring::strip(floats2), strings2);
+    OCIO::pystring::split(OCIO::pystring::strip(floats2), strings2);
     std::vector<float> numbers2;
     OCIO::StringVecToFloatVec(numbers2, strings2);
 
@@ -1153,9 +1153,9 @@ OCIO_ADD_TEST(FileFormatCSP, complete3D)
     
     //
     std::vector<std::string> osvec;
-    pystring::splitlines(output.str(), osvec);
+    OCIO::pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    pystring::splitlines(bout.str(), resvec);
+    OCIO::pystring::splitlines(bout.str(), resvec);
     OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {
@@ -1247,9 +1247,9 @@ OCIO_ADD_TEST(FileFormatCSP, shaper_hdr)
     
     //
     std::vector<std::string> osvec;
-    pystring::splitlines(output.str(), osvec);
+    OCIO::pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    pystring::splitlines(bout.str(), resvec);
+    OCIO::pystring::splitlines(bout.str(), resvec);
     OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {
@@ -1330,9 +1330,9 @@ OCIO_ADD_TEST(FileFormatCSP, no_shaper)
 
     //
     std::vector<std::string> osvec;
-    pystring::splitlines(output.str(), osvec);
+    OCIO::pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    pystring::splitlines(bout.str(), resvec);
+    OCIO::pystring::splitlines(bout.str(), resvec);
     OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {

--- a/src/OpenColorIO/fileformats/FileFormatCSP.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCSP.cpp
@@ -920,29 +920,29 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 void compareFloats(const std::string& floats1, const std::string& floats2)
 {
     // number comparison
     std::vector<std::string> strings1;
-    OCIO::pystring::split(OCIO::pystring::strip(floats1), strings1);
+    pystring::split(pystring::strip(floats1), strings1);
     std::vector<float> numbers1;
     OCIO::StringVecToFloatVec(numbers1, strings1);
 
     std::vector<std::string> strings2;
-    OCIO::pystring::split(OCIO::pystring::strip(floats2), strings2);
+    pystring::split(pystring::strip(floats2), strings2);
     std::vector<float> numbers2;
     OCIO::StringVecToFloatVec(numbers2, strings2);
 
-    OIIO_CHECK_EQUAL(numbers1.size(), numbers2.size());
+    OCIO_CHECK_EQUAL(numbers1.size(), numbers2.size());
     for(unsigned int j=0; j<numbers1.size(); ++j)
     {
-        OIIO_CHECK_CLOSE(numbers1[j], numbers2[j], 1e-5f);
+        OCIO_CHECK_CLOSE(numbers1[j], numbers2[j], 1e-5f);
     }
 }
 
-OIIO_ADD_TEST(FileFormatCSP, simple1D)
+OCIO_ADD_TEST(FileFormatCSP, simple1D)
 {
     std::ostringstream strebuf;
     strebuf << "CSPLUTV100"              << "\n";
@@ -984,10 +984,10 @@ OIIO_ADD_TEST(FileFormatCSP, simple1D)
     OCIO::CachedFileCSPRcPtr csplut = OCIO::DynamicPtrCast<OCIO::CachedFileCSP>(cachedFile);
 
     // check metadata
-    OIIO_CHECK_EQUAL(csplut->metadata, std::string("foobar\n"));
+    OCIO_CHECK_EQUAL(csplut->metadata, std::string("foobar\n"));
 
     // check prelut data
-    OIIO_CHECK_ASSERT(csplut->hasprelut);
+    OCIO_CHECK_ASSERT(csplut->hasprelut);
 
     // check prelut data (note: the spline is resampled into a 1D LUT)
     for(int c=0; c<3; ++c)
@@ -996,7 +996,7 @@ OIIO_ADD_TEST(FileFormatCSP, simple1D)
         {
             float input = float(i) / float(csplut->prelut->luts[c].size()-1);
             float output = csplut->prelut->luts[c][i];
-            OIIO_CHECK_CLOSE(input*2.0f, output, 1e-4);
+            OCIO_CHECK_CLOSE(input*2.0f, output, 1e-4);
         }
     }
 
@@ -1004,19 +1004,19 @@ OIIO_ADD_TEST(FileFormatCSP, simple1D)
     // red
     unsigned int i;
     for(i = 0; i < csplut->lut1D->luts[0].size(); ++i)
-        OIIO_CHECK_EQUAL(red[i], csplut->lut1D->luts[0][i]);
+        OCIO_CHECK_EQUAL(red[i], csplut->lut1D->luts[0][i]);
     // green
     for(i = 0; i < csplut->lut1D->luts[1].size(); ++i)
-        OIIO_CHECK_EQUAL(green[i], csplut->lut1D->luts[1][i]);
+        OCIO_CHECK_EQUAL(green[i], csplut->lut1D->luts[1][i]);
     // blue
     for(i = 0; i < csplut->lut1D->luts[2].size(); ++i)
-        OIIO_CHECK_EQUAL(blue[i], csplut->lut1D->luts[2][i]);
+        OCIO_CHECK_EQUAL(blue[i], csplut->lut1D->luts[2][i]);
     
     // check 3D data
-    OIIO_CHECK_EQUAL(csplut->lut3D->lut.size(), 0);
+    OCIO_CHECK_EQUAL(csplut->lut3D->lut.size(), 0);
 }
 
-OIIO_ADD_TEST(FileFormatCSP, simple3D)
+OCIO_ADD_TEST(FileFormatCSP, simple3D)
 {
     std::ostringstream strebuf;
     strebuf << "CSPLUTV100"                                  << "\n";
@@ -1061,24 +1061,24 @@ OIIO_ADD_TEST(FileFormatCSP, simple3D)
     OCIO::CachedFileCSPRcPtr csplut = OCIO::DynamicPtrCast<OCIO::CachedFileCSP>(cachedFile);
     
     // check metadata
-    OIIO_CHECK_EQUAL(csplut->metadata, std::string("foobar\n"));
+    OCIO_CHECK_EQUAL(csplut->metadata, std::string("foobar\n"));
 
     // check prelut data
-    OIIO_CHECK_ASSERT(!csplut->hasprelut); // as in & out preLut values are the same
+    OCIO_CHECK_ASSERT(!csplut->hasprelut); // as in & out preLut values are the same
                                            // there is nothing to do.
     
     // check cube data
     for(unsigned int i = 0; i < csplut->lut3D->lut.size(); ++i) {
-        OIIO_CHECK_EQUAL(cube[i], csplut->lut3D->lut[i]);
+        OCIO_CHECK_EQUAL(cube[i], csplut->lut3D->lut[i]);
     }
 
     // check 1D data
-    OIIO_CHECK_EQUAL(csplut->lut1D->luts[0].size(), 0);
-    OIIO_CHECK_EQUAL(csplut->lut1D->luts[1].size(), 0);
-    OIIO_CHECK_EQUAL(csplut->lut1D->luts[2].size(), 0);
+    OCIO_CHECK_EQUAL(csplut->lut1D->luts[0].size(), 0);
+    OCIO_CHECK_EQUAL(csplut->lut1D->luts[1].size(), 0);
+    OCIO_CHECK_EQUAL(csplut->lut1D->luts[2].size(), 0);
 }
 
-OIIO_ADD_TEST(FileFormatCSP, complete3D)
+OCIO_ADD_TEST(FileFormatCSP, complete3D)
 {
     // check baker output
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
@@ -1153,10 +1153,10 @@ OIIO_ADD_TEST(FileFormatCSP, complete3D)
     
     //
     std::vector<std::string> osvec;
-    OCIO::pystring::splitlines(output.str(), osvec);
+    pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    OCIO::pystring::splitlines(bout.str(), resvec);
-    OIIO_CHECK_EQUAL(osvec.size(), resvec.size());
+    pystring::splitlines(bout.str(), resvec);
+    OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {
         if(i>6)
@@ -1167,12 +1167,12 @@ OIIO_ADD_TEST(FileFormatCSP, complete3D)
         else
         {
             // text comparison
-            OIIO_CHECK_EQUAL(osvec[i], resvec[i]);
+            OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
         }
     }
 }
 
-OIIO_ADD_TEST(FileFormatCSP, shaper_hdr)
+OCIO_ADD_TEST(FileFormatCSP, shaper_hdr)
 {
     // check baker output
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
@@ -1247,10 +1247,10 @@ OIIO_ADD_TEST(FileFormatCSP, shaper_hdr)
     
     //
     std::vector<std::string> osvec;
-    OCIO::pystring::splitlines(output.str(), osvec);
+    pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    OCIO::pystring::splitlines(bout.str(), resvec);
-    OIIO_CHECK_EQUAL(osvec.size(), resvec.size());
+    pystring::splitlines(bout.str(), resvec);
+    OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {
         if(i>6)
@@ -1261,12 +1261,12 @@ OIIO_ADD_TEST(FileFormatCSP, shaper_hdr)
         else
         {
             // text comparison
-            OIIO_CHECK_EQUAL(osvec[i], resvec[i]);
+            OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
         }
     }
 }
 
-OIIO_ADD_TEST(FileFormatCSP, no_shaper)
+OCIO_ADD_TEST(FileFormatCSP, no_shaper)
 {
     // check baker output
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
@@ -1330,17 +1330,17 @@ OIIO_ADD_TEST(FileFormatCSP, no_shaper)
 
     //
     std::vector<std::string> osvec;
-    OCIO::pystring::splitlines(output.str(), osvec);
+    pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    OCIO::pystring::splitlines(bout.str(), resvec);
-    OIIO_CHECK_EQUAL(osvec.size(), resvec.size());
+    pystring::splitlines(bout.str(), resvec);
+    OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {
-        OIIO_CHECK_EQUAL(osvec[i], resvec[i]);
+        OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
     }
 }
 
-OIIO_ADD_TEST(FileFormatCSP, lessStrictParse)
+OCIO_ADD_TEST(FileFormatCSP, lessStrictParse)
 {
     std::ostringstream strebuf;
     strebuf << " CspluTV100 malformed"                       << "\n";
@@ -1375,14 +1375,14 @@ OIIO_ADD_TEST(FileFormatCSP, lessStrictParse)
     std::string emptyString;
     OCIO::LocalFileFormat tester;
     OCIO::CachedFileRcPtr cachedFile;
-    OIIO_CHECK_NO_THROW(cachedFile = tester.Read(simple3D, emptyString));
+    OCIO_CHECK_NO_THROW(cachedFile = tester.Read(simple3D, emptyString));
     OCIO::CachedFileCSPRcPtr csplut = OCIO::DynamicPtrCast<OCIO::CachedFileCSP>(cachedFile);   
     
     // check metadata
-    OIIO_CHECK_EQUAL(csplut->metadata, std::string("foobar\n"));
+    OCIO_CHECK_EQUAL(csplut->metadata, std::string("foobar\n"));
 
     // check prelut data
-    OIIO_CHECK_ASSERT(!csplut->hasprelut); // as in & out from the preLut are the same,
+    OCIO_CHECK_ASSERT(!csplut->hasprelut); // as in & out from the preLut are the same,
                                            //  there is nothing to do.
 }
 

--- a/src/OpenColorIO/fileformats/FileFormatCTF.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatCTF.cpp
@@ -1196,7 +1196,7 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
 OCIO::LocalCachedFileRcPtr LoadCLFFile(const std::string & fileName)
@@ -1205,889 +1205,889 @@ OCIO::LocalCachedFileRcPtr LoadCLFFile(const std::string & fileName)
         fileName, std::ios_base::in);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, missing_file)
+OCIO_ADD_TEST(FileFormatCTF, missing_file)
 {
     // Test LoadCLFFile helper function with missing file.
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("xxxxxxxxxxxxxxxxx.xxxxx");
-    OIIO_CHECK_THROW_WHAT(cachedFile = LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(cachedFile = LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "Error opening test file.");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, wrong_format)
+OCIO_ADD_TEST(FileFormatCTF, wrong_format)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     {
         const std::string ctfFile("logtolin_8to8.lut");
-        OIIO_CHECK_THROW_WHAT(cachedFile = LoadCLFFile(ctfFile),
+        OCIO_CHECK_THROW_WHAT(cachedFile = LoadCLFFile(ctfFile),
                               OCIO::Exception,
                               "not a CTF/CLF file.");
-        OIIO_CHECK_ASSERT(!(bool)cachedFile);
+        OCIO_CHECK_ASSERT(!(bool)cachedFile);
     }
 }
 
-OIIO_ADD_TEST(FileFormatCTF, clf_spec)
+OCIO_ADD_TEST(FileFormatCTF, clf_spec)
 {
     // Parse examples from the specifications document S-2014-006.
     OCIO::LocalCachedFileRcPtr cachedFile;
     {
         const std::string ctfFile("lut1d_example.clf");
-        OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-        OIIO_REQUIRE_ASSERT((bool)cachedFile);
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getName(),
+        OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+        OCIO_REQUIRE_ASSERT((bool)cachedFile);
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getName(),
                          "transform example lut1d");
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getID(), "exlut1");
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions().size(), 1);
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[0],
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getID(), "exlut1");
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions().size(), 1);
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[0],
                          " Turn 4 grey levels into 4 inverted codes using a 1D ");
         const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-        OIIO_REQUIRE_EQUAL(opList.size(), 1);
-        OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut1DType);
-        OIIO_CHECK_EQUAL(opList[0]->getName(), "4valueLut");
-        OIIO_CHECK_EQUAL(opList[0]->getID(), "lut-23");
-        OIIO_CHECK_EQUAL(opList[0]->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-        OIIO_CHECK_EQUAL(opList[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-        OIIO_REQUIRE_EQUAL(opList[0]->getDescriptions().size(), 1);
-        OIIO_CHECK_EQUAL(opList[0]->getDescriptions()[0], " 1D LUT ");
+        OCIO_REQUIRE_EQUAL(opList.size(), 1);
+        OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut1DType);
+        OCIO_CHECK_EQUAL(opList[0]->getName(), "4valueLut");
+        OCIO_CHECK_EQUAL(opList[0]->getID(), "lut-23");
+        OCIO_CHECK_EQUAL(opList[0]->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+        OCIO_CHECK_EQUAL(opList[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+        OCIO_REQUIRE_EQUAL(opList[0]->getDescriptions().size(), 1);
+        OCIO_CHECK_EQUAL(opList[0]->getDescriptions()[0], " 1D LUT ");
     }
 
     {
         const std::string ctfFile("lut3d_identity_12i_16f.clf");
-        OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-        OIIO_REQUIRE_ASSERT((bool)cachedFile);
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getName(),
+        OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+        OCIO_REQUIRE_ASSERT((bool)cachedFile);
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getName(),
                          "transform example lut3d");
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getID(), "exlut2");
-        OIIO_REQUIRE_EQUAL(cachedFile->m_transform->getDescriptions().size(), 1);
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[0],
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getID(), "exlut2");
+        OCIO_REQUIRE_EQUAL(cachedFile->m_transform->getDescriptions().size(), 1);
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[0],
                          " 3D LUT example from spec ");
         const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-        OIIO_REQUIRE_EQUAL(opList.size(), 1);
-        OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut3DType);
-        OIIO_CHECK_EQUAL(opList[0]->getName(), "identity");
-        OIIO_CHECK_EQUAL(opList[0]->getID(), "lut-24");
-        OIIO_CHECK_EQUAL(opList[0]->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-        OIIO_CHECK_EQUAL(opList[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
-        OIIO_REQUIRE_EQUAL(opList[0]->getDescriptions().size(), 1);
-        OIIO_CHECK_EQUAL(opList[0]->getDescriptions()[0], " 3D LUT ");
+        OCIO_REQUIRE_EQUAL(opList.size(), 1);
+        OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut3DType);
+        OCIO_CHECK_EQUAL(opList[0]->getName(), "identity");
+        OCIO_CHECK_EQUAL(opList[0]->getID(), "lut-24");
+        OCIO_CHECK_EQUAL(opList[0]->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+        OCIO_CHECK_EQUAL(opList[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
+        OCIO_REQUIRE_EQUAL(opList[0]->getDescriptions().size(), 1);
+        OCIO_CHECK_EQUAL(opList[0]->getDescriptions()[0], " 3D LUT ");
     }
 
     {
         const std::string ctfFile("matrix_3x4_example.clf");
-        OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-        OIIO_REQUIRE_ASSERT((bool)cachedFile);
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getName(),
+        OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+        OCIO_REQUIRE_ASSERT((bool)cachedFile);
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getName(),
                          "transform example matrix");
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getID(), "exmat1");
-        OIIO_REQUIRE_EQUAL(cachedFile->m_transform->getDescriptions().size(), 2);
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[0],
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getID(), "exmat1");
+        OCIO_REQUIRE_EQUAL(cachedFile->m_transform->getDescriptions().size(), 2);
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[0],
                          " Matrix example from spec ");
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[1],
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[1],
                          " Used by unit tests ");
         const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-        OIIO_REQUIRE_EQUAL(opList.size(), 1);
-        OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
-        OIIO_CHECK_EQUAL(opList[0]->getName(), "colorspace conversion");
-        OIIO_CHECK_EQUAL(opList[0]->getID(), "mat-25");
-        OIIO_CHECK_EQUAL(opList[0]->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-        OIIO_CHECK_EQUAL(opList[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-        OIIO_REQUIRE_EQUAL(opList[0]->getDescriptions().size(), 1);
-        OIIO_CHECK_EQUAL(opList[0]->getDescriptions()[0],
+        OCIO_REQUIRE_EQUAL(opList.size(), 1);
+        OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
+        OCIO_CHECK_EQUAL(opList[0]->getName(), "colorspace conversion");
+        OCIO_CHECK_EQUAL(opList[0]->getID(), "mat-25");
+        OCIO_CHECK_EQUAL(opList[0]->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+        OCIO_CHECK_EQUAL(opList[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+        OCIO_REQUIRE_EQUAL(opList[0]->getDescriptions().size(), 1);
+        OCIO_CHECK_EQUAL(opList[0]->getDescriptions()[0],
                          " 3x4 Matrix , 4th column is offset ");
     }
 
     {
         // Test two-entries IndexMap support.
         const std::string ctfFile("lut1d_indexmap_example.clf");
-        OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-        OIIO_REQUIRE_ASSERT((bool)cachedFile);
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getName(),
+        OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+        OCIO_REQUIRE_ASSERT((bool)cachedFile);
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getName(),
                          "transform example lut IndexMap");
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getID(), "exlut3");
-        OIIO_REQUIRE_EQUAL(cachedFile->m_transform->getDescriptions().size(), 1);
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[0],
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getID(), "exlut3");
+        OCIO_REQUIRE_EQUAL(cachedFile->m_transform->getDescriptions().size(), 1);
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[0],
                          " IndexMap LUT example from spec ");
         const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-        OIIO_REQUIRE_EQUAL(opList.size(), 2);
-        OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::RangeType);
+        OCIO_REQUIRE_EQUAL(opList.size(), 2);
+        OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::RangeType);
         auto pR = std::dynamic_pointer_cast<const OCIO::RangeOpData>(opList[0]);
-        OIIO_REQUIRE_ASSERT(pR);
+        OCIO_REQUIRE_ASSERT(pR);
 
-        OIIO_CHECK_EQUAL(pR->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-        OIIO_CHECK_EQUAL(pR->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+        OCIO_CHECK_EQUAL(pR->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+        OCIO_CHECK_EQUAL(pR->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
 
-        OIIO_CHECK_EQUAL(pR->getMinInValue(), 64.);
-        OIIO_CHECK_EQUAL(pR->getMaxInValue(), 940.);
-        OIIO_CHECK_EQUAL(pR->getMinOutValue(), 0.);
-        OIIO_CHECK_EQUAL(pR->getMaxOutValue(), 1023.);
+        OCIO_CHECK_EQUAL(pR->getMinInValue(), 64.);
+        OCIO_CHECK_EQUAL(pR->getMaxInValue(), 940.);
+        OCIO_CHECK_EQUAL(pR->getMinOutValue(), 0.);
+        OCIO_CHECK_EQUAL(pR->getMaxOutValue(), 1023.);
 
-        OIIO_CHECK_EQUAL(opList[1]->getType(), OCIO::OpData::Lut1DType);
-        OIIO_CHECK_EQUAL(opList[1]->getName(), "IndexMap LUT");
-        OIIO_CHECK_EQUAL(opList[1]->getID(), "lut-26");
-        OIIO_CHECK_EQUAL(opList[1]->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-        OIIO_CHECK_EQUAL(opList[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
-        OIIO_REQUIRE_EQUAL(opList[1]->getDescriptions().size(), 1);
-        OIIO_CHECK_EQUAL(opList[1]->getDescriptions()[0],
+        OCIO_CHECK_EQUAL(opList[1]->getType(), OCIO::OpData::Lut1DType);
+        OCIO_CHECK_EQUAL(opList[1]->getName(), "IndexMap LUT");
+        OCIO_CHECK_EQUAL(opList[1]->getID(), "lut-26");
+        OCIO_CHECK_EQUAL(opList[1]->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+        OCIO_CHECK_EQUAL(opList[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
+        OCIO_REQUIRE_EQUAL(opList[1]->getDescriptions().size(), 1);
+        OCIO_CHECK_EQUAL(opList[1]->getDescriptions()[0],
                          " 1D LUT with IndexMap ");
     }
 }
 
-OIIO_ADD_TEST(FileFormatCTF, lut_1d)
+OCIO_ADD_TEST(FileFormatCTF, lut_1d)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     {
         const std::string ctfFile("lut1d_32_10i_10i.ctf");
-        OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-        OIIO_REQUIRE_ASSERT((bool)cachedFile);
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getName(), "1d-lut example");
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getID(),
+        OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+        OCIO_REQUIRE_ASSERT((bool)cachedFile);
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getName(), "1d-lut example");
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getID(),
                          "9843a859-e41e-40a8-a51c-840889c3774e");
-        OIIO_REQUIRE_EQUAL(cachedFile->m_transform->getDescriptions().size(), 1);
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[0],
+        OCIO_REQUIRE_EQUAL(cachedFile->m_transform->getDescriptions().size(), 1);
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[0],
                          "Apply a 1/2.2 gamma.");
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getInputDescriptor(), "RGB");
-        OIIO_CHECK_EQUAL(cachedFile->m_transform->getOutputDescriptor(), "RGB");
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getInputDescriptor(), "RGB");
+        OCIO_CHECK_EQUAL(cachedFile->m_transform->getOutputDescriptor(), "RGB");
         const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-        OIIO_REQUIRE_EQUAL(opList.size(), 1);
+        OCIO_REQUIRE_EQUAL(opList.size(), 1);
 
-        OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut1DType);
+        OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut1DType);
         auto pLut = std::dynamic_pointer_cast<const OCIO::Lut1DOpData>(opList[0]);
-        OIIO_REQUIRE_ASSERT(pLut);
+        OCIO_REQUIRE_ASSERT(pLut);
 
-        OIIO_REQUIRE_EQUAL(pLut->getDescriptions().size(), 1);
+        OCIO_REQUIRE_EQUAL(pLut->getDescriptions().size(), 1);
 
-        OIIO_CHECK_ASSERT(!pLut->isInputHalfDomain());
-        OIIO_CHECK_ASSERT(!pLut->isOutputRawHalfs());
-        OIIO_CHECK_EQUAL(pLut->getHueAdjust(), OCIO::Lut1DOpData::HUE_NONE);
+        OCIO_CHECK_ASSERT(!pLut->isInputHalfDomain());
+        OCIO_CHECK_ASSERT(!pLut->isOutputRawHalfs());
+        OCIO_CHECK_EQUAL(pLut->getHueAdjust(), OCIO::Lut1DOpData::HUE_NONE);
 
-        OIIO_CHECK_EQUAL(pLut->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-        OIIO_CHECK_EQUAL(pLut->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-        OIIO_CHECK_ASSERT(pLut->getName() == "1d-lut example op");
+        OCIO_CHECK_EQUAL(pLut->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+        OCIO_CHECK_EQUAL(pLut->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+        OCIO_CHECK_ASSERT(pLut->getName() == "1d-lut example op");
 
         // TODO: bypass is for CTF
-        // OIIO_CHECK_ASSERT(!pLut->getBypass()->isDynamic());
+        // OCIO_CHECK_ASSERT(!pLut->getBypass()->isDynamic());
 
         // LUT is defined with a 32x1 array.
         // Array is extended to 32x3 by duplicating the available component.
         const OCIO::Array & array = pLut->getArray();
-        OIIO_CHECK_EQUAL(array.getLength(), 32);
-        OIIO_CHECK_EQUAL(array.getNumColorComponents(), 1);
-        OIIO_CHECK_EQUAL(array.getNumValues(),
+        OCIO_CHECK_EQUAL(array.getLength(), 32);
+        OCIO_CHECK_EQUAL(array.getNumColorComponents(), 1);
+        OCIO_CHECK_EQUAL(array.getNumValues(),
                          array.getLength()
                          *pLut->getArray().getMaxColorComponents());
 
-        OIIO_REQUIRE_EQUAL(array.getValues().size(), 96);
-        OIIO_CHECK_EQUAL(array.getValues()[0], 0.0f);
-        OIIO_CHECK_EQUAL(array.getValues()[1], 0.0f);
-        OIIO_CHECK_EQUAL(array.getValues()[2], 0.0f);
-        OIIO_CHECK_EQUAL(array.getValues()[3], 215.0f);
-        OIIO_CHECK_EQUAL(array.getValues()[4], 215.0f);
-        OIIO_CHECK_EQUAL(array.getValues()[5], 215.0f);
-        OIIO_CHECK_EQUAL(array.getValues()[6], 294.0f);
+        OCIO_REQUIRE_EQUAL(array.getValues().size(), 96);
+        OCIO_CHECK_EQUAL(array.getValues()[0], 0.0f);
+        OCIO_CHECK_EQUAL(array.getValues()[1], 0.0f);
+        OCIO_CHECK_EQUAL(array.getValues()[2], 0.0f);
+        OCIO_CHECK_EQUAL(array.getValues()[3], 215.0f);
+        OCIO_CHECK_EQUAL(array.getValues()[4], 215.0f);
+        OCIO_CHECK_EQUAL(array.getValues()[5], 215.0f);
+        OCIO_CHECK_EQUAL(array.getValues()[6], 294.0f);
         // and many more
-        OIIO_CHECK_EQUAL(array.getValues()[92], 1008.0f);
-        OIIO_CHECK_EQUAL(array.getValues()[93], 1023.0f);
-        OIIO_CHECK_EQUAL(array.getValues()[94], 1023.0f);
-        OIIO_CHECK_EQUAL(array.getValues()[95], 1023.0f);
+        OCIO_CHECK_EQUAL(array.getValues()[92], 1008.0f);
+        OCIO_CHECK_EQUAL(array.getValues()[93], 1023.0f);
+        OCIO_CHECK_EQUAL(array.getValues()[94], 1023.0f);
+        OCIO_CHECK_EQUAL(array.getValues()[95], 1023.0f);
     }
 
     // Test the hue adjust attribute.
     {
         const std::string ctfFile("lut1d_hue_adjust_test.ctf");
-        OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-        OIIO_REQUIRE_ASSERT((bool)cachedFile);
+        OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+        OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
         const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-        OIIO_REQUIRE_EQUAL(opList.size(), 1);
-        OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut1DType);
+        OCIO_REQUIRE_EQUAL(opList.size(), 1);
+        OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut1DType);
         auto pLut = std::dynamic_pointer_cast<const OCIO::Lut1DOpData>(opList[0]);
-        OIIO_REQUIRE_ASSERT(pLut);
-        OIIO_CHECK_EQUAL(pLut->getHueAdjust(), OCIO::Lut1DOpData::HUE_DW3);
+        OCIO_REQUIRE_ASSERT(pLut);
+        OCIO_CHECK_EQUAL(pLut->getHueAdjust(), OCIO::Lut1DOpData::HUE_DW3);
     }
 }
 
-OIIO_ADD_TEST(FileFormatCTF, matrix4x4)
+OCIO_ADD_TEST(FileFormatCTF, matrix4x4)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("matrix_example4x4.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::CTFVersion ctfVersion =
         cachedFile->m_transform->getCTFVersion();
-    OIIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_2 == ctfVersion);
+    OCIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_2 == ctfVersion);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
     auto pMatrix =
         std::dynamic_pointer_cast<const OCIO::MatrixOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pMatrix);
+    OCIO_REQUIRE_ASSERT(pMatrix);
 
-    OIIO_CHECK_ASSERT(cachedFile->m_transform->getInputDescriptor() == "XYZ");
-    OIIO_CHECK_ASSERT(cachedFile->m_transform->getOutputDescriptor() == "RGB");
+    OCIO_CHECK_ASSERT(cachedFile->m_transform->getInputDescriptor() == "XYZ");
+    OCIO_CHECK_ASSERT(cachedFile->m_transform->getOutputDescriptor() == "RGB");
 
-    OIIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     // In file, matrix is defined by a 4x4 array.
     const OCIO::ArrayDouble & array = pMatrix->getArray();
-    OIIO_CHECK_EQUAL(array.getLength(), 4);
-    OIIO_CHECK_EQUAL(array.getNumColorComponents(), 4);
-    OIIO_CHECK_EQUAL(array.getNumValues(),
+    OCIO_CHECK_EQUAL(array.getLength(), 4);
+    OCIO_CHECK_EQUAL(array.getNumColorComponents(), 4);
+    OCIO_CHECK_EQUAL(array.getNumValues(),
                      array.getLength()*array.getLength());
 
-    OIIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
-    OIIO_CHECK_EQUAL(array.getValues()[0],  3.24);
-    OIIO_CHECK_EQUAL(array.getValues()[1], -1.537);
-    OIIO_CHECK_EQUAL(array.getValues()[2], -0.49850);
-    OIIO_CHECK_EQUAL(array.getValues()[3],  0.0);
+    OCIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
+    OCIO_CHECK_EQUAL(array.getValues()[0],  3.24);
+    OCIO_CHECK_EQUAL(array.getValues()[1], -1.537);
+    OCIO_CHECK_EQUAL(array.getValues()[2], -0.49850);
+    OCIO_CHECK_EQUAL(array.getValues()[3],  0.0);
 
-    OIIO_CHECK_EQUAL(array.getValues()[4], -0.96930);
-    OIIO_CHECK_EQUAL(array.getValues()[5],  1.876);
-    OIIO_CHECK_EQUAL(array.getValues()[6],  0.04156);
-    OIIO_CHECK_EQUAL(array.getValues()[7],  0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[4], -0.96930);
+    OCIO_CHECK_EQUAL(array.getValues()[5],  1.876);
+    OCIO_CHECK_EQUAL(array.getValues()[6],  0.04156);
+    OCIO_CHECK_EQUAL(array.getValues()[7],  0.0);
 
-    OIIO_CHECK_EQUAL(array.getValues()[8],  0.05560);
-    OIIO_CHECK_EQUAL(array.getValues()[9], -0.204);
+    OCIO_CHECK_EQUAL(array.getValues()[8],  0.05560);
+    OCIO_CHECK_EQUAL(array.getValues()[9], -0.204);
     // Validate double precision can be read both matrix and ...
-    OIIO_CHECK_EQUAL(array.getValues()[10], 1.123456789012);
-    OIIO_CHECK_EQUAL(array.getValues()[11], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[10], 1.123456789012);
+    OCIO_CHECK_EQUAL(array.getValues()[11], 0.0);
 
-    OIIO_CHECK_EQUAL(array.getValues()[12], 0.0);
-    OIIO_CHECK_EQUAL(array.getValues()[13], 0.0);
-    OIIO_CHECK_EQUAL(array.getValues()[14], 0.0);
-    OIIO_CHECK_EQUAL(array.getValues()[15], 1.0);
+    OCIO_CHECK_EQUAL(array.getValues()[12], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[13], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[14], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[15], 1.0);
 
     const OCIO::MatrixOpData::Offsets & offsets = pMatrix->getOffsets();
     // ... offset
-    OIIO_CHECK_EQUAL(offsets[0], 0.987654321098);
-    OIIO_CHECK_EQUAL(offsets[1], 0.2);
-    OIIO_CHECK_EQUAL(offsets[2], 0.3);
-    OIIO_CHECK_EQUAL(offsets[3], 0.0);
+    OCIO_CHECK_EQUAL(offsets[0], 0.987654321098);
+    OCIO_CHECK_EQUAL(offsets[1], 0.2);
+    OCIO_CHECK_EQUAL(offsets[2], 0.3);
+    OCIO_CHECK_EQUAL(offsets[3], 0.0);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, matrix_1_3_3x3)
+OCIO_ADD_TEST(FileFormatCTF, matrix_1_3_3x3)
 {
     // Version 1.3, array 3x3x3: matrix with no alpha and no offsets.
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("matrix_example_1_3_3x3.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::CTFVersion & ctfVersion =
         cachedFile->m_transform->getCTFVersion();
-    OIIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_3 == ctfVersion);
+    OCIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_3 == ctfVersion);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
     auto pMatrix =
         std::dynamic_pointer_cast<const OCIO::MatrixOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pMatrix);
+    OCIO_REQUIRE_ASSERT(pMatrix);
 
-    OIIO_CHECK_ASSERT(cachedFile->m_transform->getInputDescriptor() == "XYZ");
-    OIIO_CHECK_ASSERT(cachedFile->m_transform->getOutputDescriptor() == "RGB");
+    OCIO_CHECK_ASSERT(cachedFile->m_transform->getInputDescriptor() == "XYZ");
+    OCIO_CHECK_ASSERT(cachedFile->m_transform->getOutputDescriptor() == "RGB");
 
-    OIIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
 
     // 3x3 array gets extended to 4x4.
     const OCIO::ArrayDouble & array = pMatrix->getArray();
-    OIIO_CHECK_EQUAL(array.getLength(), 4);
-    OIIO_CHECK_EQUAL(array.getNumColorComponents(), 4);
-    OIIO_CHECK_EQUAL(array.getNumValues(),
+    OCIO_CHECK_EQUAL(array.getLength(), 4);
+    OCIO_CHECK_EQUAL(array.getNumColorComponents(), 4);
+    OCIO_CHECK_EQUAL(array.getNumValues(),
                      array.getLength()*array.getLength());
 
-    OIIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
-    OIIO_CHECK_EQUAL(array.getValues()[0],  3.24);
-    OIIO_CHECK_EQUAL(array.getValues()[1], -1.537);
-    OIIO_CHECK_EQUAL(array.getValues()[2], -0.49850);
-    OIIO_CHECK_EQUAL(array.getValues()[3],  0.0);
+    OCIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
+    OCIO_CHECK_EQUAL(array.getValues()[0],  3.24);
+    OCIO_CHECK_EQUAL(array.getValues()[1], -1.537);
+    OCIO_CHECK_EQUAL(array.getValues()[2], -0.49850);
+    OCIO_CHECK_EQUAL(array.getValues()[3],  0.0);
 
-    OIIO_CHECK_EQUAL(array.getValues()[4], -0.96930);
-    OIIO_CHECK_EQUAL(array.getValues()[5],  1.876);
-    OIIO_CHECK_EQUAL(array.getValues()[6],  0.04156);
-    OIIO_CHECK_EQUAL(array.getValues()[7],  0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[4], -0.96930);
+    OCIO_CHECK_EQUAL(array.getValues()[5],  1.876);
+    OCIO_CHECK_EQUAL(array.getValues()[6],  0.04156);
+    OCIO_CHECK_EQUAL(array.getValues()[7],  0.0);
 
-    OIIO_CHECK_EQUAL(array.getValues()[8],  0.05560);
-    OIIO_CHECK_EQUAL(array.getValues()[9], -0.204);
-    OIIO_CHECK_EQUAL(array.getValues()[10], 1.0573);
-    OIIO_CHECK_EQUAL(array.getValues()[11], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[8],  0.05560);
+    OCIO_CHECK_EQUAL(array.getValues()[9], -0.204);
+    OCIO_CHECK_EQUAL(array.getValues()[10], 1.0573);
+    OCIO_CHECK_EQUAL(array.getValues()[11], 0.0);
 
-    OIIO_CHECK_EQUAL(array.getValues()[12], 0.0);
-    OIIO_CHECK_EQUAL(array.getValues()[13], 0.0);
-    OIIO_CHECK_EQUAL(array.getValues()[14], 0.0);
-    OIIO_CHECK_EQUAL(array.getValues()[15], 1.0);
+    OCIO_CHECK_EQUAL(array.getValues()[12], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[13], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[14], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[15], 1.0);
 
     const OCIO::MatrixOpData::Offsets & offsets = pMatrix->getOffsets();
-    OIIO_CHECK_EQUAL(offsets[1], 0.0);
-    OIIO_CHECK_EQUAL(offsets[2], 0.0);
-    OIIO_CHECK_EQUAL(offsets[3], 0.0);
-    OIIO_CHECK_EQUAL(offsets[0], 0.0);
+    OCIO_CHECK_EQUAL(offsets[1], 0.0);
+    OCIO_CHECK_EQUAL(offsets[2], 0.0);
+    OCIO_CHECK_EQUAL(offsets[3], 0.0);
+    OCIO_CHECK_EQUAL(offsets[0], 0.0);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, matrix_1_3_4x4)
+OCIO_ADD_TEST(FileFormatCTF, matrix_1_3_4x4)
 {
     // Version 1.3, array 4x4x4, matrix with alpha and no offsets.
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("matrix_example_1_3_4x4.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::CTFVersion & ctfVersion =
         cachedFile->m_transform->getCTFVersion();
-    OIIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_3 == ctfVersion);
+    OCIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_3 == ctfVersion);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
     auto pMatrix =
         std::dynamic_pointer_cast<const OCIO::MatrixOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pMatrix);
+    OCIO_REQUIRE_ASSERT(pMatrix);
 
-    OIIO_CHECK_ASSERT(cachedFile->m_transform->getInputDescriptor() == "XYZ");
-    OIIO_CHECK_ASSERT(cachedFile->m_transform->getOutputDescriptor() == "RGB");
+    OCIO_CHECK_ASSERT(cachedFile->m_transform->getInputDescriptor() == "XYZ");
+    OCIO_CHECK_ASSERT(cachedFile->m_transform->getOutputDescriptor() == "RGB");
 
-    OIIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     const OCIO::ArrayDouble & array = pMatrix->getArray();
-    OIIO_CHECK_EQUAL(array.getLength(), 4);
-    OIIO_CHECK_EQUAL(array.getNumColorComponents(), 4);
-    OIIO_CHECK_EQUAL(array.getNumValues(),
+    OCIO_CHECK_EQUAL(array.getLength(), 4);
+    OCIO_CHECK_EQUAL(array.getNumColorComponents(), 4);
+    OCIO_CHECK_EQUAL(array.getNumValues(),
                      array.getLength()*array.getLength());
 
-    OIIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
+    OCIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
 
-    OIIO_CHECK_EQUAL(array.getValues()[0],  3.24);
-    OIIO_CHECK_EQUAL(array.getValues()[1], -1.537);
-    OIIO_CHECK_EQUAL(array.getValues()[2], -0.49850);
-    OIIO_CHECK_EQUAL(array.getValues()[3], -0.1);
+    OCIO_CHECK_EQUAL(array.getValues()[0],  3.24);
+    OCIO_CHECK_EQUAL(array.getValues()[1], -1.537);
+    OCIO_CHECK_EQUAL(array.getValues()[2], -0.49850);
+    OCIO_CHECK_EQUAL(array.getValues()[3], -0.1);
 
-    OIIO_CHECK_EQUAL(array.getValues()[4], -0.96930);
-    OIIO_CHECK_EQUAL(array.getValues()[5],  1.876);
-    OIIO_CHECK_EQUAL(array.getValues()[6],  0.04156);
-    OIIO_CHECK_EQUAL(array.getValues()[7], -0.2);
+    OCIO_CHECK_EQUAL(array.getValues()[4], -0.96930);
+    OCIO_CHECK_EQUAL(array.getValues()[5],  1.876);
+    OCIO_CHECK_EQUAL(array.getValues()[6],  0.04156);
+    OCIO_CHECK_EQUAL(array.getValues()[7], -0.2);
 
-    OIIO_CHECK_EQUAL(array.getValues()[8],   0.05560);
-    OIIO_CHECK_EQUAL(array.getValues()[9],  -0.204);
-    OIIO_CHECK_EQUAL(array.getValues()[10],  1.0573);
-    OIIO_CHECK_EQUAL(array.getValues()[11], -0.3);
+    OCIO_CHECK_EQUAL(array.getValues()[8],   0.05560);
+    OCIO_CHECK_EQUAL(array.getValues()[9],  -0.204);
+    OCIO_CHECK_EQUAL(array.getValues()[10],  1.0573);
+    OCIO_CHECK_EQUAL(array.getValues()[11], -0.3);
 
-    OIIO_CHECK_EQUAL(array.getValues()[12], 0.11);
-    OIIO_CHECK_EQUAL(array.getValues()[13], 0.22);
-    OIIO_CHECK_EQUAL(array.getValues()[14], 0.33);
-    OIIO_CHECK_EQUAL(array.getValues()[15], 0.4);
+    OCIO_CHECK_EQUAL(array.getValues()[12], 0.11);
+    OCIO_CHECK_EQUAL(array.getValues()[13], 0.22);
+    OCIO_CHECK_EQUAL(array.getValues()[14], 0.33);
+    OCIO_CHECK_EQUAL(array.getValues()[15], 0.4);
 
     const OCIO::MatrixOpData::Offsets & offsets = pMatrix->getOffsets();
-    OIIO_CHECK_EQUAL(offsets[0], 0.0);
-    OIIO_CHECK_EQUAL(offsets[1], 0.0);
-    OIIO_CHECK_EQUAL(offsets[2], 0.0);
-    OIIO_CHECK_EQUAL(offsets[3], 0.0);
+    OCIO_CHECK_EQUAL(offsets[0], 0.0);
+    OCIO_CHECK_EQUAL(offsets[1], 0.0);
+    OCIO_CHECK_EQUAL(offsets[2], 0.0);
+    OCIO_CHECK_EQUAL(offsets[3], 0.0);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, matrix_1_3_offsets)
+OCIO_ADD_TEST(FileFormatCTF, matrix_1_3_offsets)
 {
     // Version 1.3, array 3x4x3: matrix only with offsets and no alpha.
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("matrix_example_1_3_offsets.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::CTFVersion ctfVersion =
         cachedFile->m_transform->getCTFVersion();
-    OIIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_3 == ctfVersion);
+    OCIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_3 == ctfVersion);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
     auto pMatrix =
         std::dynamic_pointer_cast<const OCIO::MatrixOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pMatrix);
+    OCIO_REQUIRE_ASSERT(pMatrix);
 
-    OIIO_CHECK_ASSERT(cachedFile->m_transform->getInputDescriptor() == "XYZ");
-    OIIO_CHECK_ASSERT(cachedFile->m_transform->getOutputDescriptor() == "RGB");
+    OCIO_CHECK_ASSERT(cachedFile->m_transform->getInputDescriptor() == "XYZ");
+    OCIO_CHECK_ASSERT(cachedFile->m_transform->getOutputDescriptor() == "RGB");
 
-    OIIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     const OCIO::ArrayDouble & array = pMatrix->getArray();
-    OIIO_CHECK_EQUAL(array.getLength(), 4);
-    OIIO_CHECK_EQUAL(array.getNumColorComponents(), 4);
-    OIIO_CHECK_EQUAL(array.getNumValues(),
+    OCIO_CHECK_EQUAL(array.getLength(), 4);
+    OCIO_CHECK_EQUAL(array.getNumColorComponents(), 4);
+    OCIO_CHECK_EQUAL(array.getNumValues(),
                      array.getLength()*array.getLength());
 
-    OIIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
-    OIIO_CHECK_EQUAL(array.getValues()[0],  3.24);
-    OIIO_CHECK_EQUAL(array.getValues()[1], -1.537);
-    OIIO_CHECK_EQUAL(array.getValues()[2], -0.49850);
-    OIIO_CHECK_EQUAL(array.getValues()[3],  0.0f);
+    OCIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
+    OCIO_CHECK_EQUAL(array.getValues()[0],  3.24);
+    OCIO_CHECK_EQUAL(array.getValues()[1], -1.537);
+    OCIO_CHECK_EQUAL(array.getValues()[2], -0.49850);
+    OCIO_CHECK_EQUAL(array.getValues()[3],  0.0f);
 
-    OIIO_CHECK_EQUAL(array.getValues()[4], -0.96930);
-    OIIO_CHECK_EQUAL(array.getValues()[5],  1.876);
-    OIIO_CHECK_EQUAL(array.getValues()[6],  0.04156);
-    OIIO_CHECK_EQUAL(array.getValues()[7],  0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[4], -0.96930);
+    OCIO_CHECK_EQUAL(array.getValues()[5],  1.876);
+    OCIO_CHECK_EQUAL(array.getValues()[6],  0.04156);
+    OCIO_CHECK_EQUAL(array.getValues()[7],  0.0);
 
-    OIIO_CHECK_EQUAL(array.getValues()[8],  0.05560);
-    OIIO_CHECK_EQUAL(array.getValues()[9], -0.204);
-    OIIO_CHECK_EQUAL(array.getValues()[10], 1.0573);
-    OIIO_CHECK_EQUAL(array.getValues()[11], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[8],  0.05560);
+    OCIO_CHECK_EQUAL(array.getValues()[9], -0.204);
+    OCIO_CHECK_EQUAL(array.getValues()[10], 1.0573);
+    OCIO_CHECK_EQUAL(array.getValues()[11], 0.0);
 
-    OIIO_CHECK_EQUAL(array.getValues()[12], 0.0);
-    OIIO_CHECK_EQUAL(array.getValues()[13], 0.0);
-    OIIO_CHECK_EQUAL(array.getValues()[14], 0.0);
-    OIIO_CHECK_EQUAL(array.getValues()[15], 1.0);
+    OCIO_CHECK_EQUAL(array.getValues()[12], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[13], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[14], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[15], 1.0);
 
     const OCIO::MatrixOpData::Offsets & offsets = pMatrix->getOffsets();
-    OIIO_CHECK_EQUAL(offsets[0], 0.1);
-    OIIO_CHECK_EQUAL(offsets[1], 0.2);
-    OIIO_CHECK_EQUAL(offsets[2], 0.3);
-    OIIO_CHECK_EQUAL(offsets[3], 0.0);
+    OCIO_CHECK_EQUAL(offsets[0], 0.1);
+    OCIO_CHECK_EQUAL(offsets[1], 0.2);
+    OCIO_CHECK_EQUAL(offsets[2], 0.3);
+    OCIO_CHECK_EQUAL(offsets[3], 0.0);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, matrix_1_3_alpha_offsets)
+OCIO_ADD_TEST(FileFormatCTF, matrix_1_3_alpha_offsets)
 {
     // Verion 1.3, array 4x5x4: matrix with alpha and offsets.
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("matrix_example_1_3_alpha_offsets.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::CTFVersion & ctfVersion =
         cachedFile->m_transform->getCTFVersion();
-    OIIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_3 == ctfVersion);
+    OCIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_3 == ctfVersion);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
     auto pMatrix =
         std::dynamic_pointer_cast<const OCIO::MatrixOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pMatrix);
+    OCIO_REQUIRE_ASSERT(pMatrix);
 
-    OIIO_CHECK_ASSERT(cachedFile->m_transform->getInputDescriptor() == "XYZ");
-    OIIO_CHECK_ASSERT(cachedFile->m_transform->getOutputDescriptor() == "RGB");
+    OCIO_CHECK_ASSERT(cachedFile->m_transform->getInputDescriptor() == "XYZ");
+    OCIO_CHECK_ASSERT(cachedFile->m_transform->getOutputDescriptor() == "RGB");
 
-    OIIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     const OCIO::ArrayDouble & array = pMatrix->getArray();
-    OIIO_CHECK_EQUAL(array.getLength(), 4);
-    OIIO_CHECK_EQUAL(array.getNumColorComponents(), 4);
-    OIIO_CHECK_EQUAL(array.getNumValues(),
+    OCIO_CHECK_EQUAL(array.getLength(), 4);
+    OCIO_CHECK_EQUAL(array.getNumColorComponents(), 4);
+    OCIO_CHECK_EQUAL(array.getNumValues(),
                      array.getLength()*array.getLength());
 
-    OIIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
-    OIIO_CHECK_EQUAL(array.getValues()[0],  3.24);
-    OIIO_CHECK_EQUAL(array.getValues()[1], -1.537);
-    OIIO_CHECK_EQUAL(array.getValues()[2], -0.49850);
-    OIIO_CHECK_EQUAL(array.getValues()[3],  0.6);
+    OCIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
+    OCIO_CHECK_EQUAL(array.getValues()[0],  3.24);
+    OCIO_CHECK_EQUAL(array.getValues()[1], -1.537);
+    OCIO_CHECK_EQUAL(array.getValues()[2], -0.49850);
+    OCIO_CHECK_EQUAL(array.getValues()[3],  0.6);
 
-    OIIO_CHECK_EQUAL(array.getValues()[4], -0.96930);
-    OIIO_CHECK_EQUAL(array.getValues()[5],  1.876);
-    OIIO_CHECK_EQUAL(array.getValues()[6],  0.04156);
-    OIIO_CHECK_EQUAL(array.getValues()[7],  0.7);
+    OCIO_CHECK_EQUAL(array.getValues()[4], -0.96930);
+    OCIO_CHECK_EQUAL(array.getValues()[5],  1.876);
+    OCIO_CHECK_EQUAL(array.getValues()[6],  0.04156);
+    OCIO_CHECK_EQUAL(array.getValues()[7],  0.7);
 
-    OIIO_CHECK_EQUAL(array.getValues()[8],  0.05560);
-    OIIO_CHECK_EQUAL(array.getValues()[9], -0.204);
-    OIIO_CHECK_EQUAL(array.getValues()[10], 1.0573);
-    OIIO_CHECK_EQUAL(array.getValues()[11], 0.8);
+    OCIO_CHECK_EQUAL(array.getValues()[8],  0.05560);
+    OCIO_CHECK_EQUAL(array.getValues()[9], -0.204);
+    OCIO_CHECK_EQUAL(array.getValues()[10], 1.0573);
+    OCIO_CHECK_EQUAL(array.getValues()[11], 0.8);
 
-    OIIO_CHECK_EQUAL(array.getValues()[12], 1.2);
-    OIIO_CHECK_EQUAL(array.getValues()[13], 1.3);
-    OIIO_CHECK_EQUAL(array.getValues()[14], 1.4);
-    OIIO_CHECK_EQUAL(array.getValues()[15], 1.5);
+    OCIO_CHECK_EQUAL(array.getValues()[12], 1.2);
+    OCIO_CHECK_EQUAL(array.getValues()[13], 1.3);
+    OCIO_CHECK_EQUAL(array.getValues()[14], 1.4);
+    OCIO_CHECK_EQUAL(array.getValues()[15], 1.5);
 
     const OCIO::MatrixOpData::Offsets & offsets = pMatrix->getOffsets();
-    OIIO_CHECK_EQUAL(offsets[0], 0.1);
-    OIIO_CHECK_EQUAL(offsets[1], 0.2);
-    OIIO_CHECK_EQUAL(offsets[2], 0.3);
-    OIIO_CHECK_EQUAL(offsets[3], 0.4);
+    OCIO_CHECK_EQUAL(offsets[0], 0.1);
+    OCIO_CHECK_EQUAL(offsets[1], 0.2);
+    OCIO_CHECK_EQUAL(offsets[2], 0.3);
+    OCIO_CHECK_EQUAL(offsets[3], 0.4);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, 3by1d_lut)
+OCIO_ADD_TEST(FileFormatCTF, 3by1d_lut)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("xyz_to_rgb.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 2);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 2);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
     auto pMatrix =
         std::dynamic_pointer_cast<const OCIO::MatrixOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pMatrix);
+    OCIO_REQUIRE_ASSERT(pMatrix);
 
-    OIIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     const OCIO::ArrayDouble & a1 = pMatrix->getArray();
-    OIIO_CHECK_EQUAL(a1.getLength(), 4);
-    OIIO_CHECK_EQUAL(a1.getNumColorComponents(), 4);
-    OIIO_CHECK_EQUAL(a1.getNumValues(), a1.getLength()*a1.getLength());
+    OCIO_CHECK_EQUAL(a1.getLength(), 4);
+    OCIO_CHECK_EQUAL(a1.getNumColorComponents(), 4);
+    OCIO_CHECK_EQUAL(a1.getNumValues(), a1.getLength()*a1.getLength());
 
-    OIIO_REQUIRE_EQUAL(a1.getValues().size(), a1.getNumValues());
-    OIIO_CHECK_EQUAL(a1.getValues()[0],  3.24);
-    OIIO_CHECK_EQUAL(a1.getValues()[1], -1.537);
-    OIIO_CHECK_EQUAL(a1.getValues()[2], -0.49850);
-    OIIO_CHECK_EQUAL(a1.getValues()[3],  0.0);
+    OCIO_REQUIRE_EQUAL(a1.getValues().size(), a1.getNumValues());
+    OCIO_CHECK_EQUAL(a1.getValues()[0],  3.24);
+    OCIO_CHECK_EQUAL(a1.getValues()[1], -1.537);
+    OCIO_CHECK_EQUAL(a1.getValues()[2], -0.49850);
+    OCIO_CHECK_EQUAL(a1.getValues()[3],  0.0);
 
-    OIIO_CHECK_EQUAL(a1.getValues()[4], -0.96930);
-    OIIO_CHECK_EQUAL(a1.getValues()[5],  1.876);
-    OIIO_CHECK_EQUAL(a1.getValues()[6],  0.04156);
-    OIIO_CHECK_EQUAL(a1.getValues()[7],  0.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[4], -0.96930);
+    OCIO_CHECK_EQUAL(a1.getValues()[5],  1.876);
+    OCIO_CHECK_EQUAL(a1.getValues()[6],  0.04156);
+    OCIO_CHECK_EQUAL(a1.getValues()[7],  0.0);
 
-    OIIO_CHECK_EQUAL(a1.getValues()[8],  0.05560);
-    OIIO_CHECK_EQUAL(a1.getValues()[9], -0.204);
-    OIIO_CHECK_EQUAL(a1.getValues()[10], 1.0573);
-    OIIO_CHECK_EQUAL(a1.getValues()[11], 0.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[8],  0.05560);
+    OCIO_CHECK_EQUAL(a1.getValues()[9], -0.204);
+    OCIO_CHECK_EQUAL(a1.getValues()[10], 1.0573);
+    OCIO_CHECK_EQUAL(a1.getValues()[11], 0.0);
 
-    OIIO_CHECK_EQUAL(a1.getValues()[12], 0.0);
-    OIIO_CHECK_EQUAL(a1.getValues()[13], 0.0);
-    OIIO_CHECK_EQUAL(a1.getValues()[14], 0.0);
-    OIIO_CHECK_EQUAL(a1.getValues()[15], 1.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[12], 0.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[13], 0.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[14], 0.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[15], 1.0);
 
     auto pLut =
         std::dynamic_pointer_cast<const OCIO::Lut1DOpData>(opList[1]);
-    OIIO_REQUIRE_ASSERT(pLut);
-    OIIO_CHECK_EQUAL(pLut->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(pLut->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pLut->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_REQUIRE_ASSERT(pLut);
+    OCIO_CHECK_EQUAL(pLut->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(pLut->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pLut->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     const OCIO::Array & a2 = pLut->getArray();
-    OIIO_CHECK_EQUAL(a2.getLength(), 17);
-    OIIO_CHECK_EQUAL(a2.getNumColorComponents(), 3);
-    OIIO_CHECK_EQUAL(a2.getNumValues(),
+    OCIO_CHECK_EQUAL(a2.getLength(), 17);
+    OCIO_CHECK_EQUAL(a2.getNumColorComponents(), 3);
+    OCIO_CHECK_EQUAL(a2.getNumValues(),
                      a2.getLength()*pLut->getArray().getMaxColorComponents());
 
-    OIIO_REQUIRE_EQUAL(a2.getValues().size(), a2.getNumValues());
-    OIIO_CHECK_EQUAL(a2.getValues()[0], 0.0f);
-    OIIO_CHECK_EQUAL(a2.getValues()[1], 0.0f);
-    OIIO_CHECK_EQUAL(a2.getValues()[2], 0.0f);
-    OIIO_CHECK_EQUAL(a2.getValues()[3], 0.28358f);
+    OCIO_REQUIRE_EQUAL(a2.getValues().size(), a2.getNumValues());
+    OCIO_CHECK_EQUAL(a2.getValues()[0], 0.0f);
+    OCIO_CHECK_EQUAL(a2.getValues()[1], 0.0f);
+    OCIO_CHECK_EQUAL(a2.getValues()[2], 0.0f);
+    OCIO_CHECK_EQUAL(a2.getValues()[3], 0.28358f);
 
-    OIIO_CHECK_EQUAL(a2.getValues()[21], 0.68677f);
-    OIIO_CHECK_EQUAL(a2.getValues()[22], 0.68677f);
-    OIIO_CHECK_EQUAL(a2.getValues()[23], 0.68677f);
+    OCIO_CHECK_EQUAL(a2.getValues()[21], 0.68677f);
+    OCIO_CHECK_EQUAL(a2.getValues()[22], 0.68677f);
+    OCIO_CHECK_EQUAL(a2.getValues()[23], 0.68677f);
 
-    OIIO_CHECK_EQUAL(a2.getValues()[48], 1.0f);
-    OIIO_CHECK_EQUAL(a2.getValues()[49], 1.0f);
-    OIIO_CHECK_EQUAL(a2.getValues()[50], 1.0f);
+    OCIO_CHECK_EQUAL(a2.getValues()[48], 1.0f);
+    OCIO_CHECK_EQUAL(a2.getValues()[49], 1.0f);
+    OCIO_CHECK_EQUAL(a2.getValues()[50], 1.0f);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, lut1d_inv)
+OCIO_ADD_TEST(FileFormatCTF, lut1d_inv)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("lut1d_inv.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 2);
+    OCIO_REQUIRE_EQUAL(opList.size(), 2);
 
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
     auto pMatrix =
         std::dynamic_pointer_cast<const OCIO::MatrixOpData>(opList[0]);
 
-    OIIO_REQUIRE_ASSERT(pMatrix);
-    OIIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_REQUIRE_ASSERT(pMatrix);
+    OCIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     const OCIO::ArrayDouble & a1 = pMatrix->getArray();
-    OIIO_CHECK_EQUAL(a1.getLength(), 4);
-    OIIO_CHECK_EQUAL(a1.getNumColorComponents(), 4);
-    OIIO_CHECK_EQUAL(a1.getNumValues(), a1.getLength()*a1.getLength());
+    OCIO_CHECK_EQUAL(a1.getLength(), 4);
+    OCIO_CHECK_EQUAL(a1.getNumColorComponents(), 4);
+    OCIO_CHECK_EQUAL(a1.getNumValues(), a1.getLength()*a1.getLength());
 
-    OIIO_REQUIRE_EQUAL(a1.getValues().size(), a1.getNumValues());
-    OIIO_CHECK_EQUAL(a1.getValues()[0],  3.24);
-    OIIO_CHECK_EQUAL(a1.getValues()[1], -1.537);
-    OIIO_CHECK_EQUAL(a1.getValues()[2], -0.49850);
-    OIIO_CHECK_EQUAL(a1.getValues()[3],  0.0);
+    OCIO_REQUIRE_EQUAL(a1.getValues().size(), a1.getNumValues());
+    OCIO_CHECK_EQUAL(a1.getValues()[0],  3.24);
+    OCIO_CHECK_EQUAL(a1.getValues()[1], -1.537);
+    OCIO_CHECK_EQUAL(a1.getValues()[2], -0.49850);
+    OCIO_CHECK_EQUAL(a1.getValues()[3],  0.0);
 
-    OIIO_CHECK_EQUAL(a1.getValues()[4], -0.96930);
-    OIIO_CHECK_EQUAL(a1.getValues()[5],  1.876);
-    OIIO_CHECK_EQUAL(a1.getValues()[6],  0.04156);
-    OIIO_CHECK_EQUAL(a1.getValues()[7],  0.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[4], -0.96930);
+    OCIO_CHECK_EQUAL(a1.getValues()[5],  1.876);
+    OCIO_CHECK_EQUAL(a1.getValues()[6],  0.04156);
+    OCIO_CHECK_EQUAL(a1.getValues()[7],  0.0);
 
-    OIIO_CHECK_EQUAL(a1.getValues()[8],  0.05560);
-    OIIO_CHECK_EQUAL(a1.getValues()[9], -0.204);
-    OIIO_CHECK_EQUAL(a1.getValues()[10], 1.0573);
-    OIIO_CHECK_EQUAL(a1.getValues()[11], 0.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[8],  0.05560);
+    OCIO_CHECK_EQUAL(a1.getValues()[9], -0.204);
+    OCIO_CHECK_EQUAL(a1.getValues()[10], 1.0573);
+    OCIO_CHECK_EQUAL(a1.getValues()[11], 0.0);
 
-    OIIO_CHECK_EQUAL(a1.getValues()[12], 0.0);
-    OIIO_CHECK_EQUAL(a1.getValues()[13], 0.0);
-    OIIO_CHECK_EQUAL(a1.getValues()[14], 0.0);
-    OIIO_CHECK_EQUAL(a1.getValues()[15], 1.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[12], 0.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[13], 0.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[14], 0.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[15], 1.0);
 
-    OIIO_CHECK_EQUAL(opList[1]->getType(), OCIO::OpData::Lut1DType);
+    OCIO_CHECK_EQUAL(opList[1]->getType(), OCIO::OpData::Lut1DType);
     auto pLut =
         std::dynamic_pointer_cast<const OCIO::Lut1DOpData>(opList[1]);
 
-    OIIO_REQUIRE_ASSERT(pLut);
-    OIIO_CHECK_EQUAL(pLut->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pLut->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(pLut->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_REQUIRE_ASSERT(pLut);
+    OCIO_CHECK_EQUAL(pLut->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pLut->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(pLut->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
 
     const OCIO::Array & a2 = pLut->getArray();
-    OIIO_CHECK_EQUAL(a2.getNumColorComponents(), 3);
+    OCIO_CHECK_EQUAL(a2.getNumColorComponents(), 3);
 
-    OIIO_CHECK_EQUAL(a2.getLength(), 17);
-    OIIO_CHECK_EQUAL(a2.getNumValues(),
+    OCIO_CHECK_EQUAL(a2.getLength(), 17);
+    OCIO_CHECK_EQUAL(a2.getNumValues(),
                      a2.getLength()*a2.getMaxColorComponents());
 
     const float error = 1e-6f;
-    OIIO_REQUIRE_EQUAL(a2.getValues().size(), a2.getNumValues());
+    OCIO_REQUIRE_EQUAL(a2.getValues().size(), a2.getNumValues());
 
-    OIIO_CHECK_CLOSE(a2.getValues()[0], 0.0f, error);
-    OIIO_CHECK_CLOSE(a2.getValues()[1], 0.0f, error);
-    OIIO_CHECK_CLOSE(a2.getValues()[2], 0.0f, error);
-    OIIO_CHECK_CLOSE(a2.getValues()[3], 0.28358f, error);
+    OCIO_CHECK_CLOSE(a2.getValues()[0], 0.0f, error);
+    OCIO_CHECK_CLOSE(a2.getValues()[1], 0.0f, error);
+    OCIO_CHECK_CLOSE(a2.getValues()[2], 0.0f, error);
+    OCIO_CHECK_CLOSE(a2.getValues()[3], 0.28358f, error);
 
-    OIIO_CHECK_CLOSE(a2.getValues()[21], 0.68677f, error);
-    OIIO_CHECK_CLOSE(a2.getValues()[22], 0.68677f, error);
-    OIIO_CHECK_CLOSE(a2.getValues()[23], 0.68677f, error);
+    OCIO_CHECK_CLOSE(a2.getValues()[21], 0.68677f, error);
+    OCIO_CHECK_CLOSE(a2.getValues()[22], 0.68677f, error);
+    OCIO_CHECK_CLOSE(a2.getValues()[23], 0.68677f, error);
 
-    OIIO_CHECK_CLOSE(a2.getValues()[48], 1.0f, error);
-    OIIO_CHECK_CLOSE(a2.getValues()[49], 1.0f, error);
-    OIIO_CHECK_CLOSE(a2.getValues()[50], 1.0f, error);
+    OCIO_CHECK_CLOSE(a2.getValues()[48], 1.0f, error);
+    OCIO_CHECK_CLOSE(a2.getValues()[49], 1.0f, error);
+    OCIO_CHECK_CLOSE(a2.getValues()[50], 1.0f, error);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, lut3d)
+OCIO_ADD_TEST(FileFormatCTF, lut3d)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("lut3d_17x17x17_32f_12i.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
 
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut3DType);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut3DType);
     auto pLut =
         std::dynamic_pointer_cast<const OCIO::Lut3DOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pLut);
-    OIIO_CHECK_EQUAL(pLut->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(pLut->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pLut->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_REQUIRE_ASSERT(pLut);
+    OCIO_CHECK_EQUAL(pLut->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(pLut->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pLut->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 
     const OCIO::Array & array = pLut->getArray();
-    OIIO_CHECK_EQUAL(array.getLength(), 17);
-    OIIO_CHECK_EQUAL(array.getNumColorComponents(), 3);
-    OIIO_CHECK_EQUAL(array.getNumValues(),
+    OCIO_CHECK_EQUAL(array.getLength(), 17);
+    OCIO_CHECK_EQUAL(array.getNumColorComponents(), 3);
+    OCIO_CHECK_EQUAL(array.getNumValues(),
                      array.getLength()*array.getLength()
                      *array.getLength()
                      *pLut->getArray().getMaxColorComponents());
 
-    OIIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
-    OIIO_CHECK_EQUAL(array.getValues()[0], 10.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[1], 0.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[2], 5.0f);
+    OCIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
+    OCIO_CHECK_EQUAL(array.getValues()[0], 10.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[1], 0.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[2], 5.0f);
 
-    OIIO_CHECK_EQUAL(array.getValues()[18], 26.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[19], 308.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[20], 580.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[18], 26.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[19], 308.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[20], 580.0f);
 
-    OIIO_CHECK_EQUAL(array.getValues()[30], 0.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[31], 586.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[32], 1350.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[30], 0.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[31], 586.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[32], 1350.0f);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, lut3d_inv)
+OCIO_ADD_TEST(FileFormatCTF, lut3d_inv)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("lut3d_example_Inv.ctf");
 
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
 
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut3DType);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut3DType);
     auto pLut =
         std::dynamic_pointer_cast<const OCIO::Lut3DOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pLut);
+    OCIO_REQUIRE_ASSERT(pLut);
 
-    OIIO_CHECK_EQUAL(pLut->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL(pLut->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pLut->getInterpolation(), OCIO::INTERP_TETRAHEDRAL);
-    OIIO_CHECK_EQUAL(pLut->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(pLut->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(pLut->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pLut->getInterpolation(), OCIO::INTERP_TETRAHEDRAL);
+    OCIO_CHECK_EQUAL(pLut->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
 
     const OCIO::Array & array = pLut->getArray();
-    OIIO_CHECK_EQUAL(array.getNumColorComponents(), 3);
-    OIIO_CHECK_EQUAL(array.getNumValues(),
+    OCIO_CHECK_EQUAL(array.getNumColorComponents(), 3);
+    OCIO_CHECK_EQUAL(array.getNumValues(),
                      array.getLength()*array.getLength()
                      *array.getLength()*array.getMaxColorComponents());
-    OIIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
+    OCIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
 
-    OIIO_CHECK_EQUAL(array.getLength(), 17);
-    OIIO_CHECK_EQUAL(array.getValues()[0], 25.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[1], 30.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[2], 33.0f);
+    OCIO_CHECK_EQUAL(array.getLength(), 17);
+    OCIO_CHECK_EQUAL(array.getValues()[0], 25.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[1], 30.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[2], 33.0f);
 
-    OIIO_CHECK_EQUAL(array.getValues()[18], 26.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[19], 308.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[20], 580.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[18], 26.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[19], 308.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[20], 580.0f);
 
-    OIIO_CHECK_EQUAL(array.getValues()[30], 0.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[31], 586.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[32], 1350.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[30], 0.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[31], 586.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[32], 1350.0f);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, check_utf8)
+OCIO_ADD_TEST(FileFormatCTF, check_utf8)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("matrix_example_utf8.clf");
 
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_REQUIRE_EQUAL(opList[0]->getDescriptions().size(), 1);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_REQUIRE_EQUAL(opList[0]->getDescriptions().size(), 1);
     std::string & desc = opList[0]->getDescriptions()[0];
     const std::string utf8Test
         ("\xE6\xA8\x99\xE6\xBA\x96\xE8\x90\xAC\xE5\x9C\x8B\xE7\xA2\xBC");
-    OIIO_CHECK_EQUAL(desc, utf8Test);
+    OCIO_CHECK_EQUAL(desc, utf8Test);
     const std::string utf8TestWrong
         ("\xE5\xA8\x99\xE6\xBA\x96\xE8\x90\xAC\xE5\x9C\x8B\xE7\xA2\xBC");
-    OIIO_CHECK_NE(desc, utf8TestWrong);
+    OCIO_CHECK_NE(desc, utf8TestWrong);
 
 }
 
-OIIO_ADD_TEST(FileFormatCTF, error_checker)
+OCIO_ADD_TEST(FileFormatCTF, error_checker)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     // NB: This file has some added unknown elements A, B, and C as a test.
     const std::string ctfFile("unknown_elements.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 4);
+    OCIO_REQUIRE_EQUAL(opList.size(), 4);
 
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
     auto pMatrix =
         std::dynamic_pointer_cast<const OCIO::MatrixOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pMatrix);
+    OCIO_REQUIRE_ASSERT(pMatrix);
 
-    OIIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     const OCIO::ArrayDouble & a1 = pMatrix->getArray();
-    OIIO_CHECK_EQUAL(a1.getLength(), 4);
-    OIIO_CHECK_EQUAL(a1.getNumColorComponents(), 4);
-    OIIO_CHECK_EQUAL(a1.getNumValues(), a1.getLength()*a1.getLength());
+    OCIO_CHECK_EQUAL(a1.getLength(), 4);
+    OCIO_CHECK_EQUAL(a1.getNumColorComponents(), 4);
+    OCIO_CHECK_EQUAL(a1.getNumValues(), a1.getLength()*a1.getLength());
 
-    OIIO_REQUIRE_EQUAL(a1.getValues().size(), a1.getNumValues());
-    OIIO_CHECK_EQUAL(a1.getValues()[0],  3.24);
-    OIIO_CHECK_EQUAL(a1.getValues()[1], -1.537);
-    OIIO_CHECK_EQUAL(a1.getValues()[2], -0.49850);
-    OIIO_CHECK_EQUAL(a1.getValues()[3],  0.0);
+    OCIO_REQUIRE_EQUAL(a1.getValues().size(), a1.getNumValues());
+    OCIO_CHECK_EQUAL(a1.getValues()[0],  3.24);
+    OCIO_CHECK_EQUAL(a1.getValues()[1], -1.537);
+    OCIO_CHECK_EQUAL(a1.getValues()[2], -0.49850);
+    OCIO_CHECK_EQUAL(a1.getValues()[3],  0.0);
 
-    OIIO_CHECK_EQUAL(a1.getValues()[4], -0.96930);
-    OIIO_CHECK_EQUAL(a1.getValues()[5],  1.876);
-    OIIO_CHECK_EQUAL(a1.getValues()[6],  0.04156);
-    OIIO_CHECK_EQUAL(a1.getValues()[7],  0.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[4], -0.96930);
+    OCIO_CHECK_EQUAL(a1.getValues()[5],  1.876);
+    OCIO_CHECK_EQUAL(a1.getValues()[6],  0.04156);
+    OCIO_CHECK_EQUAL(a1.getValues()[7],  0.0);
 
-    OIIO_CHECK_EQUAL(a1.getValues()[8],  0.05560);
-    OIIO_CHECK_EQUAL(a1.getValues()[9], -0.204);
-    OIIO_CHECK_EQUAL(a1.getValues()[10], 1.0573);
-    OIIO_CHECK_EQUAL(a1.getValues()[11], 0.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[8],  0.05560);
+    OCIO_CHECK_EQUAL(a1.getValues()[9], -0.204);
+    OCIO_CHECK_EQUAL(a1.getValues()[10], 1.0573);
+    OCIO_CHECK_EQUAL(a1.getValues()[11], 0.0);
 
-    OIIO_CHECK_EQUAL(a1.getValues()[12], 0.0);
-    OIIO_CHECK_EQUAL(a1.getValues()[13], 0.0);
-    OIIO_CHECK_EQUAL(a1.getValues()[14], 0.0);
-    OIIO_CHECK_EQUAL(a1.getValues()[15], 1.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[12], 0.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[13], 0.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[14], 0.0);
+    OCIO_CHECK_EQUAL(a1.getValues()[15], 1.0);
 
-    OIIO_CHECK_EQUAL(opList[1]->getType(), OCIO::OpData::Lut1DType);
+    OCIO_CHECK_EQUAL(opList[1]->getType(), OCIO::OpData::Lut1DType);
     auto pLut1 =
         std::dynamic_pointer_cast<const OCIO::Lut1DOpData>(opList[1]);
-    OIIO_REQUIRE_ASSERT(pLut1);
-    OIIO_CHECK_EQUAL(pLut1->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pLut1->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_REQUIRE_ASSERT(pLut1);
+    OCIO_CHECK_EQUAL(pLut1->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pLut1->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     const OCIO::Array & a2 = pLut1->getArray();
-    OIIO_CHECK_EQUAL(a2.getLength(), 17);
-    OIIO_CHECK_EQUAL(a2.getNumColorComponents(), 3);
-    OIIO_CHECK_EQUAL(a2.getNumValues(), 
+    OCIO_CHECK_EQUAL(a2.getLength(), 17);
+    OCIO_CHECK_EQUAL(a2.getNumColorComponents(), 3);
+    OCIO_CHECK_EQUAL(a2.getNumValues(), 
                      a2.getLength()
                      *pLut1->getArray().getMaxColorComponents());
 
-    OIIO_REQUIRE_EQUAL(a2.getValues().size(), a2.getNumValues());
-    OIIO_CHECK_EQUAL(a2.getValues()[0], 0.0f);
-    OIIO_CHECK_EQUAL(a2.getValues()[1], 0.0f);
-    OIIO_CHECK_EQUAL(a2.getValues()[2], 0.01f);
-    OIIO_CHECK_EQUAL(a2.getValues()[3], 0.28358f);
-    OIIO_CHECK_EQUAL(a2.getValues()[4], 0.28358f);
-    OIIO_CHECK_EQUAL(a2.getValues()[5], 100.0f);
-    OIIO_CHECK_EQUAL(a2.getValues()[6], 0.38860f);
-    OIIO_CHECK_EQUAL(a2.getValues()[7], 0.38860f);
-    OIIO_CHECK_EQUAL(a2.getValues()[8], 127.0f);
+    OCIO_REQUIRE_EQUAL(a2.getValues().size(), a2.getNumValues());
+    OCIO_CHECK_EQUAL(a2.getValues()[0], 0.0f);
+    OCIO_CHECK_EQUAL(a2.getValues()[1], 0.0f);
+    OCIO_CHECK_EQUAL(a2.getValues()[2], 0.01f);
+    OCIO_CHECK_EQUAL(a2.getValues()[3], 0.28358f);
+    OCIO_CHECK_EQUAL(a2.getValues()[4], 0.28358f);
+    OCIO_CHECK_EQUAL(a2.getValues()[5], 100.0f);
+    OCIO_CHECK_EQUAL(a2.getValues()[6], 0.38860f);
+    OCIO_CHECK_EQUAL(a2.getValues()[7], 0.38860f);
+    OCIO_CHECK_EQUAL(a2.getValues()[8], 127.0f);
 
-    OIIO_CHECK_EQUAL(a2.getValues()[21], 0.68677f);
-    OIIO_CHECK_EQUAL(a2.getValues()[22], 0.68677f);
-    OIIO_CHECK_EQUAL(a2.getValues()[23], 0.68677f);
+    OCIO_CHECK_EQUAL(a2.getValues()[21], 0.68677f);
+    OCIO_CHECK_EQUAL(a2.getValues()[22], 0.68677f);
+    OCIO_CHECK_EQUAL(a2.getValues()[23], 0.68677f);
 
-    OIIO_CHECK_EQUAL(a2.getValues()[48], 1.0f);
-    OIIO_CHECK_EQUAL(a2.getValues()[49], 1.0f);
-    OIIO_CHECK_EQUAL(a2.getValues()[50], 1.0f);
+    OCIO_CHECK_EQUAL(a2.getValues()[48], 1.0f);
+    OCIO_CHECK_EQUAL(a2.getValues()[49], 1.0f);
+    OCIO_CHECK_EQUAL(a2.getValues()[50], 1.0f);
 
-    OIIO_CHECK_EQUAL(opList[2]->getType(), OCIO::OpData::Lut1DType);
+    OCIO_CHECK_EQUAL(opList[2]->getType(), OCIO::OpData::Lut1DType);
     auto pLut2 =
         std::dynamic_pointer_cast<const OCIO::Lut1DOpData>(opList[2]);
-    OIIO_REQUIRE_ASSERT(pLut2);
-    OIIO_CHECK_EQUAL(pLut2->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pLut2->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_REQUIRE_ASSERT(pLut2);
+    OCIO_CHECK_EQUAL(pLut2->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pLut2->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
 
     const OCIO::Array & array = pLut2->getArray();
-    OIIO_CHECK_EQUAL(array.getLength(), 32);
-    OIIO_CHECK_EQUAL(array.getNumColorComponents(), 1);
-    OIIO_CHECK_EQUAL(array.getNumValues(),
+    OCIO_CHECK_EQUAL(array.getLength(), 32);
+    OCIO_CHECK_EQUAL(array.getNumColorComponents(), 1);
+    OCIO_CHECK_EQUAL(array.getNumValues(),
                      array.getLength()
                      *pLut2->getArray().getMaxColorComponents());
 
-    OIIO_REQUIRE_EQUAL(array.getValues().size(), 96);
-    OIIO_CHECK_EQUAL(array.getValues()[0], 0.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[1], 0.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[2], 0.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[3], 215.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[4], 215.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[5], 215.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[6], 294.0f);
+    OCIO_REQUIRE_EQUAL(array.getValues().size(), 96);
+    OCIO_CHECK_EQUAL(array.getValues()[0], 0.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[1], 0.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[2], 0.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[3], 215.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[4], 215.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[5], 215.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[6], 294.0f);
     // and many more
-    OIIO_CHECK_EQUAL(array.getValues()[92], 1008.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[93], 1023.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[94], 1023.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[95], 1023.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[92], 1008.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[93], 1023.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[94], 1023.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[95], 1023.0f);
 
-    OIIO_CHECK_EQUAL(opList[3]->getType(), OCIO::OpData::Lut3DType);
+    OCIO_CHECK_EQUAL(opList[3]->getType(), OCIO::OpData::Lut3DType);
     auto pLut3 =
         std::dynamic_pointer_cast<const OCIO::Lut3DOpData>(opList[3]);
-    OIIO_REQUIRE_ASSERT(pLut3);
-    OIIO_CHECK_EQUAL(pLut3->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_EQUAL(pLut3->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_REQUIRE_ASSERT(pLut3);
+    OCIO_CHECK_EQUAL(pLut3->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(pLut3->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
 
     const OCIO::Array & a3 = pLut3->getArray();
-    OIIO_CHECK_EQUAL(a3.getLength(), 3);
-    OIIO_CHECK_EQUAL(a3.getNumColorComponents(), 3);
-    OIIO_CHECK_EQUAL(a3.getNumValues(),
+    OCIO_CHECK_EQUAL(a3.getLength(), 3);
+    OCIO_CHECK_EQUAL(a3.getNumColorComponents(), 3);
+    OCIO_CHECK_EQUAL(a3.getNumValues(),
                      a3.getLength()*a3.getLength()*a3.getLength()
                      *pLut3->getArray().getMaxColorComponents());
 
-    OIIO_REQUIRE_EQUAL(a3.getValues().size(), a3.getNumValues());
-    OIIO_CHECK_EQUAL(a3.getValues()[0], 0.0f);
-    OIIO_CHECK_EQUAL(a3.getValues()[1], 30.0f);
-    OIIO_CHECK_EQUAL(a3.getValues()[2], 33.0f);
-    OIIO_CHECK_EQUAL(a3.getValues()[3], 0.0f);
-    OIIO_CHECK_EQUAL(a3.getValues()[4], 0.0f);
-    OIIO_CHECK_EQUAL(a3.getValues()[5], 133.0f);
+    OCIO_REQUIRE_EQUAL(a3.getValues().size(), a3.getNumValues());
+    OCIO_CHECK_EQUAL(a3.getValues()[0], 0.0f);
+    OCIO_CHECK_EQUAL(a3.getValues()[1], 30.0f);
+    OCIO_CHECK_EQUAL(a3.getValues()[2], 33.0f);
+    OCIO_CHECK_EQUAL(a3.getValues()[3], 0.0f);
+    OCIO_CHECK_EQUAL(a3.getValues()[4], 0.0f);
+    OCIO_CHECK_EQUAL(a3.getValues()[5], 133.0f);
 
-    OIIO_CHECK_EQUAL(a3.getValues()[78], 1023.0f);
-    OIIO_CHECK_EQUAL(a3.getValues()[79], 1023.0f);
-    OIIO_CHECK_EQUAL(a3.getValues()[80], 1023.0f);
+    OCIO_CHECK_EQUAL(a3.getValues()[78], 1023.0f);
+    OCIO_CHECK_EQUAL(a3.getValues()[79], 1023.0f);
+    OCIO_CHECK_EQUAL(a3.getValues()[80], 1023.0f);
 
     // TODO: check log for parsing warnings.
     // DummyElt is logging at debug level.
@@ -2096,85 +2096,85 @@ OIIO_ADD_TEST(FileFormatCTF, error_checker)
     // Ignore element 'A' (line 36) where its parent is 'Description' (line 36) : unknown_elements.clf
 }
 
-OIIO_ADD_TEST(FileFormatCTF, binary_file)
+OCIO_ADD_TEST(FileFormatCTF, binary_file)
 {
     const std::string ctfFile("image_png.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
                           "is not a CTF/CLF file.");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, error_checker_for_difficult_xml)
+OCIO_ADD_TEST(FileFormatCTF, error_checker_for_difficult_xml)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("difficult_test1_v1.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     // Defaults to 1.2
     const OCIO::CTFVersion ctfVersion =
         cachedFile->m_transform->getCTFVersion();
-    OIIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_2 == ctfVersion);
+    OCIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_2 == ctfVersion);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 2);
+    OCIO_REQUIRE_EQUAL(opList.size(), 2);
 
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
     auto pMatrix =
         std::dynamic_pointer_cast<const OCIO::MatrixOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pMatrix);
-    OIIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_REQUIRE_ASSERT(pMatrix);
+    OCIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     const OCIO::ArrayDouble & array = pMatrix->getArray();
-    OIIO_CHECK_EQUAL(array.getLength(), 4u);
-    OIIO_CHECK_EQUAL(array.getNumColorComponents(), 4u);
-    OIIO_CHECK_EQUAL(array.getNumValues(),
+    OCIO_CHECK_EQUAL(array.getLength(), 4u);
+    OCIO_CHECK_EQUAL(array.getNumColorComponents(), 4u);
+    OCIO_CHECK_EQUAL(array.getNumValues(),
                      array.getLength()*array.getLength());
 
-    OIIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
-    OIIO_CHECK_EQUAL(array.getValues()[0],  3.24);
-    OIIO_CHECK_EQUAL(array.getValues()[1], -1.537);
-    OIIO_CHECK_EQUAL(array.getValues()[2], -0.4985);
-    OIIO_CHECK_EQUAL(array.getValues()[3],  0.0);
+    OCIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
+    OCIO_CHECK_EQUAL(array.getValues()[0],  3.24);
+    OCIO_CHECK_EQUAL(array.getValues()[1], -1.537);
+    OCIO_CHECK_EQUAL(array.getValues()[2], -0.4985);
+    OCIO_CHECK_EQUAL(array.getValues()[3],  0.0);
 
-    OIIO_CHECK_EQUAL(array.getValues()[4], -0.96930);
-    OIIO_CHECK_EQUAL(array.getValues()[5],  1.876);
-    OIIO_CHECK_EQUAL(array.getValues()[6],  0.04156);
-    OIIO_CHECK_EQUAL(array.getValues()[7],  0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[4], -0.96930);
+    OCIO_CHECK_EQUAL(array.getValues()[5],  1.876);
+    OCIO_CHECK_EQUAL(array.getValues()[6],  0.04156);
+    OCIO_CHECK_EQUAL(array.getValues()[7],  0.0);
 
-    OIIO_CHECK_EQUAL(array.getValues()[8],  0.0556);
-    OIIO_CHECK_EQUAL(array.getValues()[9], -0.204);
-    OIIO_CHECK_EQUAL(array.getValues()[10], 0.105730e+1);
-    OIIO_CHECK_EQUAL(array.getValues()[11], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[8],  0.0556);
+    OCIO_CHECK_EQUAL(array.getValues()[9], -0.204);
+    OCIO_CHECK_EQUAL(array.getValues()[10], 0.105730e+1);
+    OCIO_CHECK_EQUAL(array.getValues()[11], 0.0);
 
-    OIIO_CHECK_EQUAL(array.getValues()[12], 0.0);
-    OIIO_CHECK_EQUAL(array.getValues()[13], 0.0);
-    OIIO_CHECK_EQUAL(array.getValues()[14], 0.0);
-    OIIO_CHECK_EQUAL(array.getValues()[15], 1.0);
+    OCIO_CHECK_EQUAL(array.getValues()[12], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[13], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[14], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[15], 1.0);
 
     auto pLut = std::dynamic_pointer_cast<const OCIO::Lut1DOpData>(opList[1]);
-    OIIO_REQUIRE_ASSERT(pLut);
-    OIIO_CHECK_EQUAL(pLut->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pLut->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_REQUIRE_ASSERT(pLut);
+    OCIO_CHECK_EQUAL(pLut->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pLut->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     const OCIO::Array & array2 = pLut->getArray();
-    OIIO_CHECK_EQUAL(array2.getLength(), 17);
-    OIIO_CHECK_EQUAL(array2.getNumColorComponents(), 3);
-    OIIO_CHECK_EQUAL(array2.getNumValues(),
+    OCIO_CHECK_EQUAL(array2.getLength(), 17);
+    OCIO_CHECK_EQUAL(array2.getNumColorComponents(), 3);
+    OCIO_CHECK_EQUAL(array2.getNumValues(),
                      array2.getLength()
                      *pLut->getArray().getMaxColorComponents());
 
-    OIIO_REQUIRE_EQUAL(array2.getValues().size(), 51);
-    OIIO_CHECK_EQUAL(array2.getValues()[0], 0.0f);
-    OIIO_CHECK_EQUAL(array2.getValues()[1], 0.0f);
-    OIIO_CHECK_EQUAL(array2.getValues()[2], 0.0f);
-    OIIO_CHECK_EQUAL(array2.getValues()[3], 0.28358f);
-    OIIO_CHECK_EQUAL(array2.getValues()[4], 0.28358f);
-    OIIO_CHECK_EQUAL(array2.getValues()[5], 0.28358f);
-    OIIO_CHECK_EQUAL(array2.getValues()[6], 0.38860f);
-    OIIO_CHECK_EQUAL(array2.getValues()[45], 0.97109f);
-    OIIO_CHECK_EQUAL(array2.getValues()[46], 0.97109f);
-    OIIO_CHECK_EQUAL(array2.getValues()[47], 0.97109f);
+    OCIO_REQUIRE_EQUAL(array2.getValues().size(), 51);
+    OCIO_CHECK_EQUAL(array2.getValues()[0], 0.0f);
+    OCIO_CHECK_EQUAL(array2.getValues()[1], 0.0f);
+    OCIO_CHECK_EQUAL(array2.getValues()[2], 0.0f);
+    OCIO_CHECK_EQUAL(array2.getValues()[3], 0.28358f);
+    OCIO_CHECK_EQUAL(array2.getValues()[4], 0.28358f);
+    OCIO_CHECK_EQUAL(array2.getValues()[5], 0.28358f);
+    OCIO_CHECK_EQUAL(array2.getValues()[6], 0.38860f);
+    OCIO_CHECK_EQUAL(array2.getValues()[45], 0.97109f);
+    OCIO_CHECK_EQUAL(array2.getValues()[46], 0.97109f);
+    OCIO_CHECK_EQUAL(array2.getValues()[47], 0.97109f);
 
     // TODO: check log for parsing warnings.
     // DummyElt is logging at debug level.
@@ -2189,429 +2189,429 @@ OIIO_ADD_TEST(FileFormatCTF, error_checker_for_difficult_xml)
     // Ignore element 'Array' (line 77) where its parent is 'Matrix' (line 75) : difficult_test1_v1.ctf
 }
 
-OIIO_ADD_TEST(FileFormatCTF, invalid_transform)
+OCIO_ADD_TEST(FileFormatCTF, invalid_transform)
 {
     const std::string ctfFile("transform_invalid.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
                           "is not a CTF/CLF file.");
 }
 
 
-OIIO_ADD_TEST(FileFormatCTF, missing_element_end)
+OCIO_ADD_TEST(FileFormatCTF, missing_element_end)
 {
     const std::string ctfFile("transform_element_end_missing.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, "no element found");
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, "no element found");
 }
 
 
-OIIO_ADD_TEST(FileFormatCTF, missing_transform_id)
+OCIO_ADD_TEST(FileFormatCTF, missing_transform_id)
 {
     const std::string ctfFile("transform_missing_id.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "Required attribute 'id'");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, missing_in_bitdepth)
+OCIO_ADD_TEST(FileFormatCTF, missing_in_bitdepth)
 {
     const std::string ctfFile("transform_missing_inbitdepth.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "inBitDepth is missing");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, missing_out_bitdepth)
+OCIO_ADD_TEST(FileFormatCTF, missing_out_bitdepth)
 {
     const std::string ctfFile("transform_missing_outbitdepth.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "outBitDepth is missing");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, array_missing_values)
+OCIO_ADD_TEST(FileFormatCTF, array_missing_values)
 {
     const std::string ctfFile("array_missing_values.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "Expected 3x3 Array values");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, array_illegal_values)
+OCIO_ADD_TEST(FileFormatCTF, array_illegal_values)
 {
     const std::string ctfFile("array_illegal_values.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
                           "Illegal values");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, unknown_value)
+OCIO_ADD_TEST(FileFormatCTF, unknown_value)
 {
     const std::string ctfFile("unknown_outdepth.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "outBitDepth unknown value");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, array_corrupted_dimension)
+OCIO_ADD_TEST(FileFormatCTF, array_corrupted_dimension)
 {
     const std::string ctfFile("array_illegal_dimension.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "Illegal dimensions");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, array_too_many_values)
+OCIO_ADD_TEST(FileFormatCTF, array_too_many_values)
 {
     const std::string ctfFile("array_too_many_values.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "Expected 3x3 Array, found too many values");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, matrix_bitdepth_illegal)
+OCIO_ADD_TEST(FileFormatCTF, matrix_bitdepth_illegal)
 {
     const std::string ctfFile("matrix_bitdepth_illegal.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "inBitDepth unknown value");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, matrix_end_missing)
+OCIO_ADD_TEST(FileFormatCTF, matrix_end_missing)
 {
     const std::string ctfFile("matrix_end_missing.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "no closing tag for 'Matrix'");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, transform_corrupted_tag)
+OCIO_ADD_TEST(FileFormatCTF, transform_corrupted_tag)
 {
     const std::string ctfFile("transform_corrupted_tag.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
                           "no closing tag");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, transform_empty)
+OCIO_ADD_TEST(FileFormatCTF, transform_empty)
 {
     const std::string ctfFile("transform_empty.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "No color operator");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, transform_id_empty)
+OCIO_ADD_TEST(FileFormatCTF, transform_id_empty)
 {
     const std::string ctfFile("transform_id_empty.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "Required attribute 'id' does not have a value");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, transform_with_bitdepth_mismatch)
+OCIO_ADD_TEST(FileFormatCTF, transform_with_bitdepth_mismatch)
 {
     const std::string ctfFile("transform_bitdepth_mismatch.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "Bitdepth missmatch");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, check_index_map)
+OCIO_ADD_TEST(FileFormatCTF, check_index_map)
 {
     const std::string ctfFile("indexMap_test.ctf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "Only two entry IndexMaps are supported");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, matrix_with_offset)
+OCIO_ADD_TEST(FileFormatCTF, matrix_with_offset)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("matrix_offsets_example.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
     // Note that the ProcessList does not have a version attribute and
     // therefore defaults to 1.2.
     // The "4x4x3" Array syntax is only allowed in versions 1.2 or earlier.
     const OCIO::CTFVersion ctfVersion =
         cachedFile->m_transform->getCTFVersion();
-    OIIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_2 == ctfVersion);
+    OCIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_2 == ctfVersion);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
     auto pMatrix =
         std::dynamic_pointer_cast<const OCIO::MatrixOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pMatrix);
+    OCIO_REQUIRE_ASSERT(pMatrix);
 
-    OIIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     const OCIO::ArrayDouble & array = pMatrix->getArray();
-    OIIO_CHECK_EQUAL(array.getLength(), 4);
-    OIIO_CHECK_EQUAL(array.getNumColorComponents(), 4);
-    OIIO_CHECK_EQUAL(array.getNumValues(),
+    OCIO_CHECK_EQUAL(array.getLength(), 4);
+    OCIO_CHECK_EQUAL(array.getNumColorComponents(), 4);
+    OCIO_CHECK_EQUAL(array.getNumValues(),
                      array.getLength()*array.getLength());
 
-    OIIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
-    OIIO_CHECK_EQUAL(array.getValues()[0],  3.24);
-    OIIO_CHECK_EQUAL(array.getValues()[1], -1.537);
-    OIIO_CHECK_EQUAL(array.getValues()[2], -0.49850);
-    OIIO_CHECK_EQUAL(array.getValues()[3],  0.0);
+    OCIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
+    OCIO_CHECK_EQUAL(array.getValues()[0],  3.24);
+    OCIO_CHECK_EQUAL(array.getValues()[1], -1.537);
+    OCIO_CHECK_EQUAL(array.getValues()[2], -0.49850);
+    OCIO_CHECK_EQUAL(array.getValues()[3],  0.0);
     
-    OIIO_CHECK_EQUAL(array.getValues()[4], -0.96930);
-    OIIO_CHECK_EQUAL(array.getValues()[5],  1.876);
-    OIIO_CHECK_EQUAL(array.getValues()[6],  0.04156);
-    OIIO_CHECK_EQUAL(array.getValues()[7],  0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[4], -0.96930);
+    OCIO_CHECK_EQUAL(array.getValues()[5],  1.876);
+    OCIO_CHECK_EQUAL(array.getValues()[6],  0.04156);
+    OCIO_CHECK_EQUAL(array.getValues()[7],  0.0);
     
-    OIIO_CHECK_EQUAL(array.getValues()[8],  0.05560);
-    OIIO_CHECK_EQUAL(array.getValues()[9], -0.204);
-    OIIO_CHECK_EQUAL(array.getValues()[10], 1.0573);
-    OIIO_CHECK_EQUAL(array.getValues()[11], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[8],  0.05560);
+    OCIO_CHECK_EQUAL(array.getValues()[9], -0.204);
+    OCIO_CHECK_EQUAL(array.getValues()[10], 1.0573);
+    OCIO_CHECK_EQUAL(array.getValues()[11], 0.0);
     
-    OIIO_CHECK_EQUAL(array.getValues()[12], 0.0);
-    OIIO_CHECK_EQUAL(array.getValues()[13], 0.0);
-    OIIO_CHECK_EQUAL(array.getValues()[14], 0.0);
-    OIIO_CHECK_EQUAL(array.getValues()[15], 1.0);
+    OCIO_CHECK_EQUAL(array.getValues()[12], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[13], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[14], 0.0);
+    OCIO_CHECK_EQUAL(array.getValues()[15], 1.0);
     
-    OIIO_CHECK_EQUAL(pMatrix->getOffsets()[0], 1.0);
-    OIIO_CHECK_EQUAL(pMatrix->getOffsets()[1], 2.0);
-    OIIO_CHECK_EQUAL(pMatrix->getOffsets()[2], 3.0);
+    OCIO_CHECK_EQUAL(pMatrix->getOffsets()[0], 1.0);
+    OCIO_CHECK_EQUAL(pMatrix->getOffsets()[1], 2.0);
+    OCIO_CHECK_EQUAL(pMatrix->getOffsets()[2], 3.0);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, matrix_with_offset_1_3)
+OCIO_ADD_TEST(FileFormatCTF, matrix_with_offset_1_3)
 {
     // Matrix 4 4 3 only valid up to version 1.2.
     const std::string ctfFile("matrix_offsets_example_1_3.ctf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "Illegal dimensions 4 4 3");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, lut_3by1d_with_nan_infinity)
+OCIO_ADD_TEST(FileFormatCTF, lut_3by1d_with_nan_infinity)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("lut3by1d_nan_infinity_example.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut1DType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut1DType);
     auto pLut1d =
         std::dynamic_pointer_cast<const OCIO::Lut1DOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pLut1d);
+    OCIO_REQUIRE_ASSERT(pLut1d);
 
     const OCIO::Array & array = pLut1d->getArray();
 
-    OIIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
-    OIIO_CHECK_ASSERT(OCIO::IsNan(array.getValues()[0]));
-    OIIO_CHECK_ASSERT(OCIO::IsNan(array.getValues()[1]));
-    OIIO_CHECK_ASSERT(OCIO::IsNan(array.getValues()[2]));
-    OIIO_CHECK_ASSERT(OCIO::IsNan(array.getValues()[3]));
-    OIIO_CHECK_ASSERT(OCIO::IsNan(array.getValues()[4]));
-    OIIO_CHECK_EQUAL(array.getValues()[5],
+    OCIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
+    OCIO_CHECK_ASSERT(OCIO::IsNan(array.getValues()[0]));
+    OCIO_CHECK_ASSERT(OCIO::IsNan(array.getValues()[1]));
+    OCIO_CHECK_ASSERT(OCIO::IsNan(array.getValues()[2]));
+    OCIO_CHECK_ASSERT(OCIO::IsNan(array.getValues()[3]));
+    OCIO_CHECK_ASSERT(OCIO::IsNan(array.getValues()[4]));
+    OCIO_CHECK_EQUAL(array.getValues()[5],
                      std::numeric_limits<float>::infinity());
-    OIIO_CHECK_EQUAL(array.getValues()[6],
+    OCIO_CHECK_EQUAL(array.getValues()[6],
                      std::numeric_limits<float>::infinity());
-    OIIO_CHECK_EQUAL(array.getValues()[7],
+    OCIO_CHECK_EQUAL(array.getValues()[7],
                      std::numeric_limits<float>::infinity());
-    OIIO_CHECK_EQUAL(array.getValues()[8],
+    OCIO_CHECK_EQUAL(array.getValues()[8],
                      -std::numeric_limits<float>::infinity());
-    OIIO_CHECK_EQUAL(array.getValues()[9],
+    OCIO_CHECK_EQUAL(array.getValues()[9],
                      -std::numeric_limits<float>::infinity());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, lut1d_half_domain_set_false)
+OCIO_ADD_TEST(FileFormatCTF, lut1d_half_domain_set_false)
 {
     // Should throw an exception because the 'half_domain' tag
     // was found but set to something other than 'true'.
     const std::string ctfFile("lut1d_half_domain_set_false.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "Illegal 'halfDomain' attribute");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, lut1d_raw_half_set_false)
+OCIO_ADD_TEST(FileFormatCTF, lut1d_raw_half_set_false)
 {
     // Should throw an exception because the 'raw_halfs' tag
     // was found but set to something other than 'true'.
     const std::string ctfFile("lut1d_raw_half_set_false.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "Illegal 'rawHalfs' attribute");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, lut1d_half_domain_raw_half_set)
+OCIO_ADD_TEST(FileFormatCTF, lut1d_half_domain_raw_half_set)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("lut1d_half_domain_raw_half_set.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut1DType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut1DType);
     auto pLut1d =
         std::dynamic_pointer_cast<const OCIO::Lut1DOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pLut1d);
+    OCIO_REQUIRE_ASSERT(pLut1d);
 
-    OIIO_CHECK_ASSERT(pLut1d->isInputHalfDomain());
-    OIIO_CHECK_ASSERT(pLut1d->isOutputRawHalfs());
+    OCIO_CHECK_ASSERT(pLut1d->isInputHalfDomain());
+    OCIO_CHECK_ASSERT(pLut1d->isOutputRawHalfs());
     
-    OIIO_CHECK_EQUAL(pLut1d->getArray().getValues()[0],
+    OCIO_CHECK_EQUAL(pLut1d->getArray().getValues()[0],
                      OCIO::ConvertHalfBitsToFloat(0));
-    OIIO_CHECK_EQUAL(pLut1d->getArray().getValues()[3],
+    OCIO_CHECK_EQUAL(pLut1d->getArray().getValues()[3],
                      OCIO::ConvertHalfBitsToFloat(215));
-    OIIO_CHECK_EQUAL(pLut1d->getArray().getValues()[6],
+    OCIO_CHECK_EQUAL(pLut1d->getArray().getValues()[6],
                      OCIO::ConvertHalfBitsToFloat(294));
-    OIIO_CHECK_EQUAL(pLut1d->getArray().getValues()[9],
+    OCIO_CHECK_EQUAL(pLut1d->getArray().getValues()[9],
                      OCIO::ConvertHalfBitsToFloat(354));
-    OIIO_CHECK_EQUAL(pLut1d->getArray().getValues()[12],
+    OCIO_CHECK_EQUAL(pLut1d->getArray().getValues()[12],
                      OCIO::ConvertHalfBitsToFloat(403));
 }
 
-OIIO_ADD_TEST(FileFormatCTF, lut1d_half_domain_invalid_entries)
+OCIO_ADD_TEST(FileFormatCTF, lut1d_half_domain_invalid_entries)
 {
     const std::string ctfFile("lut1d_half_domain_invalid_entries.clf");
     // This should fail with invalid entries exception because the number
     // of entries in the op is not 65536 (required when using half domain).
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "65536 required for halfDomain");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, inverse_of_id_test)
+OCIO_ADD_TEST(FileFormatCTF, inverse_of_id_test)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("inverseOfId_test.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
-    OIIO_CHECK_ASSERT(cachedFile->m_transform->getInverseOfId() ==
+    OCIO_CHECK_ASSERT(cachedFile->m_transform->getInverseOfId() ==
                       "inverseOfIdTest");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, range1)
+OCIO_ADD_TEST(FileFormatCTF, range1)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("range_test1.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::RangeType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::RangeType);
     auto pR = std::dynamic_pointer_cast<const OCIO::RangeOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pR);
+    OCIO_REQUIRE_ASSERT(pR);
 
-    OIIO_CHECK_EQUAL(pR->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(pR->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pR->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(pR->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     // NB: All exactly representable as flt
-    OIIO_CHECK_EQUAL(pR->getMinInValue(), 16.);
-    OIIO_CHECK_EQUAL(pR->getMaxInValue(), 235.);
-    OIIO_CHECK_EQUAL(pR->getMinOutValue(), -0.5);
-    OIIO_CHECK_EQUAL(pR->getMaxOutValue(), 2.);
+    OCIO_CHECK_EQUAL(pR->getMinInValue(), 16.);
+    OCIO_CHECK_EQUAL(pR->getMaxInValue(), 235.);
+    OCIO_CHECK_EQUAL(pR->getMinOutValue(), -0.5);
+    OCIO_CHECK_EQUAL(pR->getMaxOutValue(), 2.);
 
-    OIIO_CHECK_ASSERT(!pR->minIsEmpty());
-    OIIO_CHECK_ASSERT(!pR->maxIsEmpty());
+    OCIO_CHECK_ASSERT(!pR->minIsEmpty());
+    OCIO_CHECK_ASSERT(!pR->maxIsEmpty());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, range2)
+OCIO_ADD_TEST(FileFormatCTF, range2)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("range_test2.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::RangeType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::RangeType);
     auto pR = std::dynamic_pointer_cast<const OCIO::RangeOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pR);
-    OIIO_CHECK_EQUAL(pR->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pR->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_REQUIRE_ASSERT(pR);
+    OCIO_CHECK_EQUAL(pR->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pR->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
 
-    OIIO_CHECK_EQUAL((float)pR->getMinInValue(), 0.1f);
-    OIIO_CHECK_EQUAL((float)pR->getMinOutValue(), -0.1f);
+    OCIO_CHECK_EQUAL((float)pR->getMinInValue(), 0.1f);
+    OCIO_CHECK_EQUAL((float)pR->getMinOutValue(), -0.1f);
 
-    OIIO_CHECK_ASSERT(!pR->minIsEmpty());
-    OIIO_CHECK_ASSERT(pR->maxIsEmpty());
+    OCIO_CHECK_ASSERT(!pR->minIsEmpty());
+    OCIO_CHECK_ASSERT(pR->maxIsEmpty());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, range3)
+OCIO_ADD_TEST(FileFormatCTF, range3)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("range_test3.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::RangeType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::RangeType);
     auto pR = std::dynamic_pointer_cast<const OCIO::RangeOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pR);
-    OIIO_CHECK_EQUAL(pR->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(pR->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_REQUIRE_ASSERT(pR);
+    OCIO_CHECK_EQUAL(pR->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(pR->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_ASSERT(pR->minIsEmpty());
-    OIIO_CHECK_ASSERT(pR->maxIsEmpty());
+    OCIO_CHECK_ASSERT(pR->minIsEmpty());
+    OCIO_CHECK_ASSERT(pR->maxIsEmpty());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, gamma1)
+OCIO_ADD_TEST(FileFormatCTF, gamma1)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("gamma_test1.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
-    OIIO_CHECK_EQUAL(cachedFile->m_transform->getID(), "id");
+    OCIO_CHECK_EQUAL(cachedFile->m_transform->getID(), "id");
 
-    OIIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions().size(), 1);
-    OIIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[0], "2.4 gamma");
+    OCIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions().size(), 1);
+    OCIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[0], "2.4 gamma");
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
     auto pG = std::dynamic_pointer_cast<const OCIO::GammaOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pG);
+    OCIO_REQUIRE_ASSERT(pG);
 
-    OIIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
 
-    OIIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::BASIC_FWD);
+    OCIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::BASIC_FWD);
 
     OCIO::GammaOpData::Params params;
     params.push_back(2.4);
 
-    OIIO_CHECK_ASSERT(pG->getRedParams() == params);
-    OIIO_CHECK_ASSERT(pG->getGreenParams() == params);
-    OIIO_CHECK_ASSERT(pG->getBlueParams() == params);
+    OCIO_CHECK_ASSERT(pG->getRedParams() == params);
+    OCIO_CHECK_ASSERT(pG->getGreenParams() == params);
+    OCIO_CHECK_ASSERT(pG->getBlueParams() == params);
     // Version of the ctf is less than 1.5, so alpha must be identity.
-    OIIO_CHECK_ASSERT(OCIO::GammaOpData::isIdentityParameters(
+    OCIO_CHECK_ASSERT(OCIO::GammaOpData::isIdentityParameters(
                           pG->getAlphaParams(),
                           pG->getStyle()));
 
-    OIIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
-    OIIO_CHECK_ASSERT(pG->isNonChannelDependent()); // RGB are equal, A is an identity
+    OCIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
+    OCIO_CHECK_ASSERT(pG->isNonChannelDependent()); // RGB are equal, A is an identity
 }
 
-OIIO_ADD_TEST(FileFormatCTF, gamma2)
+OCIO_ADD_TEST(FileFormatCTF, gamma2)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("gamma_test2.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
     auto pG = std::dynamic_pointer_cast<const OCIO::GammaOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pG);
+    OCIO_REQUIRE_ASSERT(pG);
 
-    OIIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
 
-    OIIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::BASIC_REV);
+    OCIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::BASIC_REV);
     OCIO::GammaOpData::Params paramsR;
     paramsR.push_back(2.4);
     OCIO::GammaOpData::Params paramsG;
@@ -2619,68 +2619,68 @@ OIIO_ADD_TEST(FileFormatCTF, gamma2)
     OCIO::GammaOpData::Params paramsB;
     paramsB.push_back(2.2);
 
-    OIIO_CHECK_ASSERT(pG->getRedParams() == paramsR);
-    OIIO_CHECK_ASSERT(pG->getGreenParams() == paramsG);
-    OIIO_CHECK_ASSERT(pG->getBlueParams() == paramsB);
-    OIIO_CHECK_ASSERT(OCIO::GammaOpData::isIdentityParameters(
+    OCIO_CHECK_ASSERT(pG->getRedParams() == paramsR);
+    OCIO_CHECK_ASSERT(pG->getGreenParams() == paramsG);
+    OCIO_CHECK_ASSERT(pG->getBlueParams() == paramsB);
+    OCIO_CHECK_ASSERT(OCIO::GammaOpData::isIdentityParameters(
                           pG->getAlphaParams(),
                           pG->getStyle()));
 
-    OIIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
-    OIIO_CHECK_ASSERT(!pG->isNonChannelDependent());
+    OCIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
+    OCIO_CHECK_ASSERT(!pG->isNonChannelDependent());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, gamma3)
+OCIO_ADD_TEST(FileFormatCTF, gamma3)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("gamma_test3.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
     auto pG = std::dynamic_pointer_cast<const OCIO::GammaOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pG);
+    OCIO_REQUIRE_ASSERT(pG);
 
-    OIIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
 
-    OIIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::MONCURVE_FWD);
+    OCIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::MONCURVE_FWD);
     OCIO::GammaOpData::Params params;
     params.push_back(1. / 0.45);
     params.push_back(0.099);
 
     // This is a precision test to ensure we can recreate a double that is
     // exactly equal to 1/0.45, which is required to implement rec 709 exactly.
-    OIIO_CHECK_ASSERT(pG->getRedParams() == params);
-    OIIO_CHECK_ASSERT(pG->getGreenParams() == params);
-    OIIO_CHECK_ASSERT(pG->getBlueParams() == params);
-    OIIO_CHECK_ASSERT(OCIO::GammaOpData::isIdentityParameters(
+    OCIO_CHECK_ASSERT(pG->getRedParams() == params);
+    OCIO_CHECK_ASSERT(pG->getGreenParams() == params);
+    OCIO_CHECK_ASSERT(pG->getBlueParams() == params);
+    OCIO_CHECK_ASSERT(OCIO::GammaOpData::isIdentityParameters(
                           pG->getAlphaParams(),
                           pG->getStyle()));
 
-    OIIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
-    OIIO_CHECK_ASSERT(pG->isNonChannelDependent());
+    OCIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
+    OCIO_CHECK_ASSERT(pG->isNonChannelDependent());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, gamma4)
+OCIO_ADD_TEST(FileFormatCTF, gamma4)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("gamma_test4.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
     auto pG = std::dynamic_pointer_cast<const OCIO::GammaOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pG);
+    OCIO_REQUIRE_ASSERT(pG);
 
-    OIIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::MONCURVE_REV);
+    OCIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::MONCURVE_REV);
     OCIO::GammaOpData::Params paramsR;
     paramsR.push_back(2.2);
     paramsR.push_back(0.001);
@@ -2691,27 +2691,27 @@ OIIO_ADD_TEST(FileFormatCTF, gamma4)
     paramsB.push_back(2.6);
     paramsB.push_back(0.1);
 
-    OIIO_CHECK_ASSERT(pG->getRedParams() == paramsR);
-    OIIO_CHECK_ASSERT(pG->getGreenParams() == paramsG);
-    OIIO_CHECK_ASSERT(pG->getBlueParams() == paramsB);
-    OIIO_CHECK_ASSERT(OCIO::GammaOpData::isIdentityParameters(
+    OCIO_CHECK_ASSERT(pG->getRedParams() == paramsR);
+    OCIO_CHECK_ASSERT(pG->getGreenParams() == paramsG);
+    OCIO_CHECK_ASSERT(pG->getBlueParams() == paramsB);
+    OCIO_CHECK_ASSERT(OCIO::GammaOpData::isIdentityParameters(
                           pG->getAlphaParams(),
                           pG->getStyle()));
 
-    OIIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
-    OIIO_CHECK_ASSERT(!pG->isNonChannelDependent());
+    OCIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
+    OCIO_CHECK_ASSERT(!pG->isNonChannelDependent());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, gamma5)
+OCIO_ADD_TEST(FileFormatCTF, gamma5)
 {
     // This test is for an old (< 1.5) transform file that contains
     // an invalid GammaParams for the A channel.
     const std::string ctfFile("gamma_test5.ctf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
                           "Invalid channel");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, gamma6)
+OCIO_ADD_TEST(FileFormatCTF, gamma6)
 {
     // This test is for an old (< 1.5) transform file that contains
     // a single GammaParams with identity values:
@@ -2719,33 +2719,33 @@ OIIO_ADD_TEST(FileFormatCTF, gamma6)
     // - A set to identity.
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("gamma_test6.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
     auto pG = std::dynamic_pointer_cast<const OCIO::GammaOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pG);
+    OCIO_REQUIRE_ASSERT(pG);
 
-    OIIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
 
-    OIIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::MONCURVE_FWD);
-    OIIO_CHECK_ASSERT(pG->areAllComponentsEqual());
-    OIIO_CHECK_ASSERT(pG->isNonChannelDependent()); 
-    OIIO_CHECK_ASSERT(pG->isIdentity());
+    OCIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::MONCURVE_FWD);
+    OCIO_CHECK_ASSERT(pG->areAllComponentsEqual());
+    OCIO_CHECK_ASSERT(pG->isNonChannelDependent()); 
+    OCIO_CHECK_ASSERT(pG->isIdentity());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, gamma_wrong_power)
+OCIO_ADD_TEST(FileFormatCTF, gamma_wrong_power)
 {
     // The moncurve style requires a gamma value >= 1.
     const std::string ctfFile("gamma_wrong_power.ctf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
                           "is less than lower bound");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, gamma_alpha1)
+OCIO_ADD_TEST(FileFormatCTF, gamma_alpha1)
 {
     // This test is for a new (>= 1.5) transform file that contains
     // a single GammaParams:
@@ -2753,52 +2753,52 @@ OIIO_ADD_TEST(FileFormatCTF, gamma_alpha1)
     // - A set to identity.
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("gamma_alpha_test1.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
     auto pG = std::dynamic_pointer_cast<const OCIO::GammaOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pG);
+    OCIO_REQUIRE_ASSERT(pG);
 
-    OIIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::BASIC_FWD);
+    OCIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::BASIC_FWD);
 
     OCIO::GammaOpData::Params params;
     params.push_back(2.4);
 
-    OIIO_CHECK_ASSERT(pG->getRedParams() == params);
-    OIIO_CHECK_ASSERT(pG->getGreenParams() == params);
-    OIIO_CHECK_ASSERT(pG->getBlueParams() == params);
-    OIIO_CHECK_ASSERT(OCIO::GammaOpData::isIdentityParameters(
+    OCIO_CHECK_ASSERT(pG->getRedParams() == params);
+    OCIO_CHECK_ASSERT(pG->getGreenParams() == params);
+    OCIO_CHECK_ASSERT(pG->getBlueParams() == params);
+    OCIO_CHECK_ASSERT(OCIO::GammaOpData::isIdentityParameters(
                           pG->getAlphaParams(),
                           pG->getStyle()));
 
-    OIIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
-    OIIO_CHECK_ASSERT(pG->isNonChannelDependent());
+    OCIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
+    OCIO_CHECK_ASSERT(pG->isNonChannelDependent());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, gamma_alpha2)
+OCIO_ADD_TEST(FileFormatCTF, gamma_alpha2)
 {
     // This test is for a new (>= 1.5) transform file that contains
     // a different GammaParams for every channel:
     // - R, G, B and A set to different parameters.
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("gamma_alpha_test2.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
     auto pG = std::dynamic_pointer_cast<const OCIO::GammaOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pG);
+    OCIO_REQUIRE_ASSERT(pG);
 
-    OIIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::BASIC_REV);
+    OCIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::BASIC_REV);
 
     OCIO::GammaOpData::Params paramsR;
     paramsR.push_back(2.4);
@@ -2809,16 +2809,16 @@ OIIO_ADD_TEST(FileFormatCTF, gamma_alpha2)
     OCIO::GammaOpData::Params paramsA;
     paramsA.push_back(2.5);
 
-    OIIO_CHECK_ASSERT(pG->getRedParams() == paramsR);
-    OIIO_CHECK_ASSERT(pG->getGreenParams() == paramsG);
-    OIIO_CHECK_ASSERT(pG->getBlueParams() == paramsB);
-    OIIO_CHECK_ASSERT(pG->getAlphaParams() == paramsA);
+    OCIO_CHECK_ASSERT(pG->getRedParams() == paramsR);
+    OCIO_CHECK_ASSERT(pG->getGreenParams() == paramsG);
+    OCIO_CHECK_ASSERT(pG->getBlueParams() == paramsB);
+    OCIO_CHECK_ASSERT(pG->getAlphaParams() == paramsA);
 
-    OIIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
-    OIIO_CHECK_ASSERT(!pG->isNonChannelDependent());
+    OCIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
+    OCIO_CHECK_ASSERT(!pG->isNonChannelDependent());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, gamma_alpha3)
+OCIO_ADD_TEST(FileFormatCTF, gamma_alpha3)
 {
     // This test is for a new (>= 1.5) transform file that contains
     // a single GammaParams:
@@ -2826,53 +2826,53 @@ OIIO_ADD_TEST(FileFormatCTF, gamma_alpha3)
     // - A set to identity.
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("gamma_alpha_test3.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
     auto pG = std::dynamic_pointer_cast<const OCIO::GammaOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pG);
+    OCIO_REQUIRE_ASSERT(pG);
 
-    OIIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::MONCURVE_FWD);
+    OCIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::MONCURVE_FWD);
 
     OCIO::GammaOpData::Params params;
     params.push_back(1. / 0.45);
     params.push_back(0.099);
 
-    OIIO_CHECK_ASSERT(pG->getRedParams() == params);
-    OIIO_CHECK_ASSERT(pG->getGreenParams() == params);
-    OIIO_CHECK_ASSERT(pG->getBlueParams() == params);
-    OIIO_CHECK_ASSERT(OCIO::GammaOpData::isIdentityParameters(
+    OCIO_CHECK_ASSERT(pG->getRedParams() == params);
+    OCIO_CHECK_ASSERT(pG->getGreenParams() == params);
+    OCIO_CHECK_ASSERT(pG->getBlueParams() == params);
+    OCIO_CHECK_ASSERT(OCIO::GammaOpData::isIdentityParameters(
                           pG->getAlphaParams(),
                           pG->getStyle()));
 
-    OIIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
-    OIIO_CHECK_ASSERT(pG->isNonChannelDependent());
+    OCIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
+    OCIO_CHECK_ASSERT(pG->isNonChannelDependent());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, gamma_alpha4)
+OCIO_ADD_TEST(FileFormatCTF, gamma_alpha4)
 {
     // This test is for a new (>= 1.5) transform file that contains
     // a different GammaParams for every channel:
     // - R, G, B and A set to different parameters (attributes order test).
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("gamma_alpha_test4.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
     auto pG = std::dynamic_pointer_cast<const OCIO::GammaOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pG);
+    OCIO_REQUIRE_ASSERT(pG);
 
-    OIIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::MONCURVE_REV);
+    OCIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::MONCURVE_REV);
 
     OCIO::GammaOpData::Params paramsR;
     paramsR.push_back(2.2);
@@ -2887,16 +2887,16 @@ OIIO_ADD_TEST(FileFormatCTF, gamma_alpha4)
     paramsA.push_back(2.0);
     paramsA.push_back(0.0001);
 
-    OIIO_CHECK_ASSERT(pG->getRedParams() == paramsR);
-    OIIO_CHECK_ASSERT(pG->getGreenParams() == paramsG);
-    OIIO_CHECK_ASSERT(pG->getBlueParams() == paramsB);
-    OIIO_CHECK_ASSERT(pG->getAlphaParams() == paramsA);
+    OCIO_CHECK_ASSERT(pG->getRedParams() == paramsR);
+    OCIO_CHECK_ASSERT(pG->getGreenParams() == paramsG);
+    OCIO_CHECK_ASSERT(pG->getBlueParams() == paramsB);
+    OCIO_CHECK_ASSERT(pG->getAlphaParams() == paramsA);
 
-    OIIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
-    OIIO_CHECK_ASSERT(!pG->isNonChannelDependent());
+    OCIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
+    OCIO_CHECK_ASSERT(!pG->isNonChannelDependent());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, gamma_alpha5)
+OCIO_ADD_TEST(FileFormatCTF, gamma_alpha5)
 {
     // This test is for a new (>= 1.5) transform file that contains
     // a GammaParams with no channel specified:
@@ -2905,18 +2905,18 @@ OIIO_ADD_TEST(FileFormatCTF, gamma_alpha5)
     // - A set to different parameters.
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("gamma_alpha_test5.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::GammaType);
     auto pG = std::dynamic_pointer_cast<const OCIO::GammaOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pG);
+    OCIO_REQUIRE_ASSERT(pG);
 
-    OIIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::MONCURVE_FWD);
+    OCIO_CHECK_EQUAL(pG->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(pG->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(pG->getStyle(), OCIO::GammaOpData::MONCURVE_FWD);
 
     OCIO::GammaOpData::Params params;
     params.push_back(1. / 0.45);
@@ -2925,258 +2925,258 @@ OIIO_ADD_TEST(FileFormatCTF, gamma_alpha5)
     paramsA.push_back(1.7);
     paramsA.push_back(0.33);
 
-    OIIO_CHECK_ASSERT(pG->getRedParams() == params);
-    OIIO_CHECK_ASSERT(pG->getGreenParams() == params);
-    OIIO_CHECK_ASSERT(pG->getBlueParams() == params);
-    OIIO_CHECK_ASSERT(pG->getAlphaParams() == paramsA);
+    OCIO_CHECK_ASSERT(pG->getRedParams() == params);
+    OCIO_CHECK_ASSERT(pG->getGreenParams() == params);
+    OCIO_CHECK_ASSERT(pG->getBlueParams() == params);
+    OCIO_CHECK_ASSERT(pG->getAlphaParams() == paramsA);
 
-    OIIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
-    OIIO_CHECK_ASSERT(!pG->isNonChannelDependent());
+    OCIO_CHECK_ASSERT(!pG->areAllComponentsEqual());
+    OCIO_CHECK_ASSERT(!pG->isNonChannelDependent());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, gamma_alpha6)
+OCIO_ADD_TEST(FileFormatCTF, gamma_alpha6)
 {
     // This test is for an new (>= 1.5) transform file that contains
     // an invalid GammaParams for the A channel (missing offset attribute).
     const std::string ctfFile("gamma_alpha_test6.ctf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
                           "Missing required offset parameter");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, invalid_version)
+OCIO_ADD_TEST(FileFormatCTF, invalid_version)
 {
     const std::string ctfFile("process_list_invalid_version.ctf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "is not a valid version");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, valid_version)
+OCIO_ADD_TEST(FileFormatCTF, valid_version)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("process_list_valid_version.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
     
     const OCIO::CTFVersion ctfVersion =
         cachedFile->m_transform->getCTFVersion();
-    OIIO_CHECK_EQUAL(ctfVersion, OCIO::CTF_PROCESS_LIST_VERSION_1_4);
+    OCIO_CHECK_EQUAL(ctfVersion, OCIO::CTF_PROCESS_LIST_VERSION_1_4);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, higher_version)
+OCIO_ADD_TEST(FileFormatCTF, higher_version)
 {
     const std::string ctfFile("process_list_higher_version.ctf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile),
                           OCIO::Exception,
                           "Unsupported transform file version");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, version_revision)
+OCIO_ADD_TEST(FileFormatCTF, version_revision)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("process_list_version_revision.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
 
     const OCIO::CTFVersion ctfVersion =
         cachedFile->m_transform->getCTFVersion();
     const OCIO::CTFVersion ver(1, 3, 10);
-    OIIO_CHECK_EQUAL(ctfVersion, ver);
-    OIIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_3 < ctfVersion);
-    OIIO_CHECK_ASSERT(ctfVersion < OCIO::CTF_PROCESS_LIST_VERSION_1_4);
+    OCIO_CHECK_EQUAL(ctfVersion, ver);
+    OCIO_CHECK_ASSERT(OCIO::CTF_PROCESS_LIST_VERSION_1_3 < ctfVersion);
+    OCIO_CHECK_ASSERT(ctfVersion < OCIO::CTF_PROCESS_LIST_VERSION_1_4);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, no_version)
+OCIO_ADD_TEST(FileFormatCTF, no_version)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("process_list_no_version.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
 
     const OCIO::CTFVersion ctfVersion =
         cachedFile->m_transform->getCTFVersion();
-    OIIO_CHECK_EQUAL(ctfVersion, OCIO::CTF_PROCESS_LIST_VERSION_1_2);
+    OCIO_CHECK_EQUAL(ctfVersion, OCIO::CTF_PROCESS_LIST_VERSION_1_2);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, cdl)
+OCIO_ADD_TEST(FileFormatCTF, cdl)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("cdl_clamp_fwd.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_CHECK_EQUAL(cachedFile->m_transform->getInputDescriptor(),
+    OCIO_CHECK_EQUAL(cachedFile->m_transform->getInputDescriptor(),
                      "inputDesc");
-    OIIO_CHECK_EQUAL(cachedFile->m_transform->getOutputDescriptor(),
+    OCIO_CHECK_EQUAL(cachedFile->m_transform->getOutputDescriptor(),
                      "outputDesc");
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::CDLType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::CDLType);
     auto pCDL = std::dynamic_pointer_cast<const OCIO::CDLOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pCDL);
+    OCIO_REQUIRE_ASSERT(pCDL);
 
-    OIIO_CHECK_EQUAL(pCDL->getID(), std::string("look 1"));
-    OIIO_CHECK_EQUAL(pCDL->getName(), std::string("cdl"));
+    OCIO_CHECK_EQUAL(pCDL->getID(), std::string("look 1"));
+    OCIO_CHECK_EQUAL(pCDL->getName(), std::string("cdl"));
 
     OCIO::OpData::Descriptions descriptions = pCDL->getDescriptions();
 
-    OIIO_REQUIRE_EQUAL(descriptions.size(), 1u);
-    OIIO_CHECK_EQUAL(descriptions[0], std::string("ASC CDL operation"));
+    OCIO_REQUIRE_EQUAL(descriptions.size(), 1u);
+    OCIO_CHECK_EQUAL(descriptions[0], std::string("ASC CDL operation"));
 
-    OIIO_CHECK_EQUAL(pCDL->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pCDL->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(pCDL->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pCDL->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
 
-    OIIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_V1_2_FWD);
+    OCIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_V1_2_FWD);
     std::string styleName(OCIO::CDLOpData::GetStyleName(pCDL->getStyle()));
-    OIIO_CHECK_EQUAL(styleName, "Fwd");
+    OCIO_CHECK_EQUAL(styleName, "Fwd");
 
-    OIIO_CHECK_ASSERT(pCDL->getSlopeParams() 
+    OCIO_CHECK_ASSERT(pCDL->getSlopeParams() 
                       == OCIO::CDLOpData::ChannelParams(1.35, 1.1, 0.71));
-    OIIO_CHECK_ASSERT(pCDL->getOffsetParams()
+    OCIO_CHECK_ASSERT(pCDL->getOffsetParams()
                       == OCIO::CDLOpData::ChannelParams(0.05, -0.23, 0.11));
-    OIIO_CHECK_ASSERT(pCDL->getPowerParams()
+    OCIO_CHECK_ASSERT(pCDL->getPowerParams()
                       == OCIO::CDLOpData::ChannelParams(0.93, 0.81, 1.27));
-    OIIO_CHECK_EQUAL(pCDL->getSaturation(), 1.239);
+    OCIO_CHECK_EQUAL(pCDL->getSaturation(), 1.239);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, cdl_invalid_sop_node)
+OCIO_ADD_TEST(FileFormatCTF, cdl_invalid_sop_node)
 {
     const std::string ctfFile("cdl_invalidSOP.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
                           "SOPNode: 3 values required");
 }
         
-OIIO_ADD_TEST(FileFormatCTF, cdl_invalid_sat_node)
+OCIO_ADD_TEST(FileFormatCTF, cdl_invalid_sat_node)
 {
     const std::string ctfFile("cdl_invalidSat.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
                           "SatNode: non-single value");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, cdl_missing_slope)
+OCIO_ADD_TEST(FileFormatCTF, cdl_missing_slope)
 {
     const std::string ctfFile("cdl_missing_slope.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
                           "Required node 'Slope' is missing");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, cdl_missing_offset)
+OCIO_ADD_TEST(FileFormatCTF, cdl_missing_offset)
 {
     const std::string ctfFile("cdl_missing_offset.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
                           "Required node 'Offset' is missing");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, cdl_missing_power)
+OCIO_ADD_TEST(FileFormatCTF, cdl_missing_power)
 {
     const std::string ctfFile("cdl_missing_power.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
                           "Required node 'Power' is missing");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, cdl_missing_style)
+OCIO_ADD_TEST(FileFormatCTF, cdl_missing_style)
 {
     const std::string ctfFile("cdl_missing_style.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
                           "Required attribute 'style' is missing");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, cdl_invalid_style)
+OCIO_ADD_TEST(FileFormatCTF, cdl_invalid_style)
 {
     const std::string ctfFile("cdl_invalid_style.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
                           "Unknown style for CDL");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, cdl_no_sop_node)
+OCIO_ADD_TEST(FileFormatCTF, cdl_no_sop_node)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("cdl_noSOP.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::CDLType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::CDLType);
     auto pCDL =
         std::dynamic_pointer_cast<const OCIO::CDLOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pCDL);
+    OCIO_REQUIRE_ASSERT(pCDL);
 
-    OIIO_CHECK_ASSERT(pCDL->getSlopeParams()
+    OCIO_CHECK_ASSERT(pCDL->getSlopeParams()
                       == OCIO::CDLOpData::ChannelParams(1.0));
-    OIIO_CHECK_ASSERT(pCDL->getOffsetParams()
+    OCIO_CHECK_ASSERT(pCDL->getOffsetParams()
                       == OCIO::CDLOpData::ChannelParams(0.0));
-    OIIO_CHECK_ASSERT(pCDL->getPowerParams()
+    OCIO_CHECK_ASSERT(pCDL->getPowerParams()
                       == OCIO::CDLOpData::ChannelParams(1.0));
-    OIIO_CHECK_EQUAL(pCDL->getSaturation(), 1.239);
+    OCIO_CHECK_EQUAL(pCDL->getSaturation(), 1.239);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, cdl_no_sat_node)
+OCIO_ADD_TEST(FileFormatCTF, cdl_no_sat_node)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("cdl_noSat.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::CDLType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::CDLType);
     auto pCDL = std::dynamic_pointer_cast<const OCIO::CDLOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pCDL);
+    OCIO_REQUIRE_ASSERT(pCDL);
 
-    OIIO_CHECK_ASSERT(pCDL->getSlopeParams()
+    OCIO_CHECK_ASSERT(pCDL->getSlopeParams()
                       == OCIO::CDLOpData::ChannelParams(1.35, 1.1, 0.71));
-    OIIO_CHECK_ASSERT(pCDL->getOffsetParams()
+    OCIO_CHECK_ASSERT(pCDL->getOffsetParams()
                       == OCIO::CDLOpData::ChannelParams(0.05, -0.23, 0.11));
-    OIIO_CHECK_ASSERT(pCDL->getPowerParams()
+    OCIO_CHECK_ASSERT(pCDL->getPowerParams()
                       == OCIO::CDLOpData::ChannelParams(0.93, 0.81, 1.27));
-    OIIO_CHECK_EQUAL(pCDL->getSaturation(), 1.0);
+    OCIO_CHECK_EQUAL(pCDL->getSaturation(), 1.0);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, cdl_various_in_ctf)
+OCIO_ADD_TEST(FileFormatCTF, cdl_various_in_ctf)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("cdl_various.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 8);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::CDLType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 8);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::CDLType);
     auto pCDL = std::dynamic_pointer_cast<const OCIO::CDLOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pCDL);
-    OIIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_V1_2_FWD);
+    OCIO_REQUIRE_ASSERT(pCDL);
+    OCIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_V1_2_FWD);
 
     pCDL = std::dynamic_pointer_cast<const OCIO::CDLOpData>(opList[1]);
-    OIIO_REQUIRE_ASSERT(pCDL);
-    OIIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_V1_2_FWD);
+    OCIO_REQUIRE_ASSERT(pCDL);
+    OCIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_V1_2_FWD);
 
     pCDL = std::dynamic_pointer_cast<const OCIO::CDLOpData>(opList[2]);
-    OIIO_REQUIRE_ASSERT(pCDL);
-    OIIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_V1_2_REV);
+    OCIO_REQUIRE_ASSERT(pCDL);
+    OCIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_V1_2_REV);
 
     pCDL = std::dynamic_pointer_cast<const OCIO::CDLOpData>(opList[3]);
-    OIIO_REQUIRE_ASSERT(pCDL);
-    OIIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_V1_2_REV);
+    OCIO_REQUIRE_ASSERT(pCDL);
+    OCIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_V1_2_REV);
 
     pCDL = std::dynamic_pointer_cast<const OCIO::CDLOpData>(opList[4]);
-    OIIO_REQUIRE_ASSERT(pCDL);
-    OIIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_FWD);
+    OCIO_REQUIRE_ASSERT(pCDL);
+    OCIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_FWD);
 
     pCDL = std::dynamic_pointer_cast<const OCIO::CDLOpData>(opList[5]);
-    OIIO_REQUIRE_ASSERT(pCDL);
-    OIIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_FWD);
+    OCIO_REQUIRE_ASSERT(pCDL);
+    OCIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_FWD);
 
     pCDL = std::dynamic_pointer_cast<const OCIO::CDLOpData>(opList[6]);
-    OIIO_REQUIRE_ASSERT(pCDL);
-    OIIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_REV);
+    OCIO_REQUIRE_ASSERT(pCDL);
+    OCIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_REV);
 
     pCDL = std::dynamic_pointer_cast<const OCIO::CDLOpData>(opList[7]);
-    OIIO_REQUIRE_ASSERT(pCDL);
-    OIIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_REV);
+    OCIO_REQUIRE_ASSERT(pCDL);
+    OCIO_CHECK_EQUAL(pCDL->getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_REV);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, lut1d_hue_adjust_invalid_style)
+OCIO_ADD_TEST(FileFormatCTF, lut1d_hue_adjust_invalid_style)
 {
     const std::string ctfFile("lut1d_hue_adjust_invalid_style.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
                           "Illegal 'hueAdjust' attribute");
 }
 
@@ -3187,65 +3187,65 @@ void checkNames(const OCIO::Metadata::NameList & actualNames,
     for(ait = actualNames.begin(), eit = expectedNames.begin(),
         end = actualNames.end(); ait != end; ++ait, ++eit)
     {
-        OIIO_CHECK_EQUAL(*ait, *eit);
+        OCIO_CHECK_EQUAL(*ait, *eit);
     }
 }
 
-OIIO_ADD_TEST(FileFormatCTF, metadata)
+OCIO_ADD_TEST(FileFormatCTF, metadata)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("metadata.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
-    OIIO_CHECK_EQUAL(cachedFile->m_transform->getInputDescriptor(),
+    OCIO_CHECK_EQUAL(cachedFile->m_transform->getInputDescriptor(),
                      "inputDesc");
-    OIIO_CHECK_EQUAL(cachedFile->m_transform->getOutputDescriptor(),
+    OCIO_CHECK_EQUAL(cachedFile->m_transform->getOutputDescriptor(),
                      "outputDesc");
 
     // Ensure ops were not affected by metadata parsing.
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
 
     auto pMatrix =
         std::dynamic_pointer_cast<const OCIO::MatrixOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pMatrix);
-    OIIO_CHECK_EQUAL(pMatrix->getName(), "identity");
+    OCIO_REQUIRE_ASSERT(pMatrix);
+    OCIO_CHECK_EQUAL(pMatrix->getName(), "identity");
 
-    OIIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(pMatrix->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pMatrix->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 
     const OCIO::Metadata & info = cachedFile->m_transform->getInfo();
 
     // Check element values.
     //
-    OIIO_CHECK_EQUAL(info["Copyright"].getValue(), "Copyright 2013 Autodesk");
-    OIIO_CHECK_EQUAL(info["Release"].getValue(), "2015");
-    OIIO_CHECK_EQUAL(info["InputColorSpace"]["Description"].getValue(),
+    OCIO_CHECK_EQUAL(info["Copyright"].getValue(), "Copyright 2013 Autodesk");
+    OCIO_CHECK_EQUAL(info["Release"].getValue(), "2015");
+    OCIO_CHECK_EQUAL(info["InputColorSpace"]["Description"].getValue(),
                      "Input color space description");
-    OIIO_CHECK_EQUAL(info["InputColorSpace"]["Profile"].getValue(),
+    OCIO_CHECK_EQUAL(info["InputColorSpace"]["Profile"].getValue(),
                      "Input color space profile");
-    OIIO_CHECK_EQUAL(info["InputColorSpace"]["Empty"].getValue(), "");
-    OIIO_CHECK_EQUAL(info["OutputColorSpace"]["Description"].getValue(),
+    OCIO_CHECK_EQUAL(info["InputColorSpace"]["Empty"].getValue(), "");
+    OCIO_CHECK_EQUAL(info["OutputColorSpace"]["Description"].getValue(),
                      "Output color space description");
-    OIIO_CHECK_EQUAL(info["OutputColorSpace"]["Profile"].getValue(),
+    OCIO_CHECK_EQUAL(info["OutputColorSpace"]["Profile"].getValue(),
                      "Output color space profile");
-    OIIO_CHECK_EQUAL(info["Category"]["Name"].getValue(), "Category name");
+    OCIO_CHECK_EQUAL(info["Category"]["Name"].getValue(), "Category name");
 
     const OCIO::Metadata::Attributes & atts =
         info["Category"]["Name"].getAttributes();
-    OIIO_REQUIRE_EQUAL(atts.size(), 2);
-    OIIO_CHECK_EQUAL(atts[0].first, "att1");
-    OIIO_CHECK_EQUAL(atts[0].second, "test1");
-    OIIO_CHECK_EQUAL(atts[1].first, "att2");
-    OIIO_CHECK_EQUAL(atts[1].second, "test2");
+    OCIO_REQUIRE_EQUAL(atts.size(), 2);
+    OCIO_CHECK_EQUAL(atts[0].first, "att1");
+    OCIO_CHECK_EQUAL(atts[0].second, "test1");
+    OCIO_CHECK_EQUAL(atts[1].first, "att2");
+    OCIO_CHECK_EQUAL(atts[1].second, "test2");
 
     // Check element children count.
     //
-    OIIO_REQUIRE_EQUAL(info.getItems().size(), 5u);
-    OIIO_CHECK_EQUAL(info["InputColorSpace"].getItems().size(), 3u);
-    OIIO_CHECK_EQUAL(info["OutputColorSpace"].getItems().size(), 2u);
-    OIIO_CHECK_EQUAL(info["Category"].getItems().size(), 1u);
+    OCIO_REQUIRE_EQUAL(info.getItems().size(), 5u);
+    OCIO_CHECK_EQUAL(info["InputColorSpace"].getItems().size(), 3u);
+    OCIO_CHECK_EQUAL(info["OutputColorSpace"].getItems().size(), 2u);
+    OCIO_CHECK_EQUAL(info["Category"].getItems().size(), 1u);
 
     // Check element ordering.
     //
@@ -3290,150 +3290,150 @@ OIIO_ADD_TEST(FileFormatCTF, metadata)
     }
 }
 
-OIIO_ADD_TEST(FileFormatCTF, index_map_1)
+OCIO_ADD_TEST(FileFormatCTF, index_map_1)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("indexMap_test1.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 2);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::RangeType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 2);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::RangeType);
     auto pR = std::dynamic_pointer_cast<const OCIO::RangeOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pR);
+    OCIO_REQUIRE_ASSERT(pR);
 
     // Check that the indexMap caused a Range to be inserted.
-    OIIO_CHECK_EQUAL(pR->getMinInValue(), 64.5);
-    OIIO_CHECK_EQUAL(pR->getMaxInValue(), 940.);
-    OIIO_CHECK_EQUAL((int)(pR->getMinOutValue() + 0.5), 132);  // 4*1023/31
-    OIIO_CHECK_EQUAL((int)(pR->getMaxOutValue() + 0.5), 1089); // 33*1023/31
-    OIIO_CHECK_EQUAL(pR->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_EQUAL(pR->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(pR->getMinInValue(), 64.5);
+    OCIO_CHECK_EQUAL(pR->getMaxInValue(), 940.);
+    OCIO_CHECK_EQUAL((int)(pR->getMinOutValue() + 0.5), 132);  // 4*1023/31
+    OCIO_CHECK_EQUAL((int)(pR->getMaxOutValue() + 0.5), 1089); // 33*1023/31
+    OCIO_CHECK_EQUAL(pR->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(pR->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
 
     // Check the LUT is ok.
     auto pL = std::dynamic_pointer_cast<const OCIO::Lut1DOpData>(opList[1]);
-    OIIO_REQUIRE_ASSERT(pL);
-    OIIO_CHECK_EQUAL(pL->getType(), OCIO::OpData::Lut1DType);
-    OIIO_CHECK_EQUAL(pL->getArray().getLength(), 32u);
-    OIIO_CHECK_EQUAL(pL->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_EQUAL(pL->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_REQUIRE_ASSERT(pL);
+    OCIO_CHECK_EQUAL(pL->getType(), OCIO::OpData::Lut1DType);
+    OCIO_CHECK_EQUAL(pL->getArray().getLength(), 32u);
+    OCIO_CHECK_EQUAL(pL->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(pL->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, index_map_2)
+OCIO_ADD_TEST(FileFormatCTF, index_map_2)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("indexMap_test2.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
 
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 2);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::RangeType);
+    OCIO_REQUIRE_EQUAL(opList.size(), 2);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::RangeType);
     auto pR = std::dynamic_pointer_cast<const OCIO::RangeOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pR);
-    OIIO_CHECK_EQUAL(pR->getMinInValue(), -0.1f);
-    OIIO_CHECK_EQUAL(pR->getMaxInValue(), 19.f);
-    OIIO_CHECK_EQUAL(pR->getMinOutValue(), 0.f);
-    OIIO_CHECK_EQUAL(pR->getMaxOutValue(), 1.f);
-    OIIO_CHECK_EQUAL(pR->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pR->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_REQUIRE_ASSERT(pR);
+    OCIO_CHECK_EQUAL(pR->getMinInValue(), -0.1f);
+    OCIO_CHECK_EQUAL(pR->getMaxInValue(), 19.f);
+    OCIO_CHECK_EQUAL(pR->getMinOutValue(), 0.f);
+    OCIO_CHECK_EQUAL(pR->getMaxOutValue(), 1.f);
+    OCIO_CHECK_EQUAL(pR->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pR->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     // Check the LUT is ok.
     auto pL = std::dynamic_pointer_cast<const OCIO::Lut3DOpData>(opList[1]);
-    OIIO_REQUIRE_ASSERT(pL);
-    OIIO_CHECK_EQUAL(pL->getType(), OCIO::OpData::Lut3DType);
-    OIIO_CHECK_EQUAL(pL->getArray().getLength(), 2u);
-    OIIO_CHECK_EQUAL(pL->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pL->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_REQUIRE_ASSERT(pL);
+    OCIO_CHECK_EQUAL(pL->getType(), OCIO::OpData::Lut3DType);
+    OCIO_CHECK_EQUAL(pL->getArray().getLength(), 2u);
+    OCIO_CHECK_EQUAL(pL->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pL->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, index_map_3)
+OCIO_ADD_TEST(FileFormatCTF, index_map_3)
 {
     const std::string ctfFile("indexMap_test3.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
                           "Only one IndexMap allowed per LUT");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, index_map_4)
+OCIO_ADD_TEST(FileFormatCTF, index_map_4)
 {
     const std::string ctfFile("indexMap_test4.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception, 
                           "Only two entry IndexMaps are supported");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, clf_future_version)
+OCIO_ADD_TEST(FileFormatCTF, clf_future_version)
 {
     const std::string ctfFile("clf_version_future.clf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
                           "Unsupported transform file version");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, clf_1)
+OCIO_ADD_TEST(FileFormatCTF, clf_1)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("multiple_ops.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(opList.size(), 6);
+    OCIO_REQUIRE_EQUAL(opList.size(), 6);
     // First one is a CDL
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::CDLType);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::CDLType);
     auto cdlOpData =
         std::dynamic_pointer_cast<const OCIO::CDLOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(cdlOpData);
-    OIIO_CHECK_EQUAL(cdlOpData->getName(), "");
-    OIIO_CHECK_EQUAL(cdlOpData->getID(), "cc01234");
-    OIIO_CHECK_EQUAL(cdlOpData->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(cdlOpData->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-    OIIO_REQUIRE_EQUAL(cdlOpData->getDescriptions().size(), 1);
-    OIIO_CHECK_EQUAL(cdlOpData->getDescriptions()[0],
+    OCIO_REQUIRE_ASSERT(cdlOpData);
+    OCIO_CHECK_EQUAL(cdlOpData->getName(), "");
+    OCIO_CHECK_EQUAL(cdlOpData->getID(), "cc01234");
+    OCIO_CHECK_EQUAL(cdlOpData->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(cdlOpData->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_REQUIRE_EQUAL(cdlOpData->getDescriptions().size(), 1);
+    OCIO_CHECK_EQUAL(cdlOpData->getDescriptions()[0],
                      "scene 1 exterior look");
-    OIIO_CHECK_EQUAL(cdlOpData->getStyle(), OCIO::CDLOpData::CDL_V1_2_REV);
-    OIIO_CHECK_ASSERT(cdlOpData->getSlopeParams()
+    OCIO_CHECK_EQUAL(cdlOpData->getStyle(), OCIO::CDLOpData::CDL_V1_2_REV);
+    OCIO_CHECK_ASSERT(cdlOpData->getSlopeParams()
                       == OCIO::CDLOpData::ChannelParams(1., 1., 0.8));
-    OIIO_CHECK_ASSERT(cdlOpData->getOffsetParams()
+    OCIO_CHECK_ASSERT(cdlOpData->getOffsetParams()
                       == OCIO::CDLOpData::ChannelParams(-0.02, 0., 0.15));
-    OIIO_CHECK_ASSERT(cdlOpData->getPowerParams()
+    OCIO_CHECK_ASSERT(cdlOpData->getPowerParams()
                       == OCIO::CDLOpData::ChannelParams(1.05, 1.15, 1.4));
-    OIIO_CHECK_EQUAL(cdlOpData->getSaturation(), 0.75);
+    OCIO_CHECK_EQUAL(cdlOpData->getSaturation(), 0.75);
 
     // Next one in file is a lut1d, but it has an index map,
     // thus a range was inserted before the LUT.
-    OIIO_CHECK_EQUAL(opList[1]->getType(), OCIO::OpData::RangeType);
+    OCIO_CHECK_EQUAL(opList[1]->getType(), OCIO::OpData::RangeType);
     auto rangeOpData =
         std::dynamic_pointer_cast<const OCIO::RangeOpData>(opList[1]);
-    OIIO_REQUIRE_ASSERT(rangeOpData);
-    OIIO_CHECK_EQUAL(rangeOpData->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_EQUAL(rangeOpData->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_EQUAL(rangeOpData->getMinInValue(), 64.5);
-    OIIO_CHECK_EQUAL(rangeOpData->getMaxInValue(), 940.);
-    OIIO_CHECK_EQUAL((int)(rangeOpData->getMinOutValue() + 0.5), 132);  // 4*1023/31
-    OIIO_CHECK_EQUAL((int)(rangeOpData->getMaxOutValue() + 0.5), 957); // 29*1023/31
+    OCIO_REQUIRE_ASSERT(rangeOpData);
+    OCIO_CHECK_EQUAL(rangeOpData->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(rangeOpData->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(rangeOpData->getMinInValue(), 64.5);
+    OCIO_CHECK_EQUAL(rangeOpData->getMaxInValue(), 940.);
+    OCIO_CHECK_EQUAL((int)(rangeOpData->getMinOutValue() + 0.5), 132);  // 4*1023/31
+    OCIO_CHECK_EQUAL((int)(rangeOpData->getMaxOutValue() + 0.5), 957); // 29*1023/31
 
     // Lut1D.
-    OIIO_CHECK_EQUAL(opList[2]->getType(), OCIO::OpData::Lut1DType);
+    OCIO_CHECK_EQUAL(opList[2]->getType(), OCIO::OpData::Lut1DType);
     auto l1OpData =
         std::dynamic_pointer_cast<const OCIO::Lut1DOpData>(opList[2]);
-    OIIO_REQUIRE_ASSERT(l1OpData);
-    OIIO_CHECK_EQUAL(l1OpData->getName(), "");
-    OIIO_CHECK_EQUAL(l1OpData->getID(), "");
-    OIIO_CHECK_EQUAL(l1OpData->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_EQUAL(l1OpData->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL(l1OpData->getDescriptions().size(), 0);
-    OIIO_CHECK_EQUAL(l1OpData->getArray().getLength(), 32u);
+    OCIO_REQUIRE_ASSERT(l1OpData);
+    OCIO_CHECK_EQUAL(l1OpData->getName(), "");
+    OCIO_CHECK_EQUAL(l1OpData->getID(), "");
+    OCIO_CHECK_EQUAL(l1OpData->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(l1OpData->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(l1OpData->getDescriptions().size(), 0);
+    OCIO_CHECK_EQUAL(l1OpData->getArray().getLength(), 32u);
 
     // Check that the noClamp style Range became a Matrix.
-    OIIO_CHECK_EQUAL(opList[3]->getType(), OCIO::OpData::MatrixType);
+    OCIO_CHECK_EQUAL(opList[3]->getType(), OCIO::OpData::MatrixType);
     auto matOpData =
         std::dynamic_pointer_cast<const OCIO::MatrixOpData>(opList[3]);
-    OIIO_REQUIRE_ASSERT(matOpData);
-    OIIO_CHECK_EQUAL(matOpData->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL(matOpData->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_REQUIRE_ASSERT(matOpData);
+    OCIO_CHECK_EQUAL(matOpData->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(matOpData->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
 
     const OCIO::ArrayDouble & array = matOpData->getArray();
-    OIIO_CHECK_EQUAL(array.getLength(), 4u);
-    OIIO_CHECK_EQUAL(array.getNumColorComponents(), 4u);
-    OIIO_CHECK_EQUAL(array.getNumValues(),
+    OCIO_CHECK_EQUAL(array.getLength(), 4u);
+    OCIO_CHECK_EQUAL(array.getNumColorComponents(), 4u);
+    OCIO_CHECK_EQUAL(array.getNumValues(),
                      array.getLength()*array.getLength());
 
     const float scalef = (900.f - 20.f) / (3760.f - 256.f);
@@ -3442,146 +3442,146 @@ OIIO_ADD_TEST(FileFormatCTF, clf_1)
     const int scale = (int)(prec * scalef);
     const int offset = (int)(prec * offsetf);
 
-    OIIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
-    OIIO_CHECK_EQUAL((int)(prec * array.getValues()[0]), scale);
-    OIIO_CHECK_EQUAL(array.getValues()[1], 0.);
-    OIIO_CHECK_EQUAL(array.getValues()[2], 0.);
-    OIIO_CHECK_EQUAL(array.getValues()[3], 0.);
+    OCIO_REQUIRE_EQUAL(array.getValues().size(), array.getNumValues());
+    OCIO_CHECK_EQUAL((int)(prec * array.getValues()[0]), scale);
+    OCIO_CHECK_EQUAL(array.getValues()[1], 0.);
+    OCIO_CHECK_EQUAL(array.getValues()[2], 0.);
+    OCIO_CHECK_EQUAL(array.getValues()[3], 0.);
 
-    OIIO_CHECK_EQUAL(array.getValues()[4], 0.);
-    OIIO_CHECK_EQUAL((int)(prec * array.getValues()[5]), scale);
-    OIIO_CHECK_EQUAL(array.getValues()[6], 0.);
-    OIIO_CHECK_EQUAL(array.getValues()[7], 0.);
+    OCIO_CHECK_EQUAL(array.getValues()[4], 0.);
+    OCIO_CHECK_EQUAL((int)(prec * array.getValues()[5]), scale);
+    OCIO_CHECK_EQUAL(array.getValues()[6], 0.);
+    OCIO_CHECK_EQUAL(array.getValues()[7], 0.);
 
-    OIIO_CHECK_EQUAL(array.getValues()[8], 0.);
-    OIIO_CHECK_EQUAL(array.getValues()[9], 0.);
-    OIIO_CHECK_EQUAL((int)(prec * array.getValues()[10]), scale);
-    OIIO_CHECK_EQUAL(array.getValues()[11], 0.);
+    OCIO_CHECK_EQUAL(array.getValues()[8], 0.);
+    OCIO_CHECK_EQUAL(array.getValues()[9], 0.);
+    OCIO_CHECK_EQUAL((int)(prec * array.getValues()[10]), scale);
+    OCIO_CHECK_EQUAL(array.getValues()[11], 0.);
 
-    OIIO_CHECK_EQUAL(array.getValues()[12], 0.);
-    OIIO_CHECK_EQUAL(array.getValues()[13], 0.);
-    OIIO_CHECK_EQUAL(array.getValues()[14], 0.);
-    OIIO_CHECK_EQUAL((int)(prec * array.getValues()[15]),
+    OCIO_CHECK_EQUAL(array.getValues()[12], 0.);
+    OCIO_CHECK_EQUAL(array.getValues()[13], 0.);
+    OCIO_CHECK_EQUAL(array.getValues()[14], 0.);
+    OCIO_CHECK_EQUAL((int)(prec * array.getValues()[15]),
                      (int)(prec * 1023. / 4095.));
 
     const OCIO::MatrixOpData::Offsets & offsets = matOpData->getOffsets();
-    OIIO_CHECK_EQUAL((int)(prec * offsets[0]), offset);
-    OIIO_CHECK_EQUAL((int)(prec * offsets[1]), offset);
-    OIIO_CHECK_EQUAL((int)(prec * offsets[2]), offset);
-    OIIO_CHECK_EQUAL(offsets[3], 0.f);
+    OCIO_CHECK_EQUAL((int)(prec * offsets[0]), offset);
+    OCIO_CHECK_EQUAL((int)(prec * offsets[1]), offset);
+    OCIO_CHECK_EQUAL((int)(prec * offsets[2]), offset);
+    OCIO_CHECK_EQUAL(offsets[3], 0.f);
 
     // A range with Clamp.
-    OIIO_CHECK_EQUAL(opList[4]->getType(), OCIO::OpData::RangeType);
+    OCIO_CHECK_EQUAL(opList[4]->getType(), OCIO::OpData::RangeType);
     rangeOpData =
         std::dynamic_pointer_cast<const OCIO::RangeOpData>(opList[4]);
-    OIIO_REQUIRE_ASSERT(rangeOpData);
-    OIIO_CHECK_EQUAL(rangeOpData->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_EQUAL(rangeOpData->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_REQUIRE_ASSERT(rangeOpData);
+    OCIO_CHECK_EQUAL(rangeOpData->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(rangeOpData->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
 
     // A range without style defaults to clamp.
-    OIIO_CHECK_EQUAL(opList[5]->getType(), OCIO::OpData::RangeType);
+    OCIO_CHECK_EQUAL(opList[5]->getType(), OCIO::OpData::RangeType);
     rangeOpData =
         std::dynamic_pointer_cast<const OCIO::RangeOpData>(opList[5]);
-    OIIO_REQUIRE_ASSERT(rangeOpData);
-    OIIO_CHECK_EQUAL(rangeOpData->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_EQUAL(rangeOpData->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_REQUIRE_ASSERT(rangeOpData);
+    OCIO_CHECK_EQUAL(rangeOpData->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(rangeOpData->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, tabluation_support)
+OCIO_ADD_TEST(FileFormatCTF, tabluation_support)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     // This clf file contains tabulations used as delimiters for a
     // series of numbers.
     const std::string ctfFile("tabulation_support.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_CHECK_EQUAL(cachedFile->m_transform->getID(), "none");
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(cachedFile->m_transform->getID(), "none");
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
 
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut3DType);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::Lut3DType);
 
     auto pL = std::dynamic_pointer_cast<const OCIO::Lut3DOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pL);
+    OCIO_REQUIRE_ASSERT(pL);
 
-    OIIO_CHECK_EQUAL(pL->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL(pL->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(pL->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(pL->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 
     const OCIO::Array & array = pL->getArray();
-    OIIO_CHECK_EQUAL(array.getLength(), 33U);
-    OIIO_CHECK_EQUAL(array.getNumColorComponents(), 3U);
-    OIIO_CHECK_EQUAL(array.getNumValues(), 107811U);
-    OIIO_REQUIRE_EQUAL(array.getValues().size(), 107811U);
+    OCIO_CHECK_EQUAL(array.getLength(), 33U);
+    OCIO_CHECK_EQUAL(array.getNumColorComponents(), 3U);
+    OCIO_CHECK_EQUAL(array.getNumValues(), 107811U);
+    OCIO_REQUIRE_EQUAL(array.getValues().size(), 107811U);
 
-    OIIO_CHECK_EQUAL(array.getValues()[0], 0.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[1], 0.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[2], 0.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[0], 0.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[1], 0.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[2], 0.0f);
 
-    OIIO_CHECK_EQUAL(array.getValues()[3], 0.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[4], 0.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[5], 13.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[3], 0.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[4], 0.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[5], 13.0f);
 
-    OIIO_CHECK_EQUAL(array.getValues()[6], 1.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[7], 0.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[8], 44.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[6], 1.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[7], 0.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[8], 44.0f);
 
-    OIIO_CHECK_EQUAL(array.getValues()[9], 0.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[10], 1.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[11], 94.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[9], 0.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[10], 1.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[11], 94.0f);
 
-    OIIO_CHECK_EQUAL(array.getValues()[3 * 33 + 0], 1.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[3 * 33 + 1], 32.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[3 * 33 + 2], 0.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[3 * 33 + 0], 1.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[3 * 33 + 1], 32.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[3 * 33 + 2], 0.0f);
 
-    OIIO_CHECK_EQUAL(array.getValues()[3 * 35936 + 0], 4095.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[3 * 35936 + 1], 4095.0f);
-    OIIO_CHECK_EQUAL(array.getValues()[3 * 35936 + 2], 4095.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[3 * 35936 + 0], 4095.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[3 * 35936 + 1], 4095.0f);
+    OCIO_CHECK_EQUAL(array.getValues()[3 * 35936 + 2], 4095.0f);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, matrix_windows_eol)
+OCIO_ADD_TEST(FileFormatCTF, matrix_windows_eol)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     // This file uses windows end of line character and does not start
     // with the ?xml header.
     const std::string ctfFile("matrix_windows.clf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
-    OIIO_CHECK_EQUAL(cachedFile->m_transform->getID(), "42");
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
-    OIIO_CHECK_EQUAL(opList[0]->getID(), "mat42");
-    OIIO_CHECK_EQUAL(opList[0]->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(opList[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(cachedFile->m_transform->getID(), "42");
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::MatrixType);
+    OCIO_CHECK_EQUAL(opList[0]->getID(), "mat42");
+    OCIO_CHECK_EQUAL(opList[0]->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(opList[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, lut_3d_file_with_xml_extension)
+OCIO_ADD_TEST(FileFormatCTF, lut_3d_file_with_xml_extension)
 {
     const std::string ctfFile("not_a_ctf.xml");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ctfFile), OCIO::Exception,
                           "is not a CTF/CLF file.");
 }
 
 
-OIIO_ADD_TEST(FileFormatCTF, info_element_version_test)
+OCIO_ADD_TEST(FileFormatCTF, info_element_version_test)
 {
     // VALID - No Version.
     //
     {
         const std::string ctfFile("info_version_without.ctf");
-        OIIO_CHECK_NO_THROW(LoadCLFFile(ctfFile));
+        OCIO_CHECK_NO_THROW(LoadCLFFile(ctfFile));
     }
 
     // VALID - Minor Version.
     //
     {
         const std::string ctfFile("info_version_valid_minor.ctf");
-        OIIO_CHECK_NO_THROW(LoadCLFFile(ctfFile));
+        OCIO_CHECK_NO_THROW(LoadCLFFile(ctfFile));
     }
 
     // INVALID - Invalid Version.
     //
     {
         const std::string ctfFile("info_version_invalid.ctf");
-        OIIO_CHECK_THROW_WHAT(
+        OCIO_CHECK_THROW_WHAT(
             LoadCLFFile(ctfFile), OCIO::Exception,
                         "Invalid Info element version attribute");
     }
@@ -3590,7 +3590,7 @@ OIIO_ADD_TEST(FileFormatCTF, info_element_version_test)
     //
     {
         const std::string ctfFile("info_version_unsupported.ctf");
-        OIIO_CHECK_THROW_WHAT(
+        OCIO_CHECK_THROW_WHAT(
             LoadCLFFile(ctfFile), OCIO::Exception,
             "Unsupported Info element version attribute");
     }
@@ -3599,176 +3599,176 @@ OIIO_ADD_TEST(FileFormatCTF, info_element_version_test)
     //
     {
         const std::string ctfFile("info_version_empty.ctf");
-        OIIO_CHECK_THROW_WHAT(
+        OCIO_CHECK_THROW_WHAT(
             LoadCLFFile(ctfFile), OCIO::Exception,
             "Invalid Info element version attribute");
     }
     
 }
 
-OIIO_ADD_TEST(Log, load_log10)
+OCIO_ADD_TEST(Log, load_log10)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     std::string fileName("log_log10.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
     const OCIO::OpDataVec & fileOps = cachedFile->m_transform->getOps();
     
-    OIIO_CHECK_EQUAL(cachedFile->m_transform->getName(), "log example");
-    OIIO_CHECK_EQUAL(cachedFile->m_transform->getID(),
+    OCIO_CHECK_EQUAL(cachedFile->m_transform->getName(), "log example");
+    OCIO_CHECK_EQUAL(cachedFile->m_transform->getID(),
                      "b5cc7aed-d405-4d8b-b64b-382b2341a378");
-    OIIO_CHECK_EQUAL(cachedFile->m_transform->getInputDescriptor(), "inputDesc");
-    OIIO_CHECK_EQUAL(cachedFile->m_transform->getOutputDescriptor(), "outputDesc");
-    OIIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions().size(), 1);
-    OIIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[0],
+    OCIO_CHECK_EQUAL(cachedFile->m_transform->getInputDescriptor(), "inputDesc");
+    OCIO_CHECK_EQUAL(cachedFile->m_transform->getOutputDescriptor(), "outputDesc");
+    OCIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions().size(), 1);
+    OCIO_CHECK_EQUAL(cachedFile->m_transform->getDescriptions()[0],
                      "Example of Log10 logarithm operation.");
 
-    OIIO_REQUIRE_EQUAL(fileOps.size(), 1);
+    OCIO_REQUIRE_EQUAL(fileOps.size(), 1);
     OCIO::OpDataRcPtr op = fileOps[0];
     OCIO::LogOpDataRcPtr log = std::dynamic_pointer_cast<OCIO::LogOpData>(op);
-    OIIO_REQUIRE_ASSERT(log);
-    OIIO_REQUIRE_EQUAL(log->getDescriptions().size(), 1);
-    OIIO_CHECK_EQUAL(log->getDescriptions()[0],
+    OCIO_REQUIRE_ASSERT(log);
+    OCIO_REQUIRE_EQUAL(log->getDescriptions().size(), 1);
+    OCIO_CHECK_EQUAL(log->getDescriptions()[0],
                      "Log10 logarithm operation");
 
-    OIIO_CHECK_EQUAL(log->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(log->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(log->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(log->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
 
-    OIIO_CHECK_ASSERT(log->isLog10());
-    OIIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_ASSERT(log->isLog10());
+    OCIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
 }
 
-OIIO_ADD_TEST(Log, load_log2)
+OCIO_ADD_TEST(Log, load_log2)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     std::string fileName("log_log2.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
     const OCIO::OpDataVec & fileOps = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(fileOps.size(), 1);
+    OCIO_REQUIRE_EQUAL(fileOps.size(), 1);
     OCIO::OpDataRcPtr op = fileOps[0];
     OCIO::LogOpDataRcPtr log = std::dynamic_pointer_cast<OCIO::LogOpData>(op);
-    OIIO_REQUIRE_ASSERT(log);
+    OCIO_REQUIRE_ASSERT(log);
 
-    OIIO_CHECK_EQUAL(log->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(log->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(log->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(log->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_ASSERT(log->isLog2());
-    OIIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_ASSERT(log->isLog2());
+    OCIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
 }
 
-OIIO_ADD_TEST(Log, load_antilog10)
+OCIO_ADD_TEST(Log, load_antilog10)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     std::string fileName("log_antilog10.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
     const OCIO::OpDataVec & fileOps = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(fileOps.size(), 1);
+    OCIO_REQUIRE_EQUAL(fileOps.size(), 1);
     OCIO::OpDataRcPtr op = fileOps[0];
     OCIO::LogOpDataRcPtr log = std::dynamic_pointer_cast<OCIO::LogOpData>(op);
-    OIIO_REQUIRE_ASSERT(log);
+    OCIO_REQUIRE_ASSERT(log);
 
-    OIIO_CHECK_EQUAL(log->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_EQUAL(log->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(log->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(log->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
 
-    OIIO_CHECK_ASSERT(log->isLog10());
-    OIIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_ASSERT(log->isLog10());
+    OCIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
 }
 
-OIIO_ADD_TEST(Log, load_antilog2)
+OCIO_ADD_TEST(Log, load_antilog2)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     std::string fileName("log_antilog2.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
     const OCIO::OpDataVec & fileOps = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(fileOps.size(), 1);
+    OCIO_REQUIRE_EQUAL(fileOps.size(), 1);
     OCIO::OpDataRcPtr op = fileOps[0];
     OCIO::LogOpDataRcPtr log = std::dynamic_pointer_cast<OCIO::LogOpData>(op);
-    OIIO_REQUIRE_ASSERT(log);
+    OCIO_REQUIRE_ASSERT(log);
 
-    OIIO_CHECK_EQUAL(log->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(log->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(log->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(log->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
 
-    OIIO_CHECK_ASSERT(log->isLog2());
-    OIIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_ASSERT(log->isLog2());
+    OCIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
 }
 
-OIIO_ADD_TEST(Log, load_log_to_lin)
+OCIO_ADD_TEST(Log, load_log_to_lin)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     std::string fileName("log_logtolin.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
     const OCIO::OpDataVec & fileOps = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(fileOps.size(), 1);
+    OCIO_REQUIRE_EQUAL(fileOps.size(), 1);
     OCIO::OpDataRcPtr op = fileOps[0];
     OCIO::LogOpDataRcPtr log = std::dynamic_pointer_cast<OCIO::LogOpData>(op);
-    OIIO_REQUIRE_ASSERT(log);
+    OCIO_REQUIRE_ASSERT(log);
 
-    OIIO_CHECK_EQUAL(log->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(log->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(log->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(log->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_ASSERT(!log->isLog2());
-    OIIO_CHECK_ASSERT(!log->isLog10());
-    OIIO_CHECK_ASSERT(log->allComponentsEqual());
+    OCIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_ASSERT(!log->isLog2());
+    OCIO_CHECK_ASSERT(!log->isLog10());
+    OCIO_CHECK_ASSERT(log->allComponentsEqual());
     auto & param = log->getRedParams();
-    OIIO_REQUIRE_EQUAL(param.size(), 4);
+    OCIO_REQUIRE_EQUAL(param.size(), 4);
     double error = 1e-9;
-    OIIO_CHECK_CLOSE(param[OCIO::LOG_SIDE_SLOPE],  0.29325513196, error);
-    OIIO_CHECK_CLOSE(param[OCIO::LOG_SIDE_OFFSET], 0.66959921799, error);
-    OIIO_CHECK_CLOSE(param[OCIO::LIN_SIDE_SLOPE],  0.98969709693, error);
-    OIIO_CHECK_CLOSE(param[OCIO::LIN_SIDE_OFFSET], 0.01030290307, error);
+    OCIO_CHECK_CLOSE(param[OCIO::LOG_SIDE_SLOPE],  0.29325513196, error);
+    OCIO_CHECK_CLOSE(param[OCIO::LOG_SIDE_OFFSET], 0.66959921799, error);
+    OCIO_CHECK_CLOSE(param[OCIO::LIN_SIDE_SLOPE],  0.98969709693, error);
+    OCIO_CHECK_CLOSE(param[OCIO::LIN_SIDE_OFFSET], 0.01030290307, error);
 }
 
-OIIO_ADD_TEST(Log, load_lin_to_log)
+OCIO_ADD_TEST(Log, load_lin_to_log)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     std::string fileName("log_lintolog_3chan.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
     const OCIO::OpDataVec & fileOps = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(fileOps.size(), 1);
+    OCIO_REQUIRE_EQUAL(fileOps.size(), 1);
     OCIO::OpDataRcPtr op = fileOps[0];
     OCIO::LogOpDataRcPtr log = std::dynamic_pointer_cast<OCIO::LogOpData>(op);
-    OIIO_REQUIRE_ASSERT(log);
+    OCIO_REQUIRE_ASSERT(log);
 
-    OIIO_CHECK_EQUAL(log->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(log->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(log->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(log->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_ASSERT(!log->allComponentsEqual());
+    OCIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_ASSERT(!log->allComponentsEqual());
 
     auto & rParam = log->getRedParams();
-    OIIO_REQUIRE_EQUAL(rParam.size(), 4);
+    OCIO_REQUIRE_EQUAL(rParam.size(), 4);
     double error = 1e-9;
-    OIIO_CHECK_CLOSE(rParam[OCIO::LOG_SIDE_SLOPE],   0.244379276637, error);
-    OIIO_CHECK_CLOSE(rParam[OCIO::LOG_SIDE_OFFSET],  0.665689149560, error);
-    OIIO_CHECK_CLOSE(rParam[OCIO::LIN_SIDE_SLOPE],   1.111637101285, error);
-    OIIO_CHECK_CLOSE(rParam[OCIO::LIN_SIDE_OFFSET], -0.000473391157, error);
+    OCIO_CHECK_CLOSE(rParam[OCIO::LOG_SIDE_SLOPE],   0.244379276637, error);
+    OCIO_CHECK_CLOSE(rParam[OCIO::LOG_SIDE_OFFSET],  0.665689149560, error);
+    OCIO_CHECK_CLOSE(rParam[OCIO::LIN_SIDE_SLOPE],   1.111637101285, error);
+    OCIO_CHECK_CLOSE(rParam[OCIO::LIN_SIDE_OFFSET], -0.000473391157, error);
 
     auto & gParam = log->getGreenParams();
-    OIIO_REQUIRE_EQUAL(gParam.size(), 4);
-    OIIO_CHECK_CLOSE(gParam[OCIO::LOG_SIDE_SLOPE],  0.293255131964, error);
-    OIIO_CHECK_CLOSE(gParam[OCIO::LOG_SIDE_OFFSET], 0.666666666667, error);
-    OIIO_CHECK_CLOSE(gParam[OCIO::LIN_SIDE_SLOPE],  0.991514003046, error);
-    OIIO_CHECK_CLOSE(gParam[OCIO::LIN_SIDE_OFFSET], 0.008485996954, error);
+    OCIO_REQUIRE_EQUAL(gParam.size(), 4);
+    OCIO_CHECK_CLOSE(gParam[OCIO::LOG_SIDE_SLOPE],  0.293255131964, error);
+    OCIO_CHECK_CLOSE(gParam[OCIO::LOG_SIDE_OFFSET], 0.666666666667, error);
+    OCIO_CHECK_CLOSE(gParam[OCIO::LIN_SIDE_SLOPE],  0.991514003046, error);
+    OCIO_CHECK_CLOSE(gParam[OCIO::LIN_SIDE_OFFSET], 0.008485996954, error);
 
     auto & bParam = log->getBlueParams();
-    OIIO_REQUIRE_EQUAL(bParam.size(), 4);
-    OIIO_CHECK_CLOSE(bParam[OCIO::LOG_SIDE_SLOPE],  0.317693059628, error);
-    OIIO_CHECK_CLOSE(bParam[OCIO::LOG_SIDE_OFFSET], 0.667644183773, error);
-    OIIO_CHECK_CLOSE(bParam[OCIO::LIN_SIDE_SLOPE],  1.236287104632, error);
-    OIIO_CHECK_CLOSE(bParam[OCIO::LIN_SIDE_OFFSET], 0.010970316295, error);
+    OCIO_REQUIRE_EQUAL(bParam.size(), 4);
+    OCIO_CHECK_CLOSE(bParam[OCIO::LOG_SIDE_SLOPE],  0.317693059628, error);
+    OCIO_CHECK_CLOSE(bParam[OCIO::LOG_SIDE_OFFSET], 0.667644183773, error);
+    OCIO_CHECK_CLOSE(bParam[OCIO::LIN_SIDE_SLOPE],  1.236287104632, error);
+    OCIO_CHECK_CLOSE(bParam[OCIO::LIN_SIDE_OFFSET], 0.010970316295, error);
 }
 
-OIIO_ADD_TEST(Log, load_invalid_style)
+OCIO_ADD_TEST(Log, load_invalid_style)
 {
     std::string fileName("log_invalidstyle.ctf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(fileName), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(fileName), OCIO::Exception,
                           "is invalid");
 }
 
-OIIO_ADD_TEST(Log, load_faulty_version)
+OCIO_ADD_TEST(Log, load_faulty_version)
 {
     std::string fileName("log_log10_faulty_version.ctf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(fileName), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(fileName), OCIO::Exception,
                           "Unsupported transform file version");
 }
 
@@ -3777,320 +3777,320 @@ OIIO_ADD_TEST(Log, load_faulty_version)
 // with the ops from the file it is referencing.  Please see RefereceOpData.cpp
 // for tests involving the resolved ops.
 //
-OIIO_ADD_TEST(Reference, load_alias)
+OCIO_ADD_TEST(Reference, load_alias)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     std::string fileName("reference_alias.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
     const OCIO::OpDataVec & fileOps = cachedFile->m_transform->getOps();
 
-    OIIO_REQUIRE_EQUAL(fileOps.size(), 1);
+    OCIO_REQUIRE_EQUAL(fileOps.size(), 1);
     OCIO::OpDataRcPtr op = fileOps[0];
     OCIO::ReferenceOpDataRcPtr ref = std::dynamic_pointer_cast<OCIO::ReferenceOpData>(op);
-    OIIO_REQUIRE_ASSERT(ref);
-    OIIO_CHECK_EQUAL(ref->getName(), "name");
-    OIIO_CHECK_EQUAL(ref->getID(), "uuid");
-    OIIO_CHECK_EQUAL(ref->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ref->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ref->getReferenceStyle(), OCIO::REF_ALIAS);
-    OIIO_CHECK_EQUAL(ref->getPath(), "");
-    OIIO_CHECK_EQUAL(ref->getAlias(), "alias");
-    OIIO_CHECK_EQUAL(ref->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_REQUIRE_ASSERT(ref);
+    OCIO_CHECK_EQUAL(ref->getName(), "name");
+    OCIO_CHECK_EQUAL(ref->getID(), "uuid");
+    OCIO_CHECK_EQUAL(ref->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ref->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ref->getReferenceStyle(), OCIO::REF_ALIAS);
+    OCIO_CHECK_EQUAL(ref->getPath(), "");
+    OCIO_CHECK_EQUAL(ref->getAlias(), "alias");
+    OCIO_CHECK_EQUAL(ref->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
 }
 
-OIIO_ADD_TEST(Reference, load_path)
+OCIO_ADD_TEST(Reference, load_path)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     std::string fileName("reference_path_missing_file.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
     const OCIO::OpDataVec & fileOps = cachedFile->m_transform->getOps();
     
-    OIIO_REQUIRE_EQUAL(fileOps.size(), 1);
+    OCIO_REQUIRE_EQUAL(fileOps.size(), 1);
     OCIO::OpDataRcPtr op = fileOps[0];
     OCIO::ReferenceOpDataRcPtr ref = std::dynamic_pointer_cast<OCIO::ReferenceOpData>(op);
-    OIIO_REQUIRE_ASSERT(ref);
-    OIIO_CHECK_EQUAL(ref->getReferenceStyle(), OCIO::REF_PATH);
-    OIIO_CHECK_EQUAL(ref->getPath(), "toto/toto.ctf");
-    OIIO_CHECK_EQUAL(ref->getAlias(), "");
-    OIIO_CHECK_EQUAL(ref->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_REQUIRE_ASSERT(ref);
+    OCIO_CHECK_EQUAL(ref->getReferenceStyle(), OCIO::REF_PATH);
+    OCIO_CHECK_EQUAL(ref->getPath(), "toto/toto.ctf");
+    OCIO_CHECK_EQUAL(ref->getAlias(), "");
+    OCIO_CHECK_EQUAL(ref->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
 }
 
-OIIO_ADD_TEST(Reference, load_multiple)
+OCIO_ADD_TEST(Reference, load_multiple)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     // File contains 2 references, 1 range and 1 reference.
     std::string fileName("references_some_inverted.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
     const OCIO::OpDataVec & fileOps = cachedFile->m_transform->getOps();
     
-    OIIO_REQUIRE_EQUAL(fileOps.size(), 4);
+    OCIO_REQUIRE_EQUAL(fileOps.size(), 4);
     OCIO::OpDataRcPtr op0 = fileOps[0];
     OCIO::ReferenceOpDataRcPtr ref0 = std::dynamic_pointer_cast<OCIO::ReferenceOpData>(op0);
-    OIIO_REQUIRE_ASSERT(ref0);
-    OIIO_CHECK_EQUAL(ref0->getReferenceStyle(), OCIO::REF_PATH);
-    OIIO_CHECK_EQUAL(ref0->getPath(), "matrix_example.clf");
-    OIIO_CHECK_EQUAL(ref0->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ref0->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL(ref0->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_REQUIRE_ASSERT(ref0);
+    OCIO_CHECK_EQUAL(ref0->getReferenceStyle(), OCIO::REF_PATH);
+    OCIO_CHECK_EQUAL(ref0->getPath(), "matrix_example.clf");
+    OCIO_CHECK_EQUAL(ref0->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ref0->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(ref0->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
     
     OCIO::OpDataRcPtr op1 = fileOps[1];
     OCIO::ReferenceOpDataRcPtr ref1 = std::dynamic_pointer_cast<OCIO::ReferenceOpData>(op1);
-    OIIO_REQUIRE_ASSERT(ref1);
-    OIIO_CHECK_EQUAL(ref1->getReferenceStyle(), OCIO::REF_PATH);
-    OIIO_CHECK_EQUAL(ref1->getPath(), "xyz_to_rgb.clf");
-    OIIO_CHECK_EQUAL(ref1->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL(ref1->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ref1->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_REQUIRE_ASSERT(ref1);
+    OCIO_CHECK_EQUAL(ref1->getReferenceStyle(), OCIO::REF_PATH);
+    OCIO_CHECK_EQUAL(ref1->getPath(), "xyz_to_rgb.clf");
+    OCIO_CHECK_EQUAL(ref1->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(ref1->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ref1->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
 
     OCIO::OpDataRcPtr op2 = fileOps[2];
     OCIO::RangeOpDataRcPtr range2 = std::dynamic_pointer_cast<OCIO::RangeOpData>(op2);
-    OIIO_REQUIRE_ASSERT(range2);
+    OCIO_REQUIRE_ASSERT(range2);
 
     OCIO::OpDataRcPtr op3 = fileOps[3];
     OCIO::ReferenceOpDataRcPtr ref3 = std::dynamic_pointer_cast<OCIO::ReferenceOpData>(op3);
-    OIIO_REQUIRE_ASSERT(ref3);
-    OIIO_CHECK_EQUAL(ref3->getReferenceStyle(), OCIO::REF_PATH);
-    OIIO_CHECK_EQUAL(ref3->getPath(), "cdl_clamp_fwd.clf");
-    OIIO_CHECK_EQUAL(ref3->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ref3->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_REQUIRE_ASSERT(ref3);
+    OCIO_CHECK_EQUAL(ref3->getReferenceStyle(), OCIO::REF_PATH);
+    OCIO_CHECK_EQUAL(ref3->getPath(), "cdl_clamp_fwd.clf");
+    OCIO_CHECK_EQUAL(ref3->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ref3->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
     // Note: This tests that the "inverted" attribute set to anything other than
     // true does not result in an inverted transform.
-    OIIO_CHECK_EQUAL(ref3->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(ref3->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
 }
 
-OIIO_ADD_TEST(Reference, load_path_utf8)
+OCIO_ADD_TEST(Reference, load_path_utf8)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     std::string fileName("reference_utf8.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
     const OCIO::OpDataVec & fileOps = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(fileOps.size(), 1);
+    OCIO_REQUIRE_EQUAL(fileOps.size(), 1);
     OCIO::OpDataRcPtr op = fileOps[0];
     OCIO::ReferenceOpDataRcPtr ref = std::dynamic_pointer_cast<OCIO::ReferenceOpData>(op);
-    OIIO_REQUIRE_ASSERT(ref);
-    OIIO_CHECK_EQUAL(ref->getReferenceStyle(), OCIO::REF_PATH);
-    OIIO_CHECK_EQUAL(ref->getPath(), "\xE6\xA8\x99\xE6\xBA\x96\xE8\x90\xAC\xE5\x9C\x8B\xE7\xA2\xBC");
-    OIIO_CHECK_EQUAL(ref->getAlias(), "");
+    OCIO_REQUIRE_ASSERT(ref);
+    OCIO_CHECK_EQUAL(ref->getReferenceStyle(), OCIO::REF_PATH);
+    OCIO_CHECK_EQUAL(ref->getPath(), "\xE6\xA8\x99\xE6\xBA\x96\xE8\x90\xAC\xE5\x9C\x8B\xE7\xA2\xBC");
+    OCIO_CHECK_EQUAL(ref->getAlias(), "");
 }
 
-OIIO_ADD_TEST(Reference, load_alias_path)
+OCIO_ADD_TEST(Reference, load_alias_path)
 {
     std::string fileName("reference_alias_path.ctf");
     // Can't have alias and path at the same time.
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(fileName), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(fileName), OCIO::Exception,
                           "alias & path attributes for Reference should not be both defined");
 }
 
-OIIO_ADD_TEST(FileFormatCTF, exposure_contrast_video)
+OCIO_ADD_TEST(FileFormatCTF, exposure_contrast_video)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("exposure_contrast_video.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT(cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT(cachedFile);
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
 
-    OIIO_REQUIRE_EQUAL(opList.size(), 2);
+    OCIO_REQUIRE_EQUAL(opList.size(), 2);
 
-    OIIO_REQUIRE_ASSERT(opList[0]);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::ExposureContrastType);
+    OCIO_REQUIRE_ASSERT(opList[0]);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::ExposureContrastType);
 
     auto pEC = std::dynamic_pointer_cast<const OCIO::ExposureContrastOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pEC);
+    OCIO_REQUIRE_ASSERT(pEC);
 
-    OIIO_CHECK_EQUAL(pEC->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(pEC->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(pEC->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(pEC->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
 
-    OIIO_CHECK_EQUAL(pEC->getStyle(), OCIO::ExposureContrastOpData::STYLE_VIDEO);
+    OCIO_CHECK_EQUAL(pEC->getStyle(), OCIO::ExposureContrastOpData::STYLE_VIDEO);
 
-    OIIO_CHECK_EQUAL(pEC->getExposure(), -1.0);
-    OIIO_CHECK_EQUAL(pEC->getContrast(), 1.5);
-    OIIO_CHECK_EQUAL(pEC->getPivot(), 0.5);
+    OCIO_CHECK_EQUAL(pEC->getExposure(), -1.0);
+    OCIO_CHECK_EQUAL(pEC->getContrast(), 1.5);
+    OCIO_CHECK_EQUAL(pEC->getPivot(), 0.5);
 
-    OIIO_CHECK_ASSERT(pEC->isDynamic());
-    OIIO_CHECK_ASSERT(pEC->getExposureProperty()->isDynamic());
-    OIIO_CHECK_ASSERT(pEC->getContrastProperty()->isDynamic());
-    OIIO_CHECK_ASSERT(!pEC->getGammaProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(pEC->isDynamic());
+    OCIO_CHECK_ASSERT(pEC->getExposureProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(pEC->getContrastProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(!pEC->getGammaProperty()->isDynamic());
 
-    OIIO_REQUIRE_ASSERT(opList[1]);
-    OIIO_CHECK_EQUAL(opList[1]->getType(), OCIO::OpData::ExposureContrastType);
+    OCIO_REQUIRE_ASSERT(opList[1]);
+    OCIO_CHECK_EQUAL(opList[1]->getType(), OCIO::OpData::ExposureContrastType);
 
     auto pECRev = std::dynamic_pointer_cast<const OCIO::ExposureContrastOpData>(opList[1]);
-    OIIO_REQUIRE_ASSERT(pECRev);
-    OIIO_CHECK_ASSERT(!pECRev->isDynamic());
+    OCIO_REQUIRE_ASSERT(pECRev);
+    OCIO_CHECK_ASSERT(!pECRev->isDynamic());
 
-    OIIO_CHECK_EQUAL(pECRev->getStyle(), OCIO::ExposureContrastOpData::STYLE_VIDEO_REV);
+    OCIO_CHECK_EQUAL(pECRev->getStyle(), OCIO::ExposureContrastOpData::STYLE_VIDEO_REV);
 }
 
-OIIO_ADD_TEST(FileFormatCTF, exposure_contrast_log)
+OCIO_ADD_TEST(FileFormatCTF, exposure_contrast_log)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("exposure_contrast_log.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT(cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT(cachedFile);
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
 
-    OIIO_REQUIRE_EQUAL(opList.size(), 2);
+    OCIO_REQUIRE_EQUAL(opList.size(), 2);
 
-    OIIO_REQUIRE_ASSERT(opList[0]);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::ExposureContrastType);
+    OCIO_REQUIRE_ASSERT(opList[0]);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::ExposureContrastType);
 
     auto pEC = std::dynamic_pointer_cast<const OCIO::ExposureContrastOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pEC);
+    OCIO_REQUIRE_ASSERT(pEC);
 
-    OIIO_CHECK_EQUAL(pEC->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(pEC->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pEC->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pEC->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_EQUAL(pEC->getStyle(), OCIO::ExposureContrastOpData::STYLE_LOGARITHMIC);
+    OCIO_CHECK_EQUAL(pEC->getStyle(), OCIO::ExposureContrastOpData::STYLE_LOGARITHMIC);
 
-    OIIO_CHECK_EQUAL(pEC->getExposure(), -1.5);
-    OIIO_CHECK_EQUAL(pEC->getContrast(), 0.5);
-    OIIO_CHECK_EQUAL(pEC->getGamma(), 1.2);
-    OIIO_CHECK_EQUAL(pEC->getPivot(), 0.18);
+    OCIO_CHECK_EQUAL(pEC->getExposure(), -1.5);
+    OCIO_CHECK_EQUAL(pEC->getContrast(), 0.5);
+    OCIO_CHECK_EQUAL(pEC->getGamma(), 1.2);
+    OCIO_CHECK_EQUAL(pEC->getPivot(), 0.18);
 
-    OIIO_CHECK_ASSERT(pEC->isDynamic());
-    OIIO_CHECK_ASSERT(pEC->getExposureProperty()->isDynamic());
-    OIIO_CHECK_ASSERT(pEC->getContrastProperty()->isDynamic());
-    OIIO_CHECK_ASSERT(pEC->getGammaProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(pEC->isDynamic());
+    OCIO_CHECK_ASSERT(pEC->getExposureProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(pEC->getContrastProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(pEC->getGammaProperty()->isDynamic());
 
-    OIIO_REQUIRE_ASSERT(opList[1]);
-    OIIO_CHECK_EQUAL(opList[1]->getType(), OCIO::OpData::ExposureContrastType);
+    OCIO_REQUIRE_ASSERT(opList[1]);
+    OCIO_CHECK_EQUAL(opList[1]->getType(), OCIO::OpData::ExposureContrastType);
 
     auto pECRev = std::dynamic_pointer_cast<const OCIO::ExposureContrastOpData>(opList[1]);
-    OIIO_REQUIRE_ASSERT(pECRev);
+    OCIO_REQUIRE_ASSERT(pECRev);
 
-    OIIO_CHECK_EQUAL(pECRev->getStyle(), OCIO::ExposureContrastOpData::STYLE_LOGARITHMIC_REV);
-    OIIO_CHECK_ASSERT(pECRev->isDynamic());
-    OIIO_CHECK_ASSERT(pECRev->getExposureProperty()->isDynamic());
-    OIIO_CHECK_ASSERT(!pECRev->getContrastProperty()->isDynamic());
-    OIIO_CHECK_ASSERT(!pECRev->getGammaProperty()->isDynamic());
+    OCIO_CHECK_EQUAL(pECRev->getStyle(), OCIO::ExposureContrastOpData::STYLE_LOGARITHMIC_REV);
+    OCIO_CHECK_ASSERT(pECRev->isDynamic());
+    OCIO_CHECK_ASSERT(pECRev->getExposureProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(!pECRev->getContrastProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(!pECRev->getGammaProperty()->isDynamic());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, exposure_contrast_linear)
+OCIO_ADD_TEST(FileFormatCTF, exposure_contrast_linear)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("exposure_contrast_linear.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT(cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT(cachedFile);
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
 
-    OIIO_REQUIRE_EQUAL(opList.size(), 2);
+    OCIO_REQUIRE_EQUAL(opList.size(), 2);
 
-    OIIO_REQUIRE_ASSERT(opList[0]);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::ExposureContrastType);
+    OCIO_REQUIRE_ASSERT(opList[0]);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::ExposureContrastType);
 
     auto pEC = std::dynamic_pointer_cast<const OCIO::ExposureContrastOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pEC);
+    OCIO_REQUIRE_ASSERT(pEC);
 
-    OIIO_CHECK_EQUAL(pEC->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(pEC->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(pEC->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(pEC->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_EQUAL(pEC->getStyle(), OCIO::ExposureContrastOpData::STYLE_LINEAR);
+    OCIO_CHECK_EQUAL(pEC->getStyle(), OCIO::ExposureContrastOpData::STYLE_LINEAR);
 
-    OIIO_CHECK_EQUAL(pEC->getExposure(), 0.65);
-    OIIO_CHECK_EQUAL(pEC->getContrast(), 1.2);
-    OIIO_CHECK_EQUAL(pEC->getGamma(), 0.5);
-    OIIO_CHECK_EQUAL(pEC->getPivot(), 1.0);
+    OCIO_CHECK_EQUAL(pEC->getExposure(), 0.65);
+    OCIO_CHECK_EQUAL(pEC->getContrast(), 1.2);
+    OCIO_CHECK_EQUAL(pEC->getGamma(), 0.5);
+    OCIO_CHECK_EQUAL(pEC->getPivot(), 1.0);
 
-    OIIO_CHECK_ASSERT(pEC->isDynamic());
-    OIIO_CHECK_ASSERT(pEC->getExposureProperty()->isDynamic());
-    OIIO_CHECK_ASSERT(pEC->getContrastProperty()->isDynamic());
-    OIIO_CHECK_ASSERT(pEC->getGammaProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(pEC->isDynamic());
+    OCIO_CHECK_ASSERT(pEC->getExposureProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(pEC->getContrastProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(pEC->getGammaProperty()->isDynamic());
 
-    OIIO_REQUIRE_ASSERT(opList[1]);
-    OIIO_CHECK_EQUAL(opList[1]->getType(), OCIO::OpData::ExposureContrastType);
+    OCIO_REQUIRE_ASSERT(opList[1]);
+    OCIO_CHECK_EQUAL(opList[1]->getType(), OCIO::OpData::ExposureContrastType);
 
     auto pECRev = std::dynamic_pointer_cast<const OCIO::ExposureContrastOpData>(opList[1]);
-    OIIO_REQUIRE_ASSERT(pECRev);
+    OCIO_REQUIRE_ASSERT(pECRev);
 
-    OIIO_CHECK_EQUAL(pECRev->getStyle(), OCIO::ExposureContrastOpData::STYLE_LINEAR_REV);
-    OIIO_CHECK_ASSERT(!pECRev->isDynamic());
-    OIIO_CHECK_ASSERT(!pECRev->getExposureProperty()->isDynamic());
-    OIIO_CHECK_ASSERT(!pECRev->getContrastProperty()->isDynamic());
-    OIIO_CHECK_ASSERT(!pECRev->getGammaProperty()->isDynamic());
+    OCIO_CHECK_EQUAL(pECRev->getStyle(), OCIO::ExposureContrastOpData::STYLE_LINEAR_REV);
+    OCIO_CHECK_ASSERT(!pECRev->isDynamic());
+    OCIO_CHECK_ASSERT(!pECRev->getExposureProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(!pECRev->getContrastProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(!pECRev->getGammaProperty()->isDynamic());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, exposure_contrast_no_gamma) 
+OCIO_ADD_TEST(FileFormatCTF, exposure_contrast_no_gamma) 
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string ctfFile("exposure_contrast_no_gamma.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
-    OIIO_REQUIRE_ASSERT(cachedFile);
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(ctfFile));
+    OCIO_REQUIRE_ASSERT(cachedFile);
     const OCIO::OpDataVec & opList = cachedFile->m_transform->getOps();
 
-    OIIO_REQUIRE_EQUAL(opList.size(), 1);
+    OCIO_REQUIRE_EQUAL(opList.size(), 1);
 
-    OIIO_REQUIRE_ASSERT(opList[0]);
-    OIIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::ExposureContrastType);
+    OCIO_REQUIRE_ASSERT(opList[0]);
+    OCIO_CHECK_EQUAL(opList[0]->getType(), OCIO::OpData::ExposureContrastType);
 
     auto pEC = std::dynamic_pointer_cast<const OCIO::ExposureContrastOpData>(opList[0]);
-    OIIO_REQUIRE_ASSERT(pEC);
+    OCIO_REQUIRE_ASSERT(pEC);
 
-    OIIO_CHECK_EQUAL(pEC->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(pEC->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(pEC->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(pEC->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
 
-    OIIO_CHECK_EQUAL(pEC->getStyle(), OCIO::ExposureContrastOpData::STYLE_VIDEO);
+    OCIO_CHECK_EQUAL(pEC->getStyle(), OCIO::ExposureContrastOpData::STYLE_VIDEO);
 
-    OIIO_CHECK_EQUAL(pEC->getExposure(), 0.2);
-    OIIO_CHECK_EQUAL(pEC->getContrast(), 0.65);
-    OIIO_CHECK_EQUAL(pEC->getPivot(), 0.23);
+    OCIO_CHECK_EQUAL(pEC->getExposure(), 0.2);
+    OCIO_CHECK_EQUAL(pEC->getContrast(), 0.65);
+    OCIO_CHECK_EQUAL(pEC->getPivot(), 0.23);
 
-    OIIO_CHECK_EQUAL(pEC->getGamma(), 1.0);
+    OCIO_CHECK_EQUAL(pEC->getGamma(), 1.0);
 
-    OIIO_CHECK_ASSERT(!pEC->isDynamic());
-    OIIO_CHECK_ASSERT(!pEC->getExposureProperty()->isDynamic());
-    OIIO_CHECK_ASSERT(!pEC->getContrastProperty()->isDynamic());
-    OIIO_CHECK_ASSERT(!pEC->getGammaProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(!pEC->isDynamic());
+    OCIO_CHECK_ASSERT(!pEC->getExposureProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(!pEC->getContrastProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(!pEC->getGammaProperty()->isDynamic());
 }
 
-OIIO_ADD_TEST(FileFormatCTF, exposure_contrast_failures)
+OCIO_ADD_TEST(FileFormatCTF, exposure_contrast_failures)
 {
     const std::string ecBadStyle("exposure_contrast_bad_style.ctf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ecBadStyle), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ecBadStyle), OCIO::Exception,
                           "Unknown exposure contrast style");
 
     const std::string ecMissingParam("exposure_contrast_missing_param.ctf");
-    OIIO_CHECK_THROW_WHAT(LoadCLFFile(ecMissingParam), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(LoadCLFFile(ecMissingParam), OCIO::Exception,
                           "exposure missing");
 }
 
-OIIO_ADD_TEST(FixedFunction, load_ff_aces_redmod)
+OCIO_ADD_TEST(FixedFunction, load_ff_aces_redmod)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     std::string fileName("ff_aces_redmod.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
     const OCIO::OpDataVec & fileOps = cachedFile->m_transform->getOps();
-    OIIO_REQUIRE_EQUAL(fileOps.size(), 1);
+    OCIO_REQUIRE_EQUAL(fileOps.size(), 1);
     OCIO::OpDataRcPtr op = fileOps[0];
     OCIO::FixedFunctionOpDataRcPtr func = std::dynamic_pointer_cast<OCIO::FixedFunctionOpData>(op);
-    OIIO_REQUIRE_ASSERT(func);
+    OCIO_REQUIRE_ASSERT(func);
 
-    OIIO_CHECK_EQUAL(func->getInputBitDepth(), OCIO::BIT_DEPTH_UINT16);
-    OIIO_CHECK_EQUAL(func->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(func->getInputBitDepth(), OCIO::BIT_DEPTH_UINT16);
+    OCIO_CHECK_EQUAL(func->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_EQUAL(func->getStyle(), OCIO::FixedFunctionOpData::ACES_RED_MOD_03_INV);
+    OCIO_CHECK_EQUAL(func->getStyle(), OCIO::FixedFunctionOpData::ACES_RED_MOD_03_INV);
 }
 
-OIIO_ADD_TEST(FixedFunction, load_ff_aces_surround)
+OCIO_ADD_TEST(FixedFunction, load_ff_aces_surround)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     std::string fileName("ff_aces_surround.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
     const OCIO::OpDataVec & fileOps = cachedFile->m_transform->getOps();
 
-    OIIO_REQUIRE_EQUAL(fileOps.size(), 1);
+    OCIO_REQUIRE_EQUAL(fileOps.size(), 1);
     OCIO::OpDataRcPtr op = fileOps[0];
     OCIO::FixedFunctionOpDataRcPtr func = std::dynamic_pointer_cast<OCIO::FixedFunctionOpData>(op);
-    OIIO_REQUIRE_ASSERT(func);
+    OCIO_REQUIRE_ASSERT(func);
 
-    OIIO_CHECK_EQUAL(func->getInputBitDepth(), OCIO::BIT_DEPTH_UINT16);
-    OIIO_CHECK_EQUAL(func->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(func->getInputBitDepth(), OCIO::BIT_DEPTH_UINT16);
+    OCIO_CHECK_EQUAL(func->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_EQUAL(func->getStyle(), OCIO::FixedFunctionOpData::REC2100_SURROUND);
+    OCIO_CHECK_EQUAL(func->getStyle(), OCIO::FixedFunctionOpData::REC2100_SURROUND);
 
     OCIO::FixedFunctionOpData::Params params;
     params.push_back(1.2);
     func->validate();
-    OIIO_CHECK_ASSERT(func->getParams() == params);
+    OCIO_CHECK_ASSERT(func->getParams() == params);
 }
 
 void ValidateFixedFunctionStyleNoParam(OCIO::FixedFunctionOpData::Style style)
@@ -4110,19 +4110,19 @@ void ValidateFixedFunctionStyleNoParam(OCIO::FixedFunctionOpData::Style style)
     // Load file
     OCIO::LocalFileFormat tester;
     OCIO::CachedFileRcPtr file;
-    OIIO_CHECK_NO_THROW(file = tester.Read(ctf, styleName));
+    OCIO_CHECK_NO_THROW(file = tester.Read(ctf, styleName));
     OCIO::LocalCachedFileRcPtr cachedFile = OCIO_DYNAMIC_POINTER_CAST<OCIO::LocalCachedFile>(file);
     const OCIO::OpDataVec & fileOps = cachedFile->m_transform->getOps();
 
-    OIIO_REQUIRE_EQUAL(fileOps.size(), 1);
+    OCIO_REQUIRE_EQUAL(fileOps.size(), 1);
     OCIO::OpDataRcPtr op = fileOps[0];
     OCIO::FixedFunctionOpDataRcPtr func = std::dynamic_pointer_cast<OCIO::FixedFunctionOpData>(op);
-    OIIO_REQUIRE_ASSERT(func);
+    OCIO_REQUIRE_ASSERT(func);
 
-    OIIO_CHECK_EQUAL(func->getStyle(), style);
+    OCIO_CHECK_EQUAL(func->getStyle(), style);
 }
 
-OIIO_ADD_TEST(FixedFunction, load_ff_style)
+OCIO_ADD_TEST(FixedFunction, load_ff_style)
 {
     ValidateFixedFunctionStyleNoParam(OCIO::FixedFunctionOpData::ACES_RED_MOD_03_FWD);
     ValidateFixedFunctionStyleNoParam(OCIO::FixedFunctionOpData::ACES_RED_MOD_03_INV);
@@ -4136,30 +4136,30 @@ OIIO_ADD_TEST(FixedFunction, load_ff_style)
     ValidateFixedFunctionStyleNoParam(OCIO::FixedFunctionOpData::ACES_DARK_TO_DIM_10_INV);
 }
 
-OIIO_ADD_TEST(FixedFunction, load_ff_surround)
+OCIO_ADD_TEST(FixedFunction, load_ff_surround)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     std::string fileName("ff_surround.ctf");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadCLFFile(fileName));
     const OCIO::OpDataVec & fileOps = cachedFile->m_transform->getOps();
 
-    OIIO_REQUIRE_EQUAL(fileOps.size(), 1);
+    OCIO_REQUIRE_EQUAL(fileOps.size(), 1);
     OCIO::OpDataRcPtr op = fileOps[0];
     OCIO::FixedFunctionOpDataRcPtr func = std::dynamic_pointer_cast<OCIO::FixedFunctionOpData>(op);
-    OIIO_REQUIRE_ASSERT(func);
+    OCIO_REQUIRE_ASSERT(func);
 
-    OIIO_CHECK_EQUAL(func->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(func->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(func->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(func->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_EQUAL(func->getStyle(), OCIO::FixedFunctionOpData::REC2100_SURROUND);
+    OCIO_CHECK_EQUAL(func->getStyle(), OCIO::FixedFunctionOpData::REC2100_SURROUND);
 
     OCIO::FixedFunctionOpData::Params params;
     params.push_back(0.8);
     func->validate();
-    OIIO_CHECK_ASSERT(func->getParams() == params);
+    OCIO_CHECK_ASSERT(func->getParams() == params);
 }
 
-OIIO_ADD_TEST(FixedFunction, load_ff_fail_version)
+OCIO_ADD_TEST(FixedFunction, load_ff_fail_version)
 {
     std::ostringstream strebuf;
     strebuf << "<?xml version='1.0' encoding='UTF-8'?>\n";
@@ -4175,11 +4175,11 @@ OIIO_ADD_TEST(FixedFunction, load_ff_fail_version)
     // Load file
     std::string emptyString;
     OCIO::LocalFileFormat tester;
-    OIIO_CHECK_THROW_WHAT(tester.Read(ctf, emptyString), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(tester.Read(ctf, emptyString), OCIO::Exception,
                           "Unsupported transform file version");
 }
 
-OIIO_ADD_TEST(FixedFunction, load_ff_fail_params)
+OCIO_ADD_TEST(FixedFunction, load_ff_fail_params)
 {
     std::ostringstream strebuf;
     strebuf << "<?xml version='1.0' encoding='UTF-8'?>\n";
@@ -4195,11 +4195,11 @@ OIIO_ADD_TEST(FixedFunction, load_ff_fail_params)
     // Load file
     std::string emptyString;
     OCIO::LocalFileFormat tester;
-    OIIO_CHECK_THROW_WHAT(tester.Read(ctf, emptyString), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(tester.Read(ctf, emptyString), OCIO::Exception,
                           "must have one parameter but 2 found");
 }
 
-OIIO_ADD_TEST(FixedFunction, load_ff_aces_fail_style)
+OCIO_ADD_TEST(FixedFunction, load_ff_aces_fail_style)
 {
     std::ostringstream strebuf;
     strebuf << "<?xml version='1.0' encoding='UTF-8'?>\n";
@@ -4213,11 +4213,11 @@ OIIO_ADD_TEST(FixedFunction, load_ff_aces_fail_style)
     // Load file
     std::string emptyString;
     OCIO::LocalFileFormat tester;
-    OIIO_CHECK_THROW_WHAT(tester.Read(ctf, emptyString), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(tester.Read(ctf, emptyString), OCIO::Exception,
                           "Unknown FixedFunction style");
 }
 
-OIIO_ADD_TEST(FixedFunction, load_ff_aces_fail_gamma_param)
+OCIO_ADD_TEST(FixedFunction, load_ff_aces_fail_gamma_param)
 {
     std::ostringstream strebuf;
     strebuf << "<?xml version='1.0' encoding='UTF-8'?>\n";
@@ -4233,11 +4233,11 @@ OIIO_ADD_TEST(FixedFunction, load_ff_aces_fail_gamma_param)
     // Load file
     std::string emptyString;
     OCIO::LocalFileFormat tester;
-    OIIO_CHECK_THROW_WHAT(tester.Read(ctf, emptyString), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(tester.Read(ctf, emptyString), OCIO::Exception,
                           "Missing required parameter");
 }
 
-OIIO_ADD_TEST(FixedFunction, load_ff_aces_fail_gamma_twice)
+OCIO_ADD_TEST(FixedFunction, load_ff_aces_fail_gamma_twice)
 {
     std::ostringstream strebuf;
     strebuf << "<?xml version='1.0' encoding='UTF-8'?>\n";
@@ -4254,11 +4254,11 @@ OIIO_ADD_TEST(FixedFunction, load_ff_aces_fail_gamma_twice)
     // Load file
     std::string emptyString;
     OCIO::LocalFileFormat tester;
-    OIIO_CHECK_THROW_WHAT(tester.Read(ctf, emptyString), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(tester.Read(ctf, emptyString), OCIO::Exception,
                           "only 1 gamma parameter");
 }
 
-OIIO_ADD_TEST(FixedFunction, load_ff_aces_fail_missing_param)
+OCIO_ADD_TEST(FixedFunction, load_ff_aces_fail_missing_param)
 {
     std::ostringstream strebuf;
     strebuf << "<?xml version='1.0' encoding='UTF-8'?>\n";
@@ -4273,7 +4273,7 @@ OIIO_ADD_TEST(FixedFunction, load_ff_aces_fail_missing_param)
     // Load file
     std::string emptyString;
     OCIO::LocalFileFormat tester;
-    OIIO_CHECK_THROW_WHAT(tester.Read(ctf, emptyString), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(tester.Read(ctf, emptyString), OCIO::Exception,
                           "must have one parameter");
 }
 

--- a/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatDiscreet1DL.cpp
@@ -821,7 +821,7 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
 #ifdef WINDOWS
@@ -838,7 +838,7 @@ void TestToolsStripBlank(
     stringCopy(stringToStrip, stringToStripChar, 200);
     OCIO::ReplaceTabsAndStripSpaces(stringToStrip);
     std::string strippedString(stringToStrip);
-    OIIO_CHECK_EQUAL(stringResult, strippedString);
+    OCIO_CHECK_EQUAL(stringResult, strippedString);
 }
 
 void TestToolsStripEndNewLine(
@@ -849,10 +849,10 @@ void TestToolsStripEndNewLine(
     stringCopy(stringToStrip, stringToStripChar, 200);
     OCIO::StripEndNewLine(stringToStrip);
     std::string strippedString(stringToStrip);
-    OIIO_CHECK_EQUAL(stringResult, strippedString);
+    OCIO_CHECK_EQUAL(stringResult, strippedString);
 }
 
-OIIO_ADD_TEST(FileFormatD1DL, test_string_util)
+OCIO_ADD_TEST(FileFormatD1DL, test_string_util)
 {
     TestToolsStripBlank("this is a test", "this is a test");
     TestToolsStripBlank("   this is a test      ", "this is a test");
@@ -876,27 +876,27 @@ OCIO::LocalCachedFileRcPtr LoadLutFile(const std::string & fileName)
         fileName, std::ios_base::in);
 }
 
-OIIO_ADD_TEST(FileFormatD1DL, test_lut1d_8i_8i)
+OCIO_ADD_TEST(FileFormatD1DL, test_lut1d_8i_8i)
 {
     OCIO::LocalCachedFileRcPtr lutFile;
     const std::string discreetLut("logtolin_8to8.lut");
-    OIIO_CHECK_NO_THROW(lutFile = LoadLutFile(discreetLut));
+    OCIO_CHECK_NO_THROW(lutFile = LoadLutFile(discreetLut));
 
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getID(), "");
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getName(), "");
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getID(), "");
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getName(), "");
     const OCIO::OpData::Descriptions & desc = lutFile->lut1D->getDescriptions();
-    OIIO_CHECK_EQUAL(desc.size(), 0);
+    OCIO_CHECK_EQUAL(desc.size(), 0);
 
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
 
-    OIIO_CHECK_ASSERT(!lutFile->lut1D->isInputHalfDomain());
-    OIIO_CHECK_ASSERT(!lutFile->lut1D->isOutputRawHalfs());
+    OCIO_CHECK_ASSERT(!lutFile->lut1D->isInputHalfDomain());
+    OCIO_CHECK_ASSERT(!lutFile->lut1D->isOutputRawHalfs());
 
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getArray().getLength(), 256ul);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumValues(), (unsigned long)256 * 3);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumColorComponents(), 3ul);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getArray().getLength(), 256ul);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumValues(), (unsigned long)256 * 3);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumColorComponents(), 3ul);
 
     // Select some samples to verify the LUT was fully read.
     const unsigned long sampleInterval = 13ul;
@@ -913,31 +913,31 @@ OIIO_ADD_TEST(FileFormatD1DL, test_lut1d_8i_8i)
     const OCIO::Array::Values & lut1DValues = lutFile->lut1D->getArray().getValues();
     for (unsigned long li = 0, ei = 0; li<lut1DValues.size(); li += sampleInterval, ++ei)
     {
-        OIIO_CHECK_EQUAL(lut1DValues[li], expectedSampleValues[ei]);
+        OCIO_CHECK_EQUAL(lut1DValues[li], expectedSampleValues[ei]);
     }
 }
 
-OIIO_ADD_TEST(FileFormatD1DL, test_lut1d_12i_16f)
+OCIO_ADD_TEST(FileFormatD1DL, test_lut1d_12i_16f)
 {
     OCIO::LocalCachedFileRcPtr lutFile;
     const std::string discreetLut1216fp("Test_12to16fp.lut");
-    OIIO_CHECK_NO_THROW(lutFile = LoadLutFile(discreetLut1216fp));
+    OCIO_CHECK_NO_THROW(lutFile = LoadLutFile(discreetLut1216fp));
 
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getID(), "");
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getName(), "");
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getID(), "");
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getName(), "");
     const OCIO::OpData::Descriptions & desc = lutFile->lut1D->getDescriptions();
-    OIIO_CHECK_EQUAL(desc.size(), 0);
+    OCIO_CHECK_EQUAL(desc.size(), 0);
 
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
 
-    OIIO_CHECK_ASSERT(!lutFile->lut1D->isInputHalfDomain());
-    OIIO_CHECK_ASSERT(!lutFile->lut1D->isOutputRawHalfs());
+    OCIO_CHECK_ASSERT(!lutFile->lut1D->isInputHalfDomain());
+    OCIO_CHECK_ASSERT(!lutFile->lut1D->isOutputRawHalfs());
 
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getArray().getLength(), 4096ul);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumValues(), (unsigned long)4096 * 3);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumColorComponents(), 3ul);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getArray().getLength(), 4096ul);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumValues(), (unsigned long)4096 * 3);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumColorComponents(), 3ul);
 
     // Select some samples to verify the LUT was fully read.
     const unsigned long sampleInterval = 207ul;
@@ -954,26 +954,26 @@ OIIO_ADD_TEST(FileFormatD1DL, test_lut1d_12i_16f)
     const OCIO::Array::Values & lut1DValues = lutFile->lut1D->getArray().getValues();
     for (unsigned long li = 0, ei = 0; li<lut1DValues.size(); li += sampleInterval, ++ei)
     {
-        OIIO_CHECK_EQUAL(half(lut1DValues[li]).bits(), expectedSampleValues[ei]);
+        OCIO_CHECK_EQUAL(half(lut1DValues[li]).bits(), expectedSampleValues[ei]);
     }
 }
 
-OIIO_ADD_TEST(FileFormatD1DL, test_lut1d_16f_16f)
+OCIO_ADD_TEST(FileFormatD1DL, test_lut1d_16f_16f)
 {
     OCIO::LocalCachedFileRcPtr lutFile;
     const std::string discreetLut16fp16fp("photo_default_16fpto16fp.lut");
-    OIIO_CHECK_NO_THROW(lutFile = LoadLutFile(discreetLut16fp16fp));
+    OCIO_CHECK_NO_THROW(lutFile = LoadLutFile(discreetLut16fp16fp));
 
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
 
-    OIIO_CHECK_ASSERT(lutFile->lut1D->isInputHalfDomain());
-    OIIO_CHECK_ASSERT(!lutFile->lut1D->isOutputRawHalfs());
+    OCIO_CHECK_ASSERT(lutFile->lut1D->isInputHalfDomain());
+    OCIO_CHECK_ASSERT(!lutFile->lut1D->isOutputRawHalfs());
 
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getArray().getLength(), 65536ul);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumValues(), (unsigned long)65536 * 3);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumColorComponents(), 3ul);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getArray().getLength(), 65536ul);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumValues(), (unsigned long)65536 * 3);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumColorComponents(), 3ul);
 
     // Select some samples to verify the LUT was fully read.
     const unsigned long sampleInterval = 3277ul;
@@ -990,26 +990,26 @@ OIIO_ADD_TEST(FileFormatD1DL, test_lut1d_16f_16f)
     const OCIO::Array::Values & lut1DValues = lutFile->lut1D->getArray().getValues();
     for (unsigned li = 0, ei = 0; li<lut1DValues.size(); li += sampleInterval, ++ei)
     {
-        OIIO_CHECK_EQUAL(half(lut1DValues[li]).bits(), expectedSampleValues[ei]);
+        OCIO_CHECK_EQUAL(half(lut1DValues[li]).bits(), expectedSampleValues[ei]);
     }
 }
 
-OIIO_ADD_TEST(FileFormatD1DL, test_lut1d_16f_12i)
+OCIO_ADD_TEST(FileFormatD1DL, test_lut1d_16f_12i)
 {
     OCIO::LocalCachedFileRcPtr lutFile;
     const std::string discreetLut16fp12("Test_16fpto12.lut");
-    OIIO_CHECK_NO_THROW(lutFile = LoadLutFile(discreetLut16fp12));
+    OCIO_CHECK_NO_THROW(lutFile = LoadLutFile(discreetLut16fp12));
 
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 
-    OIIO_CHECK_ASSERT(lutFile->lut1D->isInputHalfDomain());
-    OIIO_CHECK_ASSERT(!lutFile->lut1D->isOutputRawHalfs());
+    OCIO_CHECK_ASSERT(lutFile->lut1D->isInputHalfDomain());
+    OCIO_CHECK_ASSERT(!lutFile->lut1D->isOutputRawHalfs());
 
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getArray().getLength(), 65536ul);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumValues(), (unsigned long)65536 * 3);
-    OIIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumColorComponents(), 3ul);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getArray().getLength(), 65536ul);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumValues(), (unsigned long)65536 * 3);
+    OCIO_CHECK_EQUAL(lutFile->lut1D->getArray().getNumColorComponents(), 3ul);
 
     // Select some samples to verify the LUT was fully read.
     const unsigned long sampleInterval = 3277ul;
@@ -1026,15 +1026,15 @@ OIIO_ADD_TEST(FileFormatD1DL, test_lut1d_16f_12i)
     const OCIO::Array::Values & lut1DValues = lutFile->lut1D->getArray().getValues();
     for (unsigned li = 0, ei = 0; li<lut1DValues.size(); li += sampleInterval, ++ei)
     {
-        OIIO_CHECK_EQUAL(lut1DValues[li], expectedSampleValues[ei]);
+        OCIO_CHECK_EQUAL(lut1DValues[li], expectedSampleValues[ei]);
     }
 }
 
-OIIO_ADD_TEST(FileFormatD1DL, test_bad_file)
+OCIO_ADD_TEST(FileFormatD1DL, test_bad_file)
 {
     // Bad file.
     const std::string truncatedLut("error_truncated_file.lut");
-    OIIO_CHECK_THROW(LoadLutFile(truncatedLut), OCIO::Exception);
+    OCIO_CHECK_THROW(LoadLutFile(truncatedLut), OCIO::Exception);
 }
 
 #endif // OCIO_UNIT_TEST

--- a/src/OpenColorIO/fileformats/FileFormatHDL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatHDL.cpp
@@ -990,9 +990,9 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(FileFormatHDL, Read1D)
+OCIO_ADD_TEST(FileFormatHDL, Read1D)
 {
     std::ostringstream strebuf;
     strebuf << "Version\t\t1" << "\n";
@@ -1035,25 +1035,25 @@ OIIO_ADD_TEST(FileFormatHDL, Read1D)
     OCIO::CachedFileHDLRcPtr lut = OCIO::DynamicPtrCast<OCIO::CachedFileHDL>(cachedFile);
     
     //
-    OIIO_CHECK_EQUAL(to_min, lut->to_min);
-    OIIO_CHECK_EQUAL(to_max, lut->to_max);
-    OIIO_CHECK_EQUAL(black, lut->hdlblack);
-    OIIO_CHECK_EQUAL(white, lut->hdlwhite);
+    OCIO_CHECK_EQUAL(to_min, lut->to_min);
+    OCIO_CHECK_EQUAL(to_max, lut->to_max);
+    OCIO_CHECK_EQUAL(black, lut->hdlblack);
+    OCIO_CHECK_EQUAL(white, lut->hdlwhite);
     
     // check 1D data (each channel has the same data)
     for(int c = 0; c < 3; ++c) {
-        OIIO_CHECK_EQUAL(from_min, lut->lut1D->from_min[c]);
-        OIIO_CHECK_EQUAL(from_max, lut->lut1D->from_max[c]);
+        OCIO_CHECK_EQUAL(from_min, lut->lut1D->from_min[c]);
+        OCIO_CHECK_EQUAL(from_max, lut->lut1D->from_max[c]);
 
-        OIIO_CHECK_EQUAL(9, lut->lut1D->luts[c].size());
+        OCIO_CHECK_EQUAL(9, lut->lut1D->luts[c].size());
 
         for(unsigned int i = 0; i < lut->lut1D->luts[c].size(); ++i) {
-            OIIO_CHECK_EQUAL(lut1d[i], lut->lut1D->luts[c][i]);
+            OCIO_CHECK_EQUAL(lut1d[i], lut->lut1D->luts[c][i]);
         }
     }
 }
 
-OIIO_ADD_TEST(FileFormatHDL, Bake1D)
+OCIO_ADD_TEST(FileFormatHDL, Bake1D)
 {
     
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
@@ -1143,16 +1143,16 @@ OIIO_ADD_TEST(FileFormatHDL, Bake1D)
     
     //
     std::vector<std::string> osvec;
-    OCIO::pystring::splitlines(output.str(), osvec);
+    pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    OCIO::pystring::splitlines(bout, resvec);
-    OIIO_CHECK_EQUAL(osvec.size(), resvec.size());
+    pystring::splitlines(bout, resvec);
+    OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < std::min(osvec.size(), resvec.size()); ++i)
-        OIIO_CHECK_EQUAL(OCIO::pystring::strip(osvec[i]), OCIO::pystring::strip(resvec[i]));
+        OCIO_CHECK_EQUAL(pystring::strip(osvec[i]), pystring::strip(resvec[i]));
     
 }
 
-OIIO_ADD_TEST(FileFormatHDL, Read3D)
+OCIO_ADD_TEST(FileFormatHDL, Read3D)
 {
     std::ostringstream strebuf;
     strebuf << "Version         2" << "\n";
@@ -1201,20 +1201,20 @@ OIIO_ADD_TEST(FileFormatHDL, Read3D)
         0.f, 0.601016f, 0.917034f };
     
     //
-    OIIO_CHECK_EQUAL(to_min, lut->to_min);
-    OIIO_CHECK_EQUAL(to_max, lut->to_max);
-    OIIO_CHECK_EQUAL(black, lut->hdlblack);
-    OIIO_CHECK_EQUAL(white, lut->hdlwhite);
+    OCIO_CHECK_EQUAL(to_min, lut->to_min);
+    OCIO_CHECK_EQUAL(to_max, lut->to_max);
+    OCIO_CHECK_EQUAL(black, lut->hdlblack);
+    OCIO_CHECK_EQUAL(white, lut->hdlwhite);
     
     // check cube data
-    OIIO_CHECK_EQUAL(2*2*2*3, lut->lut3D->lut.size());
+    OCIO_CHECK_EQUAL(2*2*2*3, lut->lut3D->lut.size());
 
     for(unsigned int i = 0; i < lut->lut3D->lut.size(); ++i) {
-        OIIO_CHECK_EQUAL(cube[i], lut->lut3D->lut[i]);
+        OCIO_CHECK_EQUAL(cube[i], lut->lut3D->lut[i]);
     }
 }
 
-OIIO_ADD_TEST(FileFormatHDL, Bake3D)
+OCIO_ADD_TEST(FileFormatHDL, Bake3D)
 {
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
     
@@ -1283,15 +1283,15 @@ OIIO_ADD_TEST(FileFormatHDL, Bake3D)
     
     //
     std::vector<std::string> osvec;
-    OCIO::pystring::splitlines(output.str(), osvec);
+    pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    OCIO::pystring::splitlines(bout, resvec);
-    OIIO_CHECK_EQUAL(osvec.size(), resvec.size());
+    pystring::splitlines(bout, resvec);
+    OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < std::min(osvec.size(), resvec.size()); ++i)
-        OIIO_CHECK_EQUAL(OCIO::pystring::strip(osvec[i]), OCIO::pystring::strip(resvec[i]));
+        OCIO_CHECK_EQUAL(pystring::strip(osvec[i]), pystring::strip(resvec[i]));
 }
 
-OIIO_ADD_TEST(FileFormatHDL, Read3D1D)
+OCIO_ADD_TEST(FileFormatHDL, Read3D1D)
 {
     std::ostringstream strebuf;
     strebuf << "Version         3" << "\n";
@@ -1355,31 +1355,31 @@ OIIO_ADD_TEST(FileFormatHDL, Read3D1D)
     OCIO::CachedFileHDLRcPtr lut = OCIO::DynamicPtrCast<OCIO::CachedFileHDL>(cachedFile);
     
     //
-    OIIO_CHECK_EQUAL(to_min, lut->to_min);
-    OIIO_CHECK_EQUAL(to_max, lut->to_max);
-    OIIO_CHECK_EQUAL(black, lut->hdlblack);
-    OIIO_CHECK_EQUAL(white, lut->hdlwhite);
+    OCIO_CHECK_EQUAL(to_min, lut->to_min);
+    OCIO_CHECK_EQUAL(to_max, lut->to_max);
+    OCIO_CHECK_EQUAL(black, lut->hdlblack);
+    OCIO_CHECK_EQUAL(white, lut->hdlwhite);
     
     // check prelut data (each channel has the same data)
     for(int c = 0; c < 3; ++c) {
-        OIIO_CHECK_EQUAL(from_min, lut->lut1D->from_min[c]);
-        OIIO_CHECK_EQUAL(from_max, lut->lut1D->from_max[c]);
-        OIIO_CHECK_EQUAL(10, lut->lut1D->luts[c].size());
+        OCIO_CHECK_EQUAL(from_min, lut->lut1D->from_min[c]);
+        OCIO_CHECK_EQUAL(from_max, lut->lut1D->from_max[c]);
+        OCIO_CHECK_EQUAL(10, lut->lut1D->luts[c].size());
 
         for(unsigned int i = 0; i < lut->lut1D->luts[c].size(); ++i) {
-            OIIO_CHECK_EQUAL(prelut[i], lut->lut1D->luts[c][i]);
+            OCIO_CHECK_EQUAL(prelut[i], lut->lut1D->luts[c][i]);
         }
     }
 
-    OIIO_CHECK_EQUAL(2*2*2*3, lut->lut3D->lut.size());
+    OCIO_CHECK_EQUAL(2*2*2*3, lut->lut3D->lut.size());
     
     // check cube data
     for(unsigned int i = 0; i < lut->lut3D->lut.size(); ++i) {
-        OIIO_CHECK_EQUAL(cube[i], lut->lut3D->lut[i]);
+        OCIO_CHECK_EQUAL(cube[i], lut->lut3D->lut[i]);
     }
 }
 
-OIIO_ADD_TEST(FileFormatHDL, Bake3D1D)
+OCIO_ADD_TEST(FileFormatHDL, Bake3D1D)
 {
     // check baker output
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
@@ -1475,20 +1475,20 @@ OIIO_ADD_TEST(FileFormatHDL, Bake3D1D)
 
     //
     std::vector<std::string> osvec;
-    OCIO::pystring::splitlines(output.str(), osvec);
+    pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    OCIO::pystring::splitlines(bout, resvec);
-    OIIO_CHECK_EQUAL(osvec.size(), resvec.size());
+    pystring::splitlines(bout, resvec);
+    OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     
     // TODO: Get this working on osx
     /*
     for(unsigned int i = 0; i < std::min(osvec.size(), resvec.size()); ++i)
-        OIIO_CHECK_EQUAL(OCIO::pystring::strip(osvec[i]), OCIO::pystring::strip(resvec[i]));
+        OCIO_CHECK_EQUAL(pystring::strip(osvec[i]), pystring::strip(resvec[i]));
     */
 }
 
 
-OIIO_ADD_TEST(FileFormatHDL, LookTest)
+OCIO_ADD_TEST(FileFormatHDL, LookTest)
 {
     // Note this sets up a Look with the same parameters as the Bake3D1D test
     // however it uses a different shaper space, to ensure we catch that case.
@@ -1616,13 +1616,13 @@ OIIO_ADD_TEST(FileFormatHDL, LookTest)
 
     //
     std::vector<std::string> osvec;
-    OCIO::pystring::splitlines(output.str(), osvec);
+    pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    OCIO::pystring::splitlines(bout, resvec);
-    OIIO_CHECK_EQUAL(osvec.size(), resvec.size());
+    pystring::splitlines(bout, resvec);
+    OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     
     for(unsigned int i = 0; i < std::min(osvec.size(), resvec.size()); ++i)
-        OIIO_CHECK_EQUAL(OCIO::pystring::strip(osvec[i]), OCIO::pystring::strip(resvec[i]));
+        OCIO_CHECK_EQUAL(pystring::strip(osvec[i]), pystring::strip(resvec[i]));
 }
 
 #endif // OCIO_BUILD_TESTS

--- a/src/OpenColorIO/fileformats/FileFormatHDL.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatHDL.cpp
@@ -1143,12 +1143,12 @@ OCIO_ADD_TEST(FileFormatHDL, Bake1D)
     
     //
     std::vector<std::string> osvec;
-    pystring::splitlines(output.str(), osvec);
+    OCIO::pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    pystring::splitlines(bout, resvec);
+    OCIO::pystring::splitlines(bout, resvec);
     OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < std::min(osvec.size(), resvec.size()); ++i)
-        OCIO_CHECK_EQUAL(pystring::strip(osvec[i]), pystring::strip(resvec[i]));
+        OCIO_CHECK_EQUAL(OCIO::pystring::strip(osvec[i]), OCIO::pystring::strip(resvec[i]));
     
 }
 
@@ -1283,12 +1283,12 @@ OCIO_ADD_TEST(FileFormatHDL, Bake3D)
     
     //
     std::vector<std::string> osvec;
-    pystring::splitlines(output.str(), osvec);
+    OCIO::pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    pystring::splitlines(bout, resvec);
+    OCIO::pystring::splitlines(bout, resvec);
     OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < std::min(osvec.size(), resvec.size()); ++i)
-        OCIO_CHECK_EQUAL(pystring::strip(osvec[i]), pystring::strip(resvec[i]));
+        OCIO_CHECK_EQUAL(OCIO::pystring::strip(osvec[i]), OCIO::pystring::strip(resvec[i]));
 }
 
 OCIO_ADD_TEST(FileFormatHDL, Read3D1D)
@@ -1475,15 +1475,15 @@ OCIO_ADD_TEST(FileFormatHDL, Bake3D1D)
 
     //
     std::vector<std::string> osvec;
-    pystring::splitlines(output.str(), osvec);
+    OCIO::pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    pystring::splitlines(bout, resvec);
+    OCIO::pystring::splitlines(bout, resvec);
     OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     
     // TODO: Get this working on osx
     /*
     for(unsigned int i = 0; i < std::min(osvec.size(), resvec.size()); ++i)
-        OCIO_CHECK_EQUAL(pystring::strip(osvec[i]), pystring::strip(resvec[i]));
+        OCIO_CHECK_EQUAL(OCIO::pystring::strip(osvec[i]), OCIO::pystring::strip(resvec[i]));
     */
 }
 
@@ -1616,13 +1616,13 @@ OCIO_ADD_TEST(FileFormatHDL, LookTest)
 
     //
     std::vector<std::string> osvec;
-    pystring::splitlines(output.str(), osvec);
+    OCIO::pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    pystring::splitlines(bout, resvec);
+    OCIO::pystring::splitlines(bout, resvec);
     OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     
     for(unsigned int i = 0; i < std::min(osvec.size(), resvec.size()); ++i)
-        OCIO_CHECK_EQUAL(pystring::strip(osvec[i]), pystring::strip(resvec[i]));
+        OCIO_CHECK_EQUAL(OCIO::pystring::strip(osvec[i]), OCIO::pystring::strip(resvec[i]));
 }
 
 #endif // OCIO_BUILD_TESTS

--- a/src/OpenColorIO/fileformats/FileFormatICC.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatICC.cpp
@@ -473,19 +473,19 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
-OIIO_ADD_TEST(FileFormatICC, Types)
+OCIO_ADD_TEST(FileFormatICC, Types)
 {
     // Test types used
-    OIIO_CHECK_EQUAL(1, sizeof(icUInt8Number));
-    OIIO_CHECK_EQUAL(2, sizeof(icUInt16Number));
-    OIIO_CHECK_EQUAL(4, sizeof(icUInt32Number));
+    OCIO_CHECK_EQUAL(1, sizeof(icUInt8Number));
+    OCIO_CHECK_EQUAL(2, sizeof(icUInt16Number));
+    OCIO_CHECK_EQUAL(4, sizeof(icUInt32Number));
 
-    OIIO_CHECK_EQUAL(4, sizeof(icInt32Number));
+    OCIO_CHECK_EQUAL(4, sizeof(icInt32Number));
 
-    OIIO_CHECK_EQUAL(4, sizeof(icS15Fixed16Number));
+    OCIO_CHECK_EQUAL(4, sizeof(icS15Fixed16Number));
 }
 
 OCIO::LocalCachedFileRcPtr LoadICCFile(const std::string & fileName)
@@ -494,7 +494,7 @@ OCIO::LocalCachedFileRcPtr LoadICCFile(const std::string & fileName)
         fileName, std::ios_base::binary);
 }
 
-OIIO_ADD_TEST(FileFormatICC, TestFile)
+OCIO_ADD_TEST(FileFormatICC, TestFile)
 {
     OCIO::LocalCachedFileRcPtr iccFile;
     {
@@ -502,14 +502,14 @@ OIIO_ADD_TEST(FileFormatICC, TestFile)
         const std::string iccFileName("sRGB_Color_Space_Profile.icm");
         OCIO::OpRcPtrVec ops;
         OCIO::ContextRcPtr context = OCIO::Context::Create();
-        OIIO_CHECK_NO_THROW(BuildOpsTest(ops, iccFileName, context,
+        OCIO_CHECK_NO_THROW(BuildOpsTest(ops, iccFileName, context,
                                          OCIO::TRANSFORM_DIR_INVERSE));
-        OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops, false));
-        OIIO_CHECK_EQUAL(4, ops.size());
-        OIIO_CHECK_EQUAL("<FileNoOp>", ops[0]->getInfo());
-        OIIO_CHECK_EQUAL("<MatrixOffsetOp>", ops[1]->getInfo());
-        OIIO_CHECK_EQUAL("<MatrixOffsetOp>", ops[2]->getInfo());
-        OIIO_CHECK_EQUAL("<Lut1DOp>", ops[3]->getInfo());
+        OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops, false));
+        OCIO_CHECK_EQUAL(4, ops.size());
+        OCIO_CHECK_EQUAL("<FileNoOp>", ops[0]->getInfo());
+        OCIO_CHECK_EQUAL("<MatrixOffsetOp>", ops[1]->getInfo());
+        OCIO_CHECK_EQUAL("<MatrixOffsetOp>", ops[2]->getInfo());
+        OCIO_CHECK_EQUAL("<Lut1DOp>", ops[3]->getInfo());
 
         std::vector<float> v0(4, 0.0f);
         v0[0] = 1.0f;
@@ -522,59 +522,59 @@ OIIO_ADD_TEST(FileFormatICC, TestFile)
 
         std::vector<float> tmp = v0;
         ops[1]->apply(&tmp[0], 1);
-        OIIO_CHECK_EQUAL(1.04788959f, tmp[0]);
-        OIIO_CHECK_EQUAL(0.0295844227f, tmp[1]);
-        OIIO_CHECK_EQUAL(-0.00925218873f, tmp[2]);
-        OIIO_CHECK_EQUAL(0.0f, tmp[3]);
+        OCIO_CHECK_EQUAL(1.04788959f, tmp[0]);
+        OCIO_CHECK_EQUAL(0.0295844227f, tmp[1]);
+        OCIO_CHECK_EQUAL(-0.00925218873f, tmp[2]);
+        OCIO_CHECK_EQUAL(0.0f, tmp[3]);
 
         tmp = v1;
         ops[1]->apply(&tmp[0], 1);
-        OIIO_CHECK_EQUAL(0.0229206420f, tmp[0]);
-        OIIO_CHECK_EQUAL(0.990481913f, tmp[1]);
-        OIIO_CHECK_EQUAL(0.0150730424f, tmp[2]);
-        OIIO_CHECK_EQUAL(0.0f, tmp[3]);
+        OCIO_CHECK_EQUAL(0.0229206420f, tmp[0]);
+        OCIO_CHECK_EQUAL(0.990481913f, tmp[1]);
+        OCIO_CHECK_EQUAL(0.0150730424f, tmp[2]);
+        OCIO_CHECK_EQUAL(0.0f, tmp[3]);
 
         tmp = v2;
         ops[1]->apply(&tmp[0], 1);
-        OIIO_CHECK_EQUAL(-0.0502183102f, tmp[0]);
-        OIIO_CHECK_EQUAL(-0.0170795303f, tmp[1]);
-        OIIO_CHECK_EQUAL(0.751668990f, tmp[2]);
-        OIIO_CHECK_EQUAL(0.0f, tmp[3]);
+        OCIO_CHECK_EQUAL(-0.0502183102f, tmp[0]);
+        OCIO_CHECK_EQUAL(-0.0170795303f, tmp[1]);
+        OCIO_CHECK_EQUAL(0.751668990f, tmp[2]);
+        OCIO_CHECK_EQUAL(0.0f, tmp[3]);
 
         tmp = v3;
         ops[1]->apply(&tmp[0], 1);
-        OIIO_CHECK_EQUAL(0.0f, tmp[0]);
-        OIIO_CHECK_EQUAL(0.0f, tmp[1]);
-        OIIO_CHECK_EQUAL(0.0f, tmp[2]);
-        OIIO_CHECK_EQUAL(1.0f, tmp[3]);
+        OCIO_CHECK_EQUAL(0.0f, tmp[0]);
+        OCIO_CHECK_EQUAL(0.0f, tmp[1]);
+        OCIO_CHECK_EQUAL(0.0f, tmp[2]);
+        OCIO_CHECK_EQUAL(1.0f, tmp[3]);
 
         tmp = v0;
         ops[2]->apply(&tmp[0], 1);
-        OIIO_CHECK_EQUAL(3.13411215332385f, tmp[0]);
-        OIIO_CHECK_EQUAL(-0.978787296139183f, tmp[1]);
-        OIIO_CHECK_EQUAL(0.0719830443856949f, tmp[2]);
-        OIIO_CHECK_EQUAL(0.0f, tmp[3]);
+        OCIO_CHECK_EQUAL(3.13411215332385f, tmp[0]);
+        OCIO_CHECK_EQUAL(-0.978787296139183f, tmp[1]);
+        OCIO_CHECK_EQUAL(0.0719830443856949f, tmp[2]);
+        OCIO_CHECK_EQUAL(0.0f, tmp[3]);
 
         tmp = v1;
         ops[2]->apply(&tmp[0], 1);
-        OIIO_CHECK_EQUAL(-1.61739245955187f, tmp[0]);
-        OIIO_CHECK_EQUAL(1.91627958642662f, tmp[1]);
-        OIIO_CHECK_EQUAL(-0.228985850247545f, tmp[2]);
-        OIIO_CHECK_EQUAL(0.0f, tmp[3]);
+        OCIO_CHECK_EQUAL(-1.61739245955187f, tmp[0]);
+        OCIO_CHECK_EQUAL(1.91627958642662f, tmp[1]);
+        OCIO_CHECK_EQUAL(-0.228985850247545f, tmp[2]);
+        OCIO_CHECK_EQUAL(0.0f, tmp[3]);
 
         tmp = v2;
         ops[2]->apply(&tmp[0], 1);
-        OIIO_CHECK_EQUAL(-0.49063340456472f, tmp[0]);
-        OIIO_CHECK_EQUAL(0.033454714231382f, tmp[1]);
-        OIIO_CHECK_EQUAL(1.4053851315845f, tmp[2]);
-        OIIO_CHECK_EQUAL(0.0f, tmp[3]);
+        OCIO_CHECK_EQUAL(-0.49063340456472f, tmp[0]);
+        OCIO_CHECK_EQUAL(0.033454714231382f, tmp[1]);
+        OCIO_CHECK_EQUAL(1.4053851315845f, tmp[2]);
+        OCIO_CHECK_EQUAL(0.0f, tmp[3]);
 
         tmp = v3;
         ops[2]->apply(&tmp[0], 1);
-        OIIO_CHECK_EQUAL(0.0f, tmp[0]);
-        OIIO_CHECK_EQUAL(0.0f, tmp[1]);
-        OIIO_CHECK_EQUAL(0.0f, tmp[2]);
-        OIIO_CHECK_EQUAL(1.0f, tmp[3]);
+        OCIO_CHECK_EQUAL(0.0f, tmp[0]);
+        OCIO_CHECK_EQUAL(0.0f, tmp[1]);
+        OCIO_CHECK_EQUAL(0.0f, tmp[2]);
+        OCIO_CHECK_EQUAL(1.0f, tmp[3]);
 
         // Knowing the LUT has 1024 elements
         // and is inverted, verify values for a given index
@@ -586,109 +586,109 @@ OIIO_ADD_TEST(FileFormatICC, TestFile)
         tmp[1] = 0.0317235067f;
         tmp[2] = 0.0317235067f;
         ops[3]->apply(&tmp[0], 1);
-        OIIO_CHECK_CLOSE(200.0f / 1023.0f, tmp[0], error);
-        OIIO_CHECK_CLOSE(200.0f / 1023.0f, tmp[1], error);
-        OIIO_CHECK_CLOSE(200.0f / 1023.0f, tmp[2], error);
+        OCIO_CHECK_CLOSE(200.0f / 1023.0f, tmp[0], error);
+        OCIO_CHECK_CLOSE(200.0f / 1023.0f, tmp[1], error);
+        OCIO_CHECK_CLOSE(200.0f / 1023.0f, tmp[2], error);
 
 
         // Get cached file to access LUT size
-        OIIO_CHECK_NO_THROW(iccFile = LoadICCFile(iccFileName));
+        OCIO_CHECK_NO_THROW(iccFile = LoadICCFile(iccFileName));
 
-        OIIO_CHECK_ASSERT((bool)iccFile);
-        OIIO_CHECK_ASSERT((bool)(iccFile->lut));
+        OCIO_CHECK_ASSERT((bool)iccFile);
+        OCIO_CHECK_ASSERT((bool)(iccFile->lut));
 
-        OIIO_CHECK_EQUAL(0.0f, iccFile->lut->from_min[0]);
-        OIIO_CHECK_EQUAL(1.0f, iccFile->lut->from_max[0]);
+        OCIO_CHECK_EQUAL(0.0f, iccFile->lut->from_min[0]);
+        OCIO_CHECK_EQUAL(1.0f, iccFile->lut->from_max[0]);
 
-        OIIO_CHECK_EQUAL(1024, iccFile->lut->luts[0].size());
-        OIIO_CHECK_EQUAL(1024, iccFile->lut->luts[1].size());
-        OIIO_CHECK_EQUAL(1024, iccFile->lut->luts[2].size());
+        OCIO_CHECK_EQUAL(1024, iccFile->lut->luts[0].size());
+        OCIO_CHECK_EQUAL(1024, iccFile->lut->luts[1].size());
+        OCIO_CHECK_EQUAL(1024, iccFile->lut->luts[2].size());
 
-        OIIO_CHECK_EQUAL(0.0317235067f, iccFile->lut->luts[0][200]);
-        OIIO_CHECK_EQUAL(0.0317235067f, iccFile->lut->luts[1][200]);
-        OIIO_CHECK_EQUAL(0.0317235067f, iccFile->lut->luts[2][200]);
+        OCIO_CHECK_EQUAL(0.0317235067f, iccFile->lut->luts[0][200]);
+        OCIO_CHECK_EQUAL(0.0317235067f, iccFile->lut->luts[1][200]);
+        OCIO_CHECK_EQUAL(0.0317235067f, iccFile->lut->luts[2][200]);
     }
 
     {
         // This test uses a profile where the TRC is a 1-entry curve,
         // to be interpreted as a gamma value.
         const std::string iccFileName("AdobeRGB1998.icc");
-        OIIO_CHECK_NO_THROW(iccFile = LoadICCFile(iccFileName));
+        OCIO_CHECK_NO_THROW(iccFile = LoadICCFile(iccFileName));
 
-        OIIO_CHECK_ASSERT((bool)iccFile);
-        OIIO_CHECK_ASSERT(!(bool)(iccFile->lut));
+        OCIO_CHECK_ASSERT((bool)iccFile);
+        OCIO_CHECK_ASSERT(!(bool)(iccFile->lut));
 
-        OIIO_CHECK_EQUAL(0.609741211f, iccFile->mMatrix44[0]);
-        OIIO_CHECK_EQUAL(0.205276489f, iccFile->mMatrix44[1]);
-        OIIO_CHECK_EQUAL(0.149185181f, iccFile->mMatrix44[2]);
-        OIIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[3]);
+        OCIO_CHECK_EQUAL(0.609741211f, iccFile->mMatrix44[0]);
+        OCIO_CHECK_EQUAL(0.205276489f, iccFile->mMatrix44[1]);
+        OCIO_CHECK_EQUAL(0.149185181f, iccFile->mMatrix44[2]);
+        OCIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[3]);
 
-        OIIO_CHECK_EQUAL(0.311111450f, iccFile->mMatrix44[4]);
-        OIIO_CHECK_EQUAL(0.625671387f, iccFile->mMatrix44[5]);
-        OIIO_CHECK_EQUAL(0.0632171631f, iccFile->mMatrix44[6]);
-        OIIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[7]);
+        OCIO_CHECK_EQUAL(0.311111450f, iccFile->mMatrix44[4]);
+        OCIO_CHECK_EQUAL(0.625671387f, iccFile->mMatrix44[5]);
+        OCIO_CHECK_EQUAL(0.0632171631f, iccFile->mMatrix44[6]);
+        OCIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[7]);
         
-        OIIO_CHECK_EQUAL(0.0194702148f, iccFile->mMatrix44[8]);
-        OIIO_CHECK_EQUAL(0.0608673096f, iccFile->mMatrix44[9]);
-        OIIO_CHECK_EQUAL(0.744567871f, iccFile->mMatrix44[10]);
-        OIIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[11]);
+        OCIO_CHECK_EQUAL(0.0194702148f, iccFile->mMatrix44[8]);
+        OCIO_CHECK_EQUAL(0.0608673096f, iccFile->mMatrix44[9]);
+        OCIO_CHECK_EQUAL(0.744567871f, iccFile->mMatrix44[10]);
+        OCIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[11]);
 
-        OIIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[12]);
-        OIIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[13]);
-        OIIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[14]);
-        OIIO_CHECK_EQUAL(1.0f, iccFile->mMatrix44[15]);
+        OCIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[12]);
+        OCIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[13]);
+        OCIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[14]);
+        OCIO_CHECK_EQUAL(1.0f, iccFile->mMatrix44[15]);
 
-        OIIO_CHECK_EQUAL(2.19921875f, iccFile->mGammaRGB[0]);
-        OIIO_CHECK_EQUAL(2.19921875f, iccFile->mGammaRGB[1]);
-        OIIO_CHECK_EQUAL(2.19921875f, iccFile->mGammaRGB[2]);
-        OIIO_CHECK_EQUAL(1.0f, iccFile->mGammaRGB[3]);
+        OCIO_CHECK_EQUAL(2.19921875f, iccFile->mGammaRGB[0]);
+        OCIO_CHECK_EQUAL(2.19921875f, iccFile->mGammaRGB[1]);
+        OCIO_CHECK_EQUAL(2.19921875f, iccFile->mGammaRGB[2]);
+        OCIO_CHECK_EQUAL(1.0f, iccFile->mGammaRGB[3]);
     }
 
     {
         // This test uses a profile where the TRC is 
         // a parametric curve of type 0 (a single gamma value).
         const std::string iccFileName("LM-1760W.icc");
-        OIIO_CHECK_NO_THROW(iccFile = LoadICCFile(iccFileName));
+        OCIO_CHECK_NO_THROW(iccFile = LoadICCFile(iccFileName));
 
-        OIIO_CHECK_ASSERT((bool)iccFile);
-        OIIO_CHECK_ASSERT(!(bool)(iccFile->lut));
+        OCIO_CHECK_ASSERT((bool)iccFile);
+        OCIO_CHECK_ASSERT(!(bool)(iccFile->lut));
 
-        OIIO_CHECK_EQUAL(0.504470825f, iccFile->mMatrix44[0]);
-        OIIO_CHECK_EQUAL(0.328125000f, iccFile->mMatrix44[1]);
-        OIIO_CHECK_EQUAL(0.131607056f, iccFile->mMatrix44[2]);
-        OIIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[3]);
+        OCIO_CHECK_EQUAL(0.504470825f, iccFile->mMatrix44[0]);
+        OCIO_CHECK_EQUAL(0.328125000f, iccFile->mMatrix44[1]);
+        OCIO_CHECK_EQUAL(0.131607056f, iccFile->mMatrix44[2]);
+        OCIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[3]);
 
-        OIIO_CHECK_EQUAL(0.264923096f, iccFile->mMatrix44[4]);
-        OIIO_CHECK_EQUAL(0.682678223f, iccFile->mMatrix44[5]);
-        OIIO_CHECK_EQUAL(0.0523834229f, iccFile->mMatrix44[6]);
-        OIIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[7]);
+        OCIO_CHECK_EQUAL(0.264923096f, iccFile->mMatrix44[4]);
+        OCIO_CHECK_EQUAL(0.682678223f, iccFile->mMatrix44[5]);
+        OCIO_CHECK_EQUAL(0.0523834229f, iccFile->mMatrix44[6]);
+        OCIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[7]);
 
-        OIIO_CHECK_EQUAL(0.0144805908f, iccFile->mMatrix44[8]);
-        OIIO_CHECK_EQUAL(0.0871734619f, iccFile->mMatrix44[9]);
-        OIIO_CHECK_EQUAL(0.723556519f, iccFile->mMatrix44[10]);
-        OIIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[11]);
+        OCIO_CHECK_EQUAL(0.0144805908f, iccFile->mMatrix44[8]);
+        OCIO_CHECK_EQUAL(0.0871734619f, iccFile->mMatrix44[9]);
+        OCIO_CHECK_EQUAL(0.723556519f, iccFile->mMatrix44[10]);
+        OCIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[11]);
 
-        OIIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[12]);
-        OIIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[13]);
-        OIIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[14]);
-        OIIO_CHECK_EQUAL(1.0f, iccFile->mMatrix44[15]);
+        OCIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[12]);
+        OCIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[13]);
+        OCIO_CHECK_EQUAL(0.0f, iccFile->mMatrix44[14]);
+        OCIO_CHECK_EQUAL(1.0f, iccFile->mMatrix44[15]);
 
-        OIIO_CHECK_EQUAL(2.17384338f, iccFile->mGammaRGB[0]);
-        OIIO_CHECK_EQUAL(2.17384338f, iccFile->mGammaRGB[1]);
-        OIIO_CHECK_EQUAL(2.17384338f, iccFile->mGammaRGB[2]);
-        OIIO_CHECK_EQUAL(1.0f, iccFile->mGammaRGB[3]);
+        OCIO_CHECK_EQUAL(2.17384338f, iccFile->mGammaRGB[0]);
+        OCIO_CHECK_EQUAL(2.17384338f, iccFile->mGammaRGB[1]);
+        OCIO_CHECK_EQUAL(2.17384338f, iccFile->mGammaRGB[2]);
+        OCIO_CHECK_EQUAL(1.0f, iccFile->mGammaRGB[3]);
     }
 }
 
-OIIO_ADD_TEST(FileFormatICC, TestApply)
+OCIO_ADD_TEST(FileFormatICC, TestApply)
 {
     OCIO::ContextRcPtr context = OCIO::Context::Create();
     {
         const std::string iccFileName("sRGB_Color_Space_Profile.icm");
         OCIO::OpRcPtrVec ops;
-        OIIO_CHECK_NO_THROW(BuildOpsTest(ops, iccFileName, context,
+        OCIO_CHECK_NO_THROW(BuildOpsTest(ops, iccFileName, context,
                                          OCIO::TRANSFORM_DIR_FORWARD));
-        OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops, true));
+        OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops, true));
 
         // apply ops
         float srcImage[] = {
@@ -711,14 +711,14 @@ OIIO_ADD_TEST(FileFormatICC, TestApply)
         // compare results
         for (unsigned int i = 0; i<12; ++i)
         {
-            OIIO_CHECK_CLOSE(srcImage[i], dstImage[i], error);
+            OCIO_CHECK_CLOSE(srcImage[i], dstImage[i], error);
         }
 
         // inverse
         OCIO::OpRcPtrVec opsInv;
-        OIIO_CHECK_NO_THROW(BuildOpsTest(opsInv, iccFileName, context,
+        OCIO_CHECK_NO_THROW(BuildOpsTest(opsInv, iccFileName, context,
                                          OCIO::TRANSFORM_DIR_INVERSE));
-        OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(opsInv, true));
+        OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(opsInv, true));
 
         numOps = opsInv.size();
         for (OCIO::OpRcPtrVec::size_type i = 0; i < numOps; ++i)
@@ -736,16 +736,16 @@ OIIO_ADD_TEST(FileFormatICC, TestApply)
         // compare results
         for (unsigned int i = 0; i<12; ++i)
         {
-            OIIO_CHECK_CLOSE(srcImage[i], bckImage[i], error);
+            OCIO_CHECK_CLOSE(srcImage[i], bckImage[i], error);
         }
     }
 
     {
         const std::string iccFileName("LM-1760W.icc");
         OCIO::OpRcPtrVec ops;
-        OIIO_CHECK_NO_THROW(BuildOpsTest(ops, iccFileName, context,
+        OCIO_CHECK_NO_THROW(BuildOpsTest(ops, iccFileName, context,
                                          OCIO::TRANSFORM_DIR_FORWARD));
-        OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops, true));
+        OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops, true));
 
         // apply ops
         float srcImage[] = {
@@ -775,14 +775,14 @@ OIIO_ADD_TEST(FileFormatICC, TestApply)
 
         for (unsigned int i = 0; i<12; ++i)
         {
-            OIIO_CHECK_CLOSE(srcImage[i], dstImage[i], error);
+            OCIO_CHECK_CLOSE(srcImage[i], dstImage[i], error);
         }
 
         // inverse
         OCIO::OpRcPtrVec opsInv;
-        OIIO_CHECK_NO_THROW(BuildOpsTest(opsInv, iccFileName, context,
+        OCIO_CHECK_NO_THROW(BuildOpsTest(opsInv, iccFileName, context,
                                          OCIO::TRANSFORM_DIR_INVERSE));
-        OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(opsInv, true));
+        OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(opsInv, true));
 
         numOps = opsInv.size();
         for (OCIO::OpRcPtrVec::size_type i = 0; i < numOps; ++i)
@@ -801,13 +801,13 @@ OIIO_ADD_TEST(FileFormatICC, TestApply)
 
         for (unsigned int i = 0; i<12; ++i)
         {
-            OIIO_CHECK_CLOSE(srcImage[i], bckImage[i], error2);
+            OCIO_CHECK_CLOSE(srcImage[i], bckImage[i], error2);
         }
     }
 
 }
 
-OIIO_ADD_TEST(FileFormatICC, Endian)
+OCIO_ADD_TEST(FileFormatICC, Endian)
 {
     unsigned char test[8];
     test[0] = 0x11;
@@ -821,40 +821,40 @@ OIIO_ADD_TEST(FileFormatICC, Endian)
 
     SampleICC::Swap32Array((void*)test, 2);
 
-    OIIO_CHECK_EQUAL(test[0], 0x44);
-    OIIO_CHECK_EQUAL(test[1], 0x33);
-    OIIO_CHECK_EQUAL(test[2], 0x22);
-    OIIO_CHECK_EQUAL(test[3], 0x11);
+    OCIO_CHECK_EQUAL(test[0], 0x44);
+    OCIO_CHECK_EQUAL(test[1], 0x33);
+    OCIO_CHECK_EQUAL(test[2], 0x22);
+    OCIO_CHECK_EQUAL(test[3], 0x11);
 
-    OIIO_CHECK_EQUAL(test[4], 0x88);
-    OIIO_CHECK_EQUAL(test[5], 0x77);
-    OIIO_CHECK_EQUAL(test[6], 0x66);
-    OIIO_CHECK_EQUAL(test[7], 0x55);
+    OCIO_CHECK_EQUAL(test[4], 0x88);
+    OCIO_CHECK_EQUAL(test[5], 0x77);
+    OCIO_CHECK_EQUAL(test[6], 0x66);
+    OCIO_CHECK_EQUAL(test[7], 0x55);
 
     SampleICC::Swap16Array((void*)test, 4);
 
-    OIIO_CHECK_EQUAL(test[0], 0x33);
-    OIIO_CHECK_EQUAL(test[1], 0x44);
+    OCIO_CHECK_EQUAL(test[0], 0x33);
+    OCIO_CHECK_EQUAL(test[1], 0x44);
 
-    OIIO_CHECK_EQUAL(test[2], 0x11);
-    OIIO_CHECK_EQUAL(test[3], 0x22);
+    OCIO_CHECK_EQUAL(test[2], 0x11);
+    OCIO_CHECK_EQUAL(test[3], 0x22);
 
-    OIIO_CHECK_EQUAL(test[4], 0x77);
-    OIIO_CHECK_EQUAL(test[5], 0x88);
+    OCIO_CHECK_EQUAL(test[4], 0x77);
+    OCIO_CHECK_EQUAL(test[5], 0x88);
 
-    OIIO_CHECK_EQUAL(test[6], 0x55);
-    OIIO_CHECK_EQUAL(test[7], 0x66);
+    OCIO_CHECK_EQUAL(test[6], 0x55);
+    OCIO_CHECK_EQUAL(test[7], 0x66);
 
     SampleICC::Swap64Array((void*)test, 1);
 
-    OIIO_CHECK_EQUAL(test[7], 0x33);
-    OIIO_CHECK_EQUAL(test[6], 0x44);
-    OIIO_CHECK_EQUAL(test[5], 0x11);
-    OIIO_CHECK_EQUAL(test[4], 0x22);
-    OIIO_CHECK_EQUAL(test[3], 0x77);
-    OIIO_CHECK_EQUAL(test[2], 0x88);
-    OIIO_CHECK_EQUAL(test[1], 0x55);
-    OIIO_CHECK_EQUAL(test[0], 0x66);
+    OCIO_CHECK_EQUAL(test[7], 0x33);
+    OCIO_CHECK_EQUAL(test[6], 0x44);
+    OCIO_CHECK_EQUAL(test[5], 0x11);
+    OCIO_CHECK_EQUAL(test[4], 0x22);
+    OCIO_CHECK_EQUAL(test[3], 0x77);
+    OCIO_CHECK_EQUAL(test[2], 0x88);
+    OCIO_CHECK_EQUAL(test[1], 0x55);
+    OCIO_CHECK_EQUAL(test[0], 0x66);
 
 }
 

--- a/src/OpenColorIO/fileformats/FileFormatIridasCube.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasCube.cpp
@@ -537,19 +537,19 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 #include <fstream>
 
-OIIO_ADD_TEST(FileFormatIridasCube, FormatInfo)
+OCIO_ADD_TEST(FileFormatIridasCube, FormatInfo)
 {
     OCIO::FormatInfoVec formatInfoVec;
     OCIO::LocalFileFormat tester;
     tester.GetFormatInfo(formatInfoVec);
 
-    OIIO_CHECK_EQUAL(1, formatInfoVec.size());
-    OIIO_CHECK_EQUAL("iridas_cube", formatInfoVec[0].name);
-    OIIO_CHECK_EQUAL("cube", formatInfoVec[0].extension);
-    OIIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ | OCIO::FORMAT_CAPABILITY_WRITE,
+    OCIO_CHECK_EQUAL(1, formatInfoVec.size());
+    OCIO_CHECK_EQUAL("iridas_cube", formatInfoVec[0].name);
+    OCIO_CHECK_EQUAL("cube", formatInfoVec[0].extension);
+    OCIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ | OCIO::FORMAT_CAPABILITY_WRITE,
         formatInfoVec[0].capabilities);
 }
 
@@ -566,7 +566,7 @@ OCIO::LocalCachedFileRcPtr ReadIridasCube(const std::string & fileContent)
     return OCIO::DynamicPtrCast<OCIO::LocalCachedFile>(cachedFile);
 }
 
-OIIO_ADD_TEST(FileFormatIridasCube, ReadFailure)
+OCIO_ADD_TEST(FileFormatIridasCube, ReadFailure)
 {
     {
         // Validate stream can be read with no error.
@@ -585,7 +585,7 @@ OIIO_ADD_TEST(FileFormatIridasCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_NO_THROW(ReadIridasCube(SAMPLE_NO_ERROR));
+        OCIO_CHECK_NO_THROW(ReadIridasCube(SAMPLE_NO_ERROR));
     }
     {
         // Wrong LUT_3D_SIZE tag
@@ -603,7 +603,7 @@ OIIO_ADD_TEST(FileFormatIridasCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadIridasCube(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadIridasCube(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Malformed LUT_3D_SIZE tag");
     }
@@ -623,7 +623,7 @@ OIIO_ADD_TEST(FileFormatIridasCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadIridasCube(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadIridasCube(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Malformed DOMAIN_MIN tag");
     }
@@ -643,7 +643,7 @@ OIIO_ADD_TEST(FileFormatIridasCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadIridasCube(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadIridasCube(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Malformed DOMAIN_MAX tag");
     }
@@ -663,7 +663,7 @@ OIIO_ADD_TEST(FileFormatIridasCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadIridasCube(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadIridasCube(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Malformed color triples specified");
     }
@@ -685,13 +685,13 @@ OIIO_ADD_TEST(FileFormatIridasCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadIridasCube(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadIridasCube(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Incorrect number of 3D LUT entries");
     }
 }
 
-OIIO_ADD_TEST(FileFormatIridasCube, no_shaper)
+OCIO_ADD_TEST(FileFormatIridasCube, no_shaper)
 {
     // check baker output
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
@@ -738,13 +738,13 @@ OIIO_ADD_TEST(FileFormatIridasCube, no_shaper)
     
     //
     std::vector<std::string> osvec;
-    OCIO::pystring::splitlines(output.str(), osvec);
+    pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    OCIO::pystring::splitlines(bout.str(), resvec);
-    OIIO_CHECK_EQUAL(osvec.size(), resvec.size());
+    pystring::splitlines(bout.str(), resvec);
+    OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {
-        OIIO_CHECK_EQUAL(osvec[i], resvec[i]);
+        OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
     }
 }
 

--- a/src/OpenColorIO/fileformats/FileFormatIridasCube.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasCube.cpp
@@ -738,9 +738,9 @@ OCIO_ADD_TEST(FileFormatIridasCube, no_shaper)
     
     //
     std::vector<std::string> osvec;
-    pystring::splitlines(output.str(), osvec);
+    OCIO::pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    pystring::splitlines(bout.str(), resvec);
+    OCIO::pystring::splitlines(bout.str(), resvec);
     OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {

--- a/src/OpenColorIO/fileformats/FileFormatIridasItx.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasItx.cpp
@@ -378,7 +378,7 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 void ReadIridasItx(const std::string & fileContent)
 {
@@ -391,7 +391,7 @@ void ReadIridasItx(const std::string & fileContent)
     OCIO::CachedFileRcPtr cachedFile = tester.Read(is, SAMPLE_NAME);
 }
 
-OIIO_ADD_TEST(FileFormatIridasItx, ReadFailure)
+OCIO_ADD_TEST(FileFormatIridasItx, ReadFailure)
 {
     {
         // Validate stream can be read with no error.
@@ -408,7 +408,7 @@ OIIO_ADD_TEST(FileFormatIridasItx, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_NO_THROW(ReadIridasItx(SAMPLE_NO_ERROR));
+        OCIO_CHECK_NO_THROW(ReadIridasItx(SAMPLE_NO_ERROR));
     }
     {
         // Wrong LUT_3D_SIZE tag
@@ -424,7 +424,7 @@ OIIO_ADD_TEST(FileFormatIridasItx, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadIridasItx(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadIridasItx(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Malformed LUT_3D_SIZE tag");
     }
@@ -443,7 +443,7 @@ OIIO_ADD_TEST(FileFormatIridasItx, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadIridasItx(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadIridasItx(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Malformed color triples specified");
     }
@@ -463,7 +463,7 @@ OIIO_ADD_TEST(FileFormatIridasItx, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadIridasItx(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadIridasItx(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Incorrect number of 3D LUT entries");
     }

--- a/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatIridasLook.cpp
@@ -612,77 +612,77 @@ OCIO_NAMESPACE_EXIT
 
 #ifdef OCIO_UNIT_TEST
 
-#include "unittest.h"
+#include "UnitTest.h"
 
 OCIO_NAMESPACE_USING
 
 
 
-OIIO_ADD_TEST(FileFormatIridasLook, hexasciitoint)
+OCIO_ADD_TEST(FileFormatIridasLook, hexasciitoint)
 {
     {
     char ival = 0;
     bool success = hexasciitoint(ival, 'a');
-    OIIO_CHECK_EQUAL(success, true); OIIO_CHECK_EQUAL(ival, 10);
+    OCIO_CHECK_EQUAL(success, true); OCIO_CHECK_EQUAL(ival, 10);
     }
     
     {
     char ival = 0;
     bool success = hexasciitoint(ival, 'A');
-    OIIO_CHECK_EQUAL(success, true); OIIO_CHECK_EQUAL(ival, 10);
+    OCIO_CHECK_EQUAL(success, true); OCIO_CHECK_EQUAL(ival, 10);
     }
     
     {
     char ival = 0;
     bool success = hexasciitoint(ival, 'f');
-    OIIO_CHECK_EQUAL(success, true); OIIO_CHECK_EQUAL(ival, 15);
+    OCIO_CHECK_EQUAL(success, true); OCIO_CHECK_EQUAL(ival, 15);
     }
     
     {
     char ival = 0;
     bool success = hexasciitoint(ival, 'F');
-    OIIO_CHECK_EQUAL(success, true); OIIO_CHECK_EQUAL(ival, 15);
+    OCIO_CHECK_EQUAL(success, true); OCIO_CHECK_EQUAL(ival, 15);
     }
     
     {
     char ival = 0;
     bool success = hexasciitoint(ival, '0');
-    OIIO_CHECK_EQUAL(success, true); OIIO_CHECK_EQUAL(ival, 0);
+    OCIO_CHECK_EQUAL(success, true); OCIO_CHECK_EQUAL(ival, 0);
     }
     
     {
     char ival = 0;
     bool success = hexasciitoint(ival, '0');
-    OIIO_CHECK_EQUAL(success, true); OIIO_CHECK_EQUAL(ival, 0);
+    OCIO_CHECK_EQUAL(success, true); OCIO_CHECK_EQUAL(ival, 0);
     }
     
     {
     char ival = 0;
     bool success = hexasciitoint(ival, '9');
-    OIIO_CHECK_EQUAL(success, true); OIIO_CHECK_EQUAL(ival, 9);
+    OCIO_CHECK_EQUAL(success, true); OCIO_CHECK_EQUAL(ival, 9);
     }
     
     {
     char ival = 0;
     bool success = hexasciitoint(ival, '\n');
-    OIIO_CHECK_EQUAL(success, false);
+    OCIO_CHECK_EQUAL(success, false);
     }
     
     {
     char ival = 0;
     bool success = hexasciitoint(ival, 'j');
-    OIIO_CHECK_EQUAL(success, false);
+    OCIO_CHECK_EQUAL(success, false);
     }
     
     {
     char ival = 0;
     bool success = hexasciitoint(ival, 'x');
-    OIIO_CHECK_EQUAL(success, false);
+    OCIO_CHECK_EQUAL(success, false);
     }
 }
 
 
-OIIO_ADD_TEST(FileFormatIridasLook, hexasciitofloat)
+OCIO_ADD_TEST(FileFormatIridasLook, hexasciitofloat)
 {
     //>>> import binascii, struct
     //>> struct.unpack("<f", binascii.unhexlify("AD10753F"))[0]
@@ -691,30 +691,30 @@ OIIO_ADD_TEST(FileFormatIridasLook, hexasciitofloat)
     {
     float fval = 0.0f;
     bool success = hexasciitofloat(fval, "0000003F");
-    OIIO_CHECK_EQUAL(success, true); OIIO_CHECK_EQUAL(fval, 0.5f);
+    OCIO_CHECK_EQUAL(success, true); OCIO_CHECK_EQUAL(fval, 0.5f);
     }
     
     {
     float fval = 0.0f;
     bool success = hexasciitofloat(fval, "0000803F");
-    OIIO_CHECK_EQUAL(success, true); OIIO_CHECK_EQUAL(fval, 1.0f);
+    OCIO_CHECK_EQUAL(success, true); OCIO_CHECK_EQUAL(fval, 1.0f);
     }
     
     {
     float fval = 0.0f;
     bool success = hexasciitofloat(fval, "AD10753F");
-    OIIO_CHECK_EQUAL(success, true); OIIO_CHECK_EQUAL(fval, 0.9572857022285461f);
+    OCIO_CHECK_EQUAL(success, true); OCIO_CHECK_EQUAL(fval, 0.9572857022285461f);
     }
     
     {
     float fval = 0.0f;
     bool success = hexasciitofloat(fval, "AD10X53F");
-    OIIO_CHECK_EQUAL(success, false);
+    OCIO_CHECK_EQUAL(success, false);
     }
 }
 
 
-OIIO_ADD_TEST(FileFormatIridasLook, simple3d)
+OCIO_ADD_TEST(FileFormatIridasLook, simple3d)
 {
     std::ostringstream strebuf;
     strebuf << "<?xml version=\"1.0\" ?>" << "\n";
@@ -946,12 +946,12 @@ OIIO_ADD_TEST(FileFormatIridasLook, simple3d)
     LocalCachedFileRcPtr looklut = DynamicPtrCast<LocalCachedFile>(cachedFile);
 
     // Check LUT size is correct
-    OIIO_CHECK_EQUAL(looklut->lut3D->size[0], 8);
-    OIIO_CHECK_EQUAL(looklut->lut3D->size[1], 8);
-    OIIO_CHECK_EQUAL(looklut->lut3D->size[2], 8);
+    OCIO_CHECK_EQUAL(looklut->lut3D->size[0], 8);
+    OCIO_CHECK_EQUAL(looklut->lut3D->size[1], 8);
+    OCIO_CHECK_EQUAL(looklut->lut3D->size[2], 8);
 
     // Check LUT values
-    OIIO_CHECK_EQUAL(looklut->lut3D->lut.size(), 8*8*8*3);
+    OCIO_CHECK_EQUAL(looklut->lut3D->lut.size(), 8*8*8*3);
 
     double cube[8 * 8 * 8 * 3] = {
         -0.00000, -0.00000, -0.00000,
@@ -1470,12 +1470,12 @@ OIIO_ADD_TEST(FileFormatIridasLook, simple3d)
 
     // check cube data
     for(unsigned int i = 0; i < looklut->lut3D->lut.size(); ++i) {
-        OIIO_CHECK_CLOSE(cube[i], looklut->lut3D->lut[i], 1e-4);
+        OCIO_CHECK_CLOSE(cube[i], looklut->lut3D->lut[i], 1e-4);
     }
 }
 
 
-OIIO_ADD_TEST(FileFormatIridasLook, fail_on_mask)
+OCIO_ADD_TEST(FileFormatIridasLook, fail_on_mask)
 {
     std::ostringstream strebuf;
     strebuf << "<?xml version=\"1.0\" ?>" << "\n";
@@ -1541,7 +1541,7 @@ OIIO_ADD_TEST(FileFormatIridasLook, fail_on_mask)
     LocalFileFormat tester;
     std::string emptyString;
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         tester.Read(infile, emptyString),
         Exception, "Cannot load .look LUT containing mask");
 

--- a/src/OpenColorIO/fileformats/FileFormatPandora.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatPandora.cpp
@@ -354,23 +354,23 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 #include <fstream>
 
-OIIO_ADD_TEST(FileFormatPandora, FormatInfo)
+OCIO_ADD_TEST(FileFormatPandora, FormatInfo)
 {
     OCIO::FormatInfoVec formatInfoVec;
     OCIO::LocalFileFormat tester;
     tester.GetFormatInfo(formatInfoVec);
 
-    OIIO_CHECK_EQUAL(2, formatInfoVec.size());
-    OIIO_CHECK_EQUAL("pandora_mga", formatInfoVec[0].name);
-    OIIO_CHECK_EQUAL("mga", formatInfoVec[0].extension);
-    OIIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ,
+    OCIO_CHECK_EQUAL(2, formatInfoVec.size());
+    OCIO_CHECK_EQUAL("pandora_mga", formatInfoVec[0].name);
+    OCIO_CHECK_EQUAL("mga", formatInfoVec[0].extension);
+    OCIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ,
         formatInfoVec[0].capabilities);
-    OIIO_CHECK_EQUAL("pandora_m3d", formatInfoVec[1].name);
-    OIIO_CHECK_EQUAL("m3d", formatInfoVec[1].extension);
-    OIIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ,
+    OCIO_CHECK_EQUAL("pandora_m3d", formatInfoVec[1].name);
+    OCIO_CHECK_EQUAL("m3d", formatInfoVec[1].extension);
+    OCIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ,
         formatInfoVec[1].capabilities);
 }
 
@@ -385,7 +385,7 @@ void ReadPandora(const std::string & fileContent)
     OCIO::CachedFileRcPtr cachedFile = tester.Read(is, SAMPLE_NAME);
 }
 
-OIIO_ADD_TEST(FileFormatPandora, ReadFailure)
+OCIO_ADD_TEST(FileFormatPandora, ReadFailure)
 {
     {
         // Validate stream can be read with no error.
@@ -405,7 +405,7 @@ OIIO_ADD_TEST(FileFormatPandora, ReadFailure)
             "6 255 255   0\n"
             "7 255 255 255\n";
 
-        OIIO_CHECK_NO_THROW(ReadPandora(SAMPLE_NO_ERROR));
+        OCIO_CHECK_NO_THROW(ReadPandora(SAMPLE_NO_ERROR));
     }
     {
         // Wrong channel tag
@@ -424,7 +424,7 @@ OIIO_ADD_TEST(FileFormatPandora, ReadFailure)
             "6 255 255   0\n"
             "7 255 255 255\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadPandora(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadPandora(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Only 3D LUTs are currently supported");
     }
@@ -444,7 +444,7 @@ OIIO_ADD_TEST(FileFormatPandora, ReadFailure)
             "6 255 255   0\n"
             "7 255 255 255\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadPandora(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadPandora(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Incorrect number of 3D LUT entries");
     }
@@ -465,7 +465,7 @@ OIIO_ADD_TEST(FileFormatPandora, ReadFailure)
             "6 255 255   0\n"
             "7 255 255 255\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadPandora(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadPandora(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Expected to find 4 integers");
     }
@@ -487,7 +487,7 @@ OIIO_ADD_TEST(FileFormatPandora, ReadFailure)
             "7 255 255   0\n"
             "8 255 255 255\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadPandora(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadPandora(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Incorrect number of 3D LUT entries");
     }

--- a/src/OpenColorIO/fileformats/FileFormatResolveCube.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatResolveCube.cpp
@@ -1182,9 +1182,9 @@ OCIO_ADD_TEST(FileFormatResolveCube, Bake1D)
     
     //
     std::vector<std::string> osvec;
-    pystring::splitlines(output.str(), osvec);
+    OCIO::pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    pystring::splitlines(bout.str(), resvec);
+    OCIO::pystring::splitlines(bout.str(), resvec);
     OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {
@@ -1244,9 +1244,9 @@ OCIO_ADD_TEST(FileFormatResolveCube, Bake3D)
     
     //
     std::vector<std::string> osvec;
-    pystring::splitlines(output.str(), osvec);
+    OCIO::pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    pystring::splitlines(bout.str(), resvec);
+    OCIO::pystring::splitlines(bout.str(), resvec);
     OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {
@@ -1325,9 +1325,9 @@ OCIO_ADD_TEST(FileFormatResolveCube, Bake1D3D)
     
     //
     std::vector<std::string> osvec;
-    pystring::splitlines(output.str(), osvec);
+    OCIO::pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    pystring::splitlines(bout.str(), resvec);
+    OCIO::pystring::splitlines(bout.str(), resvec);
     OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {

--- a/src/OpenColorIO/fileformats/FileFormatResolveCube.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatResolveCube.cpp
@@ -909,7 +909,7 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 #include <fstream>
 
 OCIO::LocalCachedFileRcPtr ReadResolveCube(const std::string & fileContent)
@@ -925,20 +925,20 @@ OCIO::LocalCachedFileRcPtr ReadResolveCube(const std::string & fileContent)
     return OCIO::DynamicPtrCast<OCIO::LocalCachedFile>(cachedFile);
 }
 
-OIIO_ADD_TEST(FileFormatResolveCube, FormatInfo)
+OCIO_ADD_TEST(FileFormatResolveCube, FormatInfo)
 {
     OCIO::FormatInfoVec formatInfoVec;
     OCIO::LocalFileFormat tester;
     tester.GetFormatInfo(formatInfoVec);
 
-    OIIO_CHECK_EQUAL(1, formatInfoVec.size());
-    OIIO_CHECK_EQUAL("resolve_cube", formatInfoVec[0].name);
-    OIIO_CHECK_EQUAL("cube", formatInfoVec[0].extension);
-    OIIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ | OCIO::FORMAT_CAPABILITY_WRITE,
+    OCIO_CHECK_EQUAL(1, formatInfoVec.size());
+    OCIO_CHECK_EQUAL("resolve_cube", formatInfoVec[0].name);
+    OCIO_CHECK_EQUAL("cube", formatInfoVec[0].extension);
+    OCIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ | OCIO::FORMAT_CAPABILITY_WRITE,
         formatInfoVec[0].capabilities);
 }
 
-OIIO_ADD_TEST(FileFormatResolveCube, Read1D)
+OCIO_ADD_TEST(FileFormatResolveCube, Read1D)
 {
     const std::string SAMPLE =
         "LUT_1D_SIZE 2\n"
@@ -947,10 +947,10 @@ OIIO_ADD_TEST(FileFormatResolveCube, Read1D)
         "0.0 0.0 0.0\n"
         "1.0 0.0 0.0\n";
 
-    OIIO_CHECK_NO_THROW(ReadResolveCube(SAMPLE));
+    OCIO_CHECK_NO_THROW(ReadResolveCube(SAMPLE));
 }
 
-OIIO_ADD_TEST(FileFormatResolveCube, Read3D)
+OCIO_ADD_TEST(FileFormatResolveCube, Read3D)
 {
     const std::string SAMPLE =
         "LUT_3D_SIZE 2\n"
@@ -965,10 +965,10 @@ OIIO_ADD_TEST(FileFormatResolveCube, Read3D)
         "0.0 1.0 1.0\n"
         "1.0 1.0 1.0\n";
 
-    OIIO_CHECK_NO_THROW(ReadResolveCube(SAMPLE));
+    OCIO_CHECK_NO_THROW(ReadResolveCube(SAMPLE));
 }
 
-OIIO_ADD_TEST(FileFormatResolveCube, Read1D3D)
+OCIO_ADD_TEST(FileFormatResolveCube, Read1D3D)
 {
     const std::string SAMPLE =
         "LUT_1D_SIZE 6\n"
@@ -1010,10 +1010,10 @@ OIIO_ADD_TEST(FileFormatResolveCube, Read1D3D)
         "0.5 0.0 0.0\n"
         "0.0 0.0 0.0\n";
 
-    OIIO_CHECK_NO_THROW(ReadResolveCube(SAMPLE));
+    OCIO_CHECK_NO_THROW(ReadResolveCube(SAMPLE));
 }
 
-OIIO_ADD_TEST(FileFormatResolveCube, ReadDefaultRange)
+OCIO_ADD_TEST(FileFormatResolveCube, ReadDefaultRange)
 {
     const std::string SAMPLE_1D =
         "LUT_1D_SIZE 2\n"
@@ -1021,7 +1021,7 @@ OIIO_ADD_TEST(FileFormatResolveCube, ReadDefaultRange)
         "0.0 0.0 0.0\n"
         "1.0 0.0 0.0\n";
 
-    OIIO_CHECK_NO_THROW(ReadResolveCube(SAMPLE_1D));
+    OCIO_CHECK_NO_THROW(ReadResolveCube(SAMPLE_1D));
     
     const std::string SAMPLE_3D =
         "LUT_3D_SIZE 2\n"
@@ -1035,7 +1035,7 @@ OIIO_ADD_TEST(FileFormatResolveCube, ReadDefaultRange)
         "0.0 1.0 1.0\n"
         "1.0 1.0 1.0\n";
 
-    OIIO_CHECK_NO_THROW(ReadResolveCube(SAMPLE_3D));
+    OCIO_CHECK_NO_THROW(ReadResolveCube(SAMPLE_3D));
     
     const std::string SAMPLE_1D3D =
         "LUT_1D_SIZE 2\n"
@@ -1052,11 +1052,11 @@ OIIO_ADD_TEST(FileFormatResolveCube, ReadDefaultRange)
         "0.0 1.0 1.0\n"
         "1.0 1.0 1.0\n";
 
-    OIIO_CHECK_NO_THROW(ReadResolveCube(SAMPLE_1D3D));
+    OCIO_CHECK_NO_THROW(ReadResolveCube(SAMPLE_1D3D));
 }
 
 
-OIIO_ADD_TEST(FileFormatResolveCube, ReadFailure)
+OCIO_ADD_TEST(FileFormatResolveCube, ReadFailure)
 {
     {
         // Wrong LUT_3D_SIZE tag
@@ -1073,7 +1073,7 @@ OIIO_ADD_TEST(FileFormatResolveCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW(ReadResolveCube(SAMPLE_ERROR), OCIO::Exception);
+        OCIO_CHECK_THROW(ReadResolveCube(SAMPLE_ERROR), OCIO::Exception);
     }
     {
         // Wrong LUT_3D_INPUT_RANGE tag
@@ -1090,7 +1090,7 @@ OIIO_ADD_TEST(FileFormatResolveCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW(ReadResolveCube(SAMPLE_ERROR), OCIO::Exception);
+        OCIO_CHECK_THROW(ReadResolveCube(SAMPLE_ERROR), OCIO::Exception);
     }
     {
         // Comment after header
@@ -1107,7 +1107,7 @@ OIIO_ADD_TEST(FileFormatResolveCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW(ReadResolveCube(SAMPLE_ERROR), OCIO::Exception);
+        OCIO_CHECK_THROW(ReadResolveCube(SAMPLE_ERROR), OCIO::Exception);
     }
     {
         // Unexpected tag
@@ -1124,7 +1124,7 @@ OIIO_ADD_TEST(FileFormatResolveCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW(ReadResolveCube(SAMPLE_ERROR), OCIO::Exception);
+        OCIO_CHECK_THROW(ReadResolveCube(SAMPLE_ERROR), OCIO::Exception);
     }
     {
         // Wrong number of entries
@@ -1143,11 +1143,11 @@ OIIO_ADD_TEST(FileFormatResolveCube, ReadFailure)
             "0.0 1.0 1.0\n"
             "1.0 1.0 1.0\n";
 
-        OIIO_CHECK_THROW(ReadResolveCube(SAMPLE_ERROR), OCIO::Exception);
+        OCIO_CHECK_THROW(ReadResolveCube(SAMPLE_ERROR), OCIO::Exception);
     }
 }
 
-OIIO_ADD_TEST(FileFormatResolveCube, Bake1D)
+OCIO_ADD_TEST(FileFormatResolveCube, Bake1D)
 {
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
     {
@@ -1182,17 +1182,17 @@ OIIO_ADD_TEST(FileFormatResolveCube, Bake1D)
     
     //
     std::vector<std::string> osvec;
-    OCIO::pystring::splitlines(output.str(), osvec);
+    pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    OCIO::pystring::splitlines(bout.str(), resvec);
-    OIIO_CHECK_EQUAL(osvec.size(), resvec.size());
+    pystring::splitlines(bout.str(), resvec);
+    OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {
-        OIIO_CHECK_EQUAL(osvec[i], resvec[i]);
+        OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
     }
 }
 
-OIIO_ADD_TEST(FileFormatResolveCube, Bake3D)
+OCIO_ADD_TEST(FileFormatResolveCube, Bake3D)
 {
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
     {
@@ -1244,17 +1244,17 @@ OIIO_ADD_TEST(FileFormatResolveCube, Bake3D)
     
     //
     std::vector<std::string> osvec;
-    OCIO::pystring::splitlines(output.str(), osvec);
+    pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    OCIO::pystring::splitlines(bout.str(), resvec);
-    OIIO_CHECK_EQUAL(osvec.size(), resvec.size());
+    pystring::splitlines(bout.str(), resvec);
+    OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {
-        OIIO_CHECK_EQUAL(osvec[i], resvec[i]);
+        OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
     }
 }
 
-OIIO_ADD_TEST(FileFormatResolveCube, Bake1D3D)
+OCIO_ADD_TEST(FileFormatResolveCube, Bake1D3D)
 {
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
     {
@@ -1325,13 +1325,13 @@ OIIO_ADD_TEST(FileFormatResolveCube, Bake1D3D)
     
     //
     std::vector<std::string> osvec;
-    OCIO::pystring::splitlines(output.str(), osvec);
+    pystring::splitlines(output.str(), osvec);
     std::vector<std::string> resvec;
-    OCIO::pystring::splitlines(bout.str(), resvec);
-    OIIO_CHECK_EQUAL(osvec.size(), resvec.size());
+    pystring::splitlines(bout.str(), resvec);
+    OCIO_CHECK_EQUAL(osvec.size(), resvec.size());
     for(unsigned int i = 0; i < resvec.size(); ++i)
     {
-        OIIO_CHECK_EQUAL(osvec[i], resvec[i]);
+        OCIO_CHECK_EQUAL(osvec[i], resvec[i]);
     }
 }
 

--- a/src/OpenColorIO/fileformats/FileFormatSpi1D.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpi1D.cpp
@@ -327,19 +327,19 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
-OIIO_ADD_TEST(FileFormatSpi1D, FormatInfo)
+OCIO_ADD_TEST(FileFormatSpi1D, FormatInfo)
 {
     OCIO::FormatInfoVec formatInfoVec;
     OCIO::LocalFileFormat tester;
     tester.GetFormatInfo(formatInfoVec);
 
-    OIIO_CHECK_EQUAL(1, formatInfoVec.size());
-    OIIO_CHECK_EQUAL("spi1d", formatInfoVec[0].name);
-    OIIO_CHECK_EQUAL("spi1d", formatInfoVec[0].extension);
-    OIIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ,
+    OCIO_CHECK_EQUAL(1, formatInfoVec.size());
+    OCIO_CHECK_EQUAL("spi1d", formatInfoVec[0].name);
+    OCIO_CHECK_EQUAL("spi1d", formatInfoVec[0].extension);
+    OCIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ,
         formatInfoVec[0].capabilities);
 }
 
@@ -349,32 +349,32 @@ OCIO::LocalCachedFileRcPtr LoadLutFile(const std::string & fileName)
         fileName, std::ios_base::in);
 }
 
-OIIO_ADD_TEST(FileFormatSpi1D, Test)
+OCIO_ADD_TEST(FileFormatSpi1D, Test)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string spi1dFile("cpf.spi1d");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadLutFile(spi1dFile));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadLutFile(spi1dFile));
 
-    OIIO_CHECK_ASSERT((bool)cachedFile);
-    OIIO_CHECK_ASSERT((bool)(cachedFile->lut));
+    OCIO_CHECK_ASSERT((bool)cachedFile);
+    OCIO_CHECK_ASSERT((bool)(cachedFile->lut));
 
-    OIIO_CHECK_EQUAL(0.0f, cachedFile->lut->from_min[0]);
-    OIIO_CHECK_EQUAL(1.0f, cachedFile->lut->from_max[0]);
+    OCIO_CHECK_EQUAL(0.0f, cachedFile->lut->from_min[0]);
+    OCIO_CHECK_EQUAL(1.0f, cachedFile->lut->from_max[0]);
 
-    OIIO_CHECK_EQUAL(2048, cachedFile->lut->luts[0].size());
-    OIIO_CHECK_EQUAL(2048, cachedFile->lut->luts[1].size());
-    OIIO_CHECK_EQUAL(2048, cachedFile->lut->luts[2].size());
+    OCIO_CHECK_EQUAL(2048, cachedFile->lut->luts[0].size());
+    OCIO_CHECK_EQUAL(2048, cachedFile->lut->luts[1].size());
+    OCIO_CHECK_EQUAL(2048, cachedFile->lut->luts[2].size());
 
-    OIIO_CHECK_EQUAL(0.0f, cachedFile->lut->luts[0][0]);
-    OIIO_CHECK_EQUAL(0.0f, cachedFile->lut->luts[1][0]);
-    OIIO_CHECK_EQUAL(0.0f, cachedFile->lut->luts[2][0]);
+    OCIO_CHECK_EQUAL(0.0f, cachedFile->lut->luts[0][0]);
+    OCIO_CHECK_EQUAL(0.0f, cachedFile->lut->luts[1][0]);
+    OCIO_CHECK_EQUAL(0.0f, cachedFile->lut->luts[2][0]);
 
-    OIIO_CHECK_EQUAL(4.511920005404118f, cachedFile->lut->luts[0][1970]);
-    OIIO_CHECK_EQUAL(4.511920005404118f, cachedFile->lut->luts[1][1970]);
-    OIIO_CHECK_EQUAL(4.511920005404118f, cachedFile->lut->luts[2][1970]);
+    OCIO_CHECK_EQUAL(4.511920005404118f, cachedFile->lut->luts[0][1970]);
+    OCIO_CHECK_EQUAL(4.511920005404118f, cachedFile->lut->luts[1][1970]);
+    OCIO_CHECK_EQUAL(4.511920005404118f, cachedFile->lut->luts[2][1970]);
 
-    OIIO_CHECK_EQUAL(1e-5f, cachedFile->lut->maxerror);
-    OIIO_CHECK_EQUAL(OCIO::Lut1D::ERROR_RELATIVE, cachedFile->lut->errortype);
+    OCIO_CHECK_EQUAL(1e-5f, cachedFile->lut->maxerror);
+    OCIO_CHECK_EQUAL(OCIO::Lut1D::ERROR_RELATIVE, cachedFile->lut->errortype);
 }
 
 void ReadSpi1d(const std::string & fileContent)
@@ -388,7 +388,7 @@ void ReadSpi1d(const std::string & fileContent)
     OCIO::CachedFileRcPtr cachedFile = tester.Read(is, SAMPLE_NAME);
 }
 
-OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
+OCIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
 {
     {
         // Validate stream can be read with no error.
@@ -403,7 +403,7 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_NO_THROW(ReadSpi1d(SAMPLE_NO_ERROR));
+        OCIO_CHECK_NO_THROW(ReadSpi1d(SAMPLE_NO_ERROR));
     }
     {
         // Version missing
@@ -416,7 +416,7 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Could not find 'Version' Tag");
     }
@@ -432,7 +432,7 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Only format version 1 supported");
     }
@@ -448,7 +448,7 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Invalid 'Version' Tag");
     }
@@ -464,7 +464,7 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Could not find 'Version' Tag");
     }
@@ -480,7 +480,7 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Invalid 'From' Tag");
     }
@@ -495,7 +495,7 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Could not find 'Length' Tag");
     }
@@ -511,7 +511,7 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Invalid 'Length' Tag");
     }
@@ -526,7 +526,7 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Could not find 'Components' Tag");
     }
@@ -542,7 +542,7 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Invalid 'Components' Tag");
     }
@@ -558,7 +558,7 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "1.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Components must be [1,2,3]");
     }
@@ -573,7 +573,7 @@ OIIO_ADD_TEST(FileFormatSpi1D, ReadFailure)
             "0.0\n"
             "}\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpi1d(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Not enough entries found");
     }

--- a/src/OpenColorIO/fileformats/FileFormatSpi3D.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpi3D.cpp
@@ -255,19 +255,19 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
-OIIO_ADD_TEST(FileFormatSpi3D, FormatInfo)
+OCIO_ADD_TEST(FileFormatSpi3D, FormatInfo)
 {
     OCIO::FormatInfoVec formatInfoVec;
     OCIO::LocalFileFormat tester;
     tester.GetFormatInfo(formatInfoVec);
 
-    OIIO_CHECK_EQUAL(1, formatInfoVec.size());
-    OIIO_CHECK_EQUAL("spi3d", formatInfoVec[0].name);
-    OIIO_CHECK_EQUAL("spi3d", formatInfoVec[0].extension);
-    OIIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ,
+    OCIO_CHECK_EQUAL(1, formatInfoVec.size());
+    OCIO_CHECK_EQUAL("spi3d", formatInfoVec[0].name);
+    OCIO_CHECK_EQUAL("spi3d", formatInfoVec[0].extension);
+    OCIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ,
         formatInfoVec[0].capabilities);
 }
 
@@ -277,27 +277,27 @@ OCIO::LocalCachedFileRcPtr LoadLutFile(const std::string & fileName)
         fileName, std::ios_base::in);
 }
 
-OIIO_ADD_TEST(FileFormatSpi3D, Test)
+OCIO_ADD_TEST(FileFormatSpi3D, Test)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string spi3dFile("spi_ocio_srgb_test.spi3d");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadLutFile(spi3dFile));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadLutFile(spi3dFile));
 
-    OIIO_CHECK_ASSERT((bool)cachedFile);
-    OIIO_CHECK_ASSERT((bool)(cachedFile->lut));
+    OCIO_CHECK_ASSERT((bool)cachedFile);
+    OCIO_CHECK_ASSERT((bool)(cachedFile->lut));
 
-    OIIO_CHECK_EQUAL(32, cachedFile->lut->size[0]);
-    OIIO_CHECK_EQUAL(32, cachedFile->lut->size[1]);
-    OIIO_CHECK_EQUAL(32, cachedFile->lut->size[2]);
-    OIIO_CHECK_EQUAL(32*32*32*3, cachedFile->lut->lut.size());
+    OCIO_CHECK_EQUAL(32, cachedFile->lut->size[0]);
+    OCIO_CHECK_EQUAL(32, cachedFile->lut->size[1]);
+    OCIO_CHECK_EQUAL(32, cachedFile->lut->size[2]);
+    OCIO_CHECK_EQUAL(32*32*32*3, cachedFile->lut->lut.size());
 
-    OIIO_CHECK_EQUAL(0.040157f, cachedFile->lut->lut[0]);
-    OIIO_CHECK_EQUAL(0.038904f, cachedFile->lut->lut[1]);
-    OIIO_CHECK_EQUAL(0.028316f, cachedFile->lut->lut[2]);
+    OCIO_CHECK_EQUAL(0.040157f, cachedFile->lut->lut[0]);
+    OCIO_CHECK_EQUAL(0.038904f, cachedFile->lut->lut[1]);
+    OCIO_CHECK_EQUAL(0.028316f, cachedFile->lut->lut[2]);
     // 10 2 12
-    OIIO_CHECK_EQUAL(0.102161f, cachedFile->lut->lut[37086]);
-    OIIO_CHECK_EQUAL(0.032187f, cachedFile->lut->lut[37087]);
-    OIIO_CHECK_EQUAL(0.175453f, cachedFile->lut->lut[37088]);
+    OCIO_CHECK_EQUAL(0.102161f, cachedFile->lut->lut[37086]);
+    OCIO_CHECK_EQUAL(0.032187f, cachedFile->lut->lut[37087]);
+    OCIO_CHECK_EQUAL(0.175453f, cachedFile->lut->lut[37088]);
 }
 
 void ReadSpi3d(const std::string & fileContent)
@@ -311,7 +311,7 @@ void ReadSpi3d(const std::string & fileContent)
     OCIO::CachedFileRcPtr cachedFile = tester.Read(is, SAMPLE_NAME);
 }
 
-OIIO_ADD_TEST(FileFormatSpi3D, ReadFailure)
+OCIO_ADD_TEST(FileFormatSpi3D, ReadFailure)
 {
     {
         // Validate stream can be read with no error.
@@ -329,7 +329,7 @@ OIIO_ADD_TEST(FileFormatSpi3D, ReadFailure)
             "1 1 0 0.6 0.7 0.1\n"
             "1 1 1 0.6 0.7 0.7\n";
 
-        OIIO_CHECK_NO_THROW(ReadSpi3d(SAMPLE_NO_ERROR));
+        OCIO_CHECK_NO_THROW(ReadSpi3d(SAMPLE_NO_ERROR));
     }
     {
         // Wrong first line
@@ -346,7 +346,7 @@ OIIO_ADD_TEST(FileFormatSpi3D, ReadFailure)
             "1 1 0 0.6 0.7 0.1\n"
             "1 1 1 0.6 0.7 0.7\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpi3d(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpi3d(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Expected 'SPILUT'");
     }
@@ -365,7 +365,7 @@ OIIO_ADD_TEST(FileFormatSpi3D, ReadFailure)
             "1 1 0 0.6 0.7 0.1\n"
             "1 1 1 0.6 0.7 0.7\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpi3d(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpi3d(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Error while reading LUT size");
     }
@@ -384,7 +384,7 @@ OIIO_ADD_TEST(FileFormatSpi3D, ReadFailure)
             "1 1 0 0.6 0.7 0.1\n"
             "1 1 1 0.6 0.7 0.7\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpi3d(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpi3d(SAMPLE_ERROR),
                               OCIO::Exception,
                               "that falls outside of the cube");
     }
@@ -402,7 +402,7 @@ OIIO_ADD_TEST(FileFormatSpi3D, ReadFailure)
             "1 1 0 0.6 0.7 0.1\n"
             "1 1 1 0.6 0.7 0.7\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpi3d(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpi3d(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Not enough entries found");
     }

--- a/src/OpenColorIO/fileformats/FileFormatSpiMtx.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatSpiMtx.cpp
@@ -203,19 +203,19 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
-OIIO_ADD_TEST(FileFormatSpiMtx, FormatInfo)
+OCIO_ADD_TEST(FileFormatSpiMtx, FormatInfo)
 {
     OCIO::FormatInfoVec formatInfoVec;
     OCIO::LocalFileFormat tester;
     tester.GetFormatInfo(formatInfoVec);
 
-    OIIO_CHECK_EQUAL(1, formatInfoVec.size());
-    OIIO_CHECK_EQUAL("spimtx", formatInfoVec[0].name);
-    OIIO_CHECK_EQUAL("spimtx", formatInfoVec[0].extension);
-    OIIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ,
+    OCIO_CHECK_EQUAL(1, formatInfoVec.size());
+    OCIO_CHECK_EQUAL("spimtx", formatInfoVec[0].name);
+    OCIO_CHECK_EQUAL("spimtx", formatInfoVec[0].extension);
+    OCIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ,
         formatInfoVec[0].capabilities);
 }
 
@@ -225,37 +225,37 @@ OCIO::LocalCachedFileRcPtr LoadLutFile(const std::string & fileName)
         fileName, std::ios_base::in);
 }
 
-OIIO_ADD_TEST(FileFormatSpiMtx, Test)
+OCIO_ADD_TEST(FileFormatSpiMtx, Test)
 {
     OCIO::LocalCachedFileRcPtr cachedFile;
     const std::string spiMtxFile("camera_to_aces.spimtx");
-    OIIO_CHECK_NO_THROW(cachedFile = LoadLutFile(spiMtxFile));
+    OCIO_CHECK_NO_THROW(cachedFile = LoadLutFile(spiMtxFile));
 
-    OIIO_REQUIRE_ASSERT((bool)cachedFile);
-    OIIO_CHECK_EQUAL(0.0f, cachedFile->offset4[0]);
-    OIIO_CHECK_EQUAL(0.0f, cachedFile->offset4[1]);
-    OIIO_CHECK_EQUAL(0.0f, cachedFile->offset4[2]);
-    OIIO_CHECK_EQUAL(0.0f, cachedFile->offset4[3]);
+    OCIO_REQUIRE_ASSERT((bool)cachedFile);
+    OCIO_CHECK_EQUAL(0.0f, cachedFile->offset4[0]);
+    OCIO_CHECK_EQUAL(0.0f, cachedFile->offset4[1]);
+    OCIO_CHECK_EQUAL(0.0f, cachedFile->offset4[2]);
+    OCIO_CHECK_EQUAL(0.0f, cachedFile->offset4[3]);
 
-    OIIO_CHECK_EQUAL(0.754338638f, cachedFile->m44[0]);
-    OIIO_CHECK_EQUAL(0.133697046f, cachedFile->m44[1]);
-    OIIO_CHECK_EQUAL(0.111968437f, cachedFile->m44[2]);
-    OIIO_CHECK_EQUAL(0.0f, cachedFile->m44[3]);
+    OCIO_CHECK_EQUAL(0.754338638f, cachedFile->m44[0]);
+    OCIO_CHECK_EQUAL(0.133697046f, cachedFile->m44[1]);
+    OCIO_CHECK_EQUAL(0.111968437f, cachedFile->m44[2]);
+    OCIO_CHECK_EQUAL(0.0f, cachedFile->m44[3]);
 
-    OIIO_CHECK_EQUAL(0.021198141f, cachedFile->m44[4]);
-    OIIO_CHECK_EQUAL(1.005410934f, cachedFile->m44[5]);
-    OIIO_CHECK_EQUAL(-0.026610548f, cachedFile->m44[6]);
-    OIIO_CHECK_EQUAL(0.0f, cachedFile->m44[7]);
+    OCIO_CHECK_EQUAL(0.021198141f, cachedFile->m44[4]);
+    OCIO_CHECK_EQUAL(1.005410934f, cachedFile->m44[5]);
+    OCIO_CHECK_EQUAL(-0.026610548f, cachedFile->m44[6]);
+    OCIO_CHECK_EQUAL(0.0f, cachedFile->m44[7]);
 
-    OIIO_CHECK_CLOSE(-0.00975699, cachedFile->m44[8], 1e-6f);
-    OIIO_CHECK_EQUAL(0.004508563f, cachedFile->m44[9]);
-    OIIO_CHECK_EQUAL(1.005253201f, cachedFile->m44[10]);
-    OIIO_CHECK_EQUAL(0.0f, cachedFile->m44[11]);
+    OCIO_CHECK_CLOSE(-0.00975699, cachedFile->m44[8], 1e-6f);
+    OCIO_CHECK_EQUAL(0.004508563f, cachedFile->m44[9]);
+    OCIO_CHECK_EQUAL(1.005253201f, cachedFile->m44[10]);
+    OCIO_CHECK_EQUAL(0.0f, cachedFile->m44[11]);
 
-    OIIO_CHECK_EQUAL(0.0f, cachedFile->m44[12]);
-    OIIO_CHECK_EQUAL(0.0f, cachedFile->m44[13]);
-    OIIO_CHECK_EQUAL(0.0f, cachedFile->m44[14]);
-    OIIO_CHECK_EQUAL(1.0f, cachedFile->m44[15]);
+    OCIO_CHECK_EQUAL(0.0f, cachedFile->m44[12]);
+    OCIO_CHECK_EQUAL(0.0f, cachedFile->m44[13]);
+    OCIO_CHECK_EQUAL(0.0f, cachedFile->m44[14]);
+    OCIO_CHECK_EQUAL(1.0f, cachedFile->m44[15]);
 }
 
 OCIO::LocalCachedFileRcPtr ReadSpiMtx(const std::string & fileContent)
@@ -271,7 +271,7 @@ OCIO::LocalCachedFileRcPtr ReadSpiMtx(const std::string & fileContent)
     return OCIO::DynamicPtrCast<OCIO::LocalCachedFile>(cachedFile);
 }
 
-OIIO_ADD_TEST(FileFormatSpiMtx, ReadOffset)
+OCIO_ADD_TEST(FileFormatSpiMtx, ReadOffset)
 {
     {
         // Validate stream can be read with no error.
@@ -282,16 +282,16 @@ OIIO_ADD_TEST(FileFormatSpiMtx, ReadOffset)
             "0 0 1 65535.0\n";
 
         OCIO::LocalCachedFileRcPtr cachedFile;
-        OIIO_CHECK_NO_THROW(cachedFile = ReadSpiMtx(SAMPLE_FILE));
-        OIIO_REQUIRE_ASSERT((bool)cachedFile);
-        OIIO_CHECK_EQUAL(0.1f, cachedFile->offset4[0]);
-        OIIO_CHECK_EQUAL(0.5f, cachedFile->offset4[1]);
-        OIIO_CHECK_EQUAL(1.0f, cachedFile->offset4[2]);
-        OIIO_CHECK_EQUAL(0.0f, cachedFile->offset4[3]);
+        OCIO_CHECK_NO_THROW(cachedFile = ReadSpiMtx(SAMPLE_FILE));
+        OCIO_REQUIRE_ASSERT((bool)cachedFile);
+        OCIO_CHECK_EQUAL(0.1f, cachedFile->offset4[0]);
+        OCIO_CHECK_EQUAL(0.5f, cachedFile->offset4[1]);
+        OCIO_CHECK_EQUAL(1.0f, cachedFile->offset4[2]);
+        OCIO_CHECK_EQUAL(0.0f, cachedFile->offset4[3]);
     }
 }
 
-OIIO_ADD_TEST(FileFormatSpiMtx, ReadFailure)
+OCIO_ADD_TEST(FileFormatSpiMtx, ReadFailure)
 {
     {
         // Validate stream can be read with no error.
@@ -301,7 +301,7 @@ OIIO_ADD_TEST(FileFormatSpiMtx, ReadFailure)
             "0.0 1.0 0.0 0.0\n"
             "0.0 0.0 1.0 0.0\n";
 
-        OIIO_CHECK_NO_THROW(ReadSpiMtx(SAMPLE_NO_ERROR));
+        OCIO_CHECK_NO_THROW(ReadSpiMtx(SAMPLE_NO_ERROR));
     }
     {
         // Wrong number of elements
@@ -310,7 +310,7 @@ OIIO_ADD_TEST(FileFormatSpiMtx, ReadFailure)
             "0.0 1.0 0.0\n"
             "0.0 0.0 1.0\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpiMtx(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpiMtx(SAMPLE_ERROR),
                               OCIO::Exception,
                               "File must contain 12 float entries");
     }
@@ -321,7 +321,7 @@ OIIO_ADD_TEST(FileFormatSpiMtx, ReadFailure)
             "0.0 error 0.0 0.0\n"
             "0.0 0.0 1.0 0.0\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadSpiMtx(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadSpiMtx(SAMPLE_ERROR),
                               OCIO::Exception,
                               "File must contain all float entries");
     }

--- a/src/OpenColorIO/fileformats/FileFormatTruelight.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatTruelight.cpp
@@ -433,9 +433,9 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(FileFormatTruelight, ShaperAndLut3D)
+OCIO_ADD_TEST(FileFormatTruelight, ShaperAndLut3D)
 {
     // This lowers the red channel by 0.5, other channels are unaffected.
     const char * luttext = "# Truelight Cube v2.0\n"
@@ -497,11 +497,11 @@ OIIO_ADD_TEST(FileFormatTruelight, ShaperAndLut3D)
     std::string emptyString;
     OCIO::LocalFileFormat tester;
     OCIO::CachedFileRcPtr cachedFile;
-    OIIO_CHECK_NO_THROW(cachedFile = tester.Read(lutIStream, emptyString));
+    OCIO_CHECK_NO_THROW(cachedFile = tester.Read(lutIStream, emptyString));
     OCIO::LocalCachedFileRcPtr lut = OCIO::DynamicPtrCast<OCIO::LocalCachedFile>(cachedFile);
     
-    OIIO_CHECK_ASSERT(lut->has1D);
-    OIIO_CHECK_ASSERT(lut->has3D);
+    OCIO_CHECK_ASSERT(lut->has1D);
+    OCIO_CHECK_ASSERT(lut->has3D);
     
     float data[4*3] = { 0.1f, 0.2f, 0.3f, 0.0f,
                         1.0f, 0.5f, 0.123456f, 0.0f,
@@ -533,11 +533,11 @@ OIIO_ADD_TEST(FileFormatTruelight, ShaperAndLut3D)
     
     for(int i=0; i<4*3; ++i)
     {
-        OIIO_CHECK_CLOSE( data[i], result[i], 1.0e-6 );
+        OCIO_CHECK_CLOSE( data[i], result[i], 1.0e-6 );
     }
 }
 
-OIIO_ADD_TEST(FileFormatTruelight, Shaper)
+OCIO_ADD_TEST(FileFormatTruelight, Shaper)
 {
     const char * luttext = "# Truelight Cube v2.0\n"
        "# lutLength 11\n"
@@ -566,12 +566,12 @@ OIIO_ADD_TEST(FileFormatTruelight, Shaper)
     std::string emptyString;
     OCIO::LocalFileFormat tester;
     OCIO::CachedFileRcPtr cachedFile;
-    OIIO_CHECK_NO_THROW(cachedFile = tester.Read(lutIStream, emptyString));
+    OCIO_CHECK_NO_THROW(cachedFile = tester.Read(lutIStream, emptyString));
     
     OCIO::LocalCachedFileRcPtr lut = OCIO::DynamicPtrCast<OCIO::LocalCachedFile>(cachedFile);
     
-    OIIO_CHECK_ASSERT(lut->has1D);
-    OIIO_CHECK_ASSERT(!lut->has3D);
+    OCIO_CHECK_ASSERT(lut->has1D);
+    OCIO_CHECK_ASSERT(!lut->has3D);
     
     float data[4*3] = { 0.1f, 0.2f, 0.3f, 0.0f,
                         1.0f, 0.5f, 0.123456f, 0.0f,
@@ -603,12 +603,12 @@ OIIO_ADD_TEST(FileFormatTruelight, Shaper)
     
     for(int i=0; i<4*3; ++i)
     {
-        OIIO_CHECK_CLOSE( data[i], result[i], 1.0e-6 );
+        OCIO_CHECK_CLOSE( data[i], result[i], 1.0e-6 );
     }
 }
 
 
-OIIO_ADD_TEST(FileFormatTruelight, Lut3D)
+OCIO_ADD_TEST(FileFormatTruelight, Lut3D)
 {
     // This lowers the red channel by 0.5, other channels are unaffected.
     const char * luttext = "# Truelight Cube v2.0\n"
@@ -654,11 +654,11 @@ OIIO_ADD_TEST(FileFormatTruelight, Lut3D)
     std::string emptyString;
     OCIO::LocalFileFormat tester;
     OCIO::CachedFileRcPtr cachedFile;
-    OIIO_CHECK_NO_THROW(cachedFile = tester.Read(lutIStream, emptyString));
+    OCIO_CHECK_NO_THROW(cachedFile = tester.Read(lutIStream, emptyString));
     OCIO::LocalCachedFileRcPtr lut = OCIO::DynamicPtrCast<OCIO::LocalCachedFile>(cachedFile);
     
-    OIIO_CHECK_ASSERT(!lut->has1D);
-    OIIO_CHECK_ASSERT(lut->has3D);
+    OCIO_CHECK_ASSERT(!lut->has1D);
+    OCIO_CHECK_ASSERT(lut->has3D);
     
     float data[4*3] = { 0.1f, 0.2f, 0.3f, 0.0f,
                         1.0f, 0.5f, 0.123456f, 0.0f,
@@ -690,7 +690,7 @@ OIIO_ADD_TEST(FileFormatTruelight, Lut3D)
     
     for(int i=0; i<4*3; ++i)
     {
-        OIIO_CHECK_CLOSE( data[i], result[i], 1.0e-6 );
+        OCIO_CHECK_CLOSE( data[i], result[i], 1.0e-6 );
     }
 }
 

--- a/src/OpenColorIO/fileformats/FileFormatVF.cpp
+++ b/src/OpenColorIO/fileformats/FileFormatVF.cpp
@@ -341,19 +341,19 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 #include <fstream>
 
-OIIO_ADD_TEST(FileFormatVF, FormatInfo)
+OCIO_ADD_TEST(FileFormatVF, FormatInfo)
 {
     OCIO::FormatInfoVec formatInfoVec;
     OCIO::LocalFileFormat tester;
     tester.GetFormatInfo(formatInfoVec);
 
-    OIIO_CHECK_EQUAL(1, formatInfoVec.size());
-    OIIO_CHECK_EQUAL("nukevf", formatInfoVec[0].name);
-    OIIO_CHECK_EQUAL("vf", formatInfoVec[0].extension);
-    OIIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ,
+    OCIO_CHECK_EQUAL(1, formatInfoVec.size());
+    OCIO_CHECK_EQUAL("nukevf", formatInfoVec[0].name);
+    OCIO_CHECK_EQUAL("vf", formatInfoVec[0].extension);
+    OCIO_CHECK_EQUAL(OCIO::FORMAT_CAPABILITY_READ,
         formatInfoVec[0].capabilities);
 }
 
@@ -368,7 +368,7 @@ void ReadVF(const std::string & fileContent)
     OCIO::CachedFileRcPtr cachedFile = tester.Read(is, SAMPLE_NAME);
 }
 
-OIIO_ADD_TEST(FileFormatVF, ReadFailure)
+OCIO_ADD_TEST(FileFormatVF, ReadFailure)
 {
     {
         // Validate stream can be read with no error.
@@ -387,7 +387,7 @@ OIIO_ADD_TEST(FileFormatVF, ReadFailure)
             "1 1 0\n"
             "1 1 1\n";
 
-        OIIO_CHECK_NO_THROW(ReadVF(SAMPLE_NO_ERROR));
+        OCIO_CHECK_NO_THROW(ReadVF(SAMPLE_NO_ERROR));
     }
     {
         // Too much data
@@ -406,7 +406,7 @@ OIIO_ADD_TEST(FileFormatVF, ReadFailure)
             "1 1 0\n"
             "1 1 1\n";
 
-        OIIO_CHECK_THROW_WHAT(ReadVF(SAMPLE_ERROR),
+        OCIO_CHECK_THROW_WHAT(ReadVF(SAMPLE_ERROR),
                               OCIO::Exception,
                               "Incorrect number of 3D LUT entries");
     }

--- a/src/OpenColorIO/fileformats/ctf/CTFTransform.cpp
+++ b/src/OpenColorIO/fileformats/ctf/CTFTransform.cpp
@@ -216,140 +216,140 @@ OCIO_NAMESPACE_EXIT
 
 namespace OCIO = OCIO_NAMESPACE;
 #include "ops/Matrix/MatrixOpData.h"
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(CTFVersion, read_version)
+OCIO_ADD_TEST(CTFVersion, read_version)
 {
     {
         const OCIO::CTFVersion version1(1, 2, 3);
         const OCIO::CTFVersion version2(1, 2, 3);
-        OIIO_CHECK_EQUAL(version1, version2);
+        OCIO_CHECK_EQUAL(version1, version2);
         {
             const OCIO::CTFVersion version3(0, 0, 1);
-            OIIO_CHECK_ASSERT(false == (version1 == version3));
-            OIIO_CHECK_ASSERT(version3 < version1);
+            OCIO_CHECK_ASSERT(false == (version1 == version3));
+            OCIO_CHECK_ASSERT(version3 < version1);
         }
         {
             const OCIO::CTFVersion version3(0, 1, 0);
-            OIIO_CHECK_ASSERT(false == (version1 == version3));
-            OIIO_CHECK_ASSERT(version3 < version1);
+            OCIO_CHECK_ASSERT(false == (version1 == version3));
+            OCIO_CHECK_ASSERT(version3 < version1);
         }
         {
             const OCIO::CTFVersion version3(1, 0, 0);
-            OIIO_CHECK_ASSERT(false == (version1 == version3));
-            OIIO_CHECK_ASSERT(version3 < version1);
+            OCIO_CHECK_ASSERT(false == (version1 == version3));
+            OCIO_CHECK_ASSERT(version3 < version1);
         }
         {
             const OCIO::CTFVersion version3(1, 2, 0);
-            OIIO_CHECK_ASSERT(false == (version1 == version3));
-            OIIO_CHECK_ASSERT(version3 < version1);
+            OCIO_CHECK_ASSERT(false == (version1 == version3));
+            OCIO_CHECK_ASSERT(version3 < version1);
         }
         {
             const OCIO::CTFVersion version3(1, 2, 2);
-            OIIO_CHECK_ASSERT(false == (version1 == version3));
-            OIIO_CHECK_ASSERT(version3 < version1);
+            OCIO_CHECK_ASSERT(false == (version1 == version3));
+            OCIO_CHECK_ASSERT(version3 < version1);
         }
     }
 
     OCIO::CTFVersion versionRead;
     {
-        OIIO_CHECK_NO_THROW(OCIO::CTFVersion::ReadVersion("1.2.3", versionRead));
+        OCIO_CHECK_NO_THROW(OCIO::CTFVersion::ReadVersion("1.2.3", versionRead));
         const OCIO::CTFVersion version(1, 2, 3);
-        OIIO_CHECK_EQUAL(version, versionRead);
+        OCIO_CHECK_EQUAL(version, versionRead);
     }
     {
-        OIIO_CHECK_NO_THROW(OCIO::CTFVersion::ReadVersion("1.2", versionRead));
+        OCIO_CHECK_NO_THROW(OCIO::CTFVersion::ReadVersion("1.2", versionRead));
         const OCIO::CTFVersion version(1, 2, 0);
-        OIIO_CHECK_EQUAL(version, versionRead);
+        OCIO_CHECK_EQUAL(version, versionRead);
     }
     {
-        OIIO_CHECK_NO_THROW(OCIO::CTFVersion::ReadVersion("1", versionRead));
+        OCIO_CHECK_NO_THROW(OCIO::CTFVersion::ReadVersion("1", versionRead));
         const OCIO::CTFVersion version(1, 0, 0);
-        OIIO_CHECK_EQUAL(version, versionRead);
+        OCIO_CHECK_EQUAL(version, versionRead);
     }
     {
-        OIIO_CHECK_NO_THROW(OCIO::CTFVersion::ReadVersion("1.10", versionRead));
+        OCIO_CHECK_NO_THROW(OCIO::CTFVersion::ReadVersion("1.10", versionRead));
         const OCIO::CTFVersion version(1, 10, 0);
-        OIIO_CHECK_EQUAL(version, versionRead);
+        OCIO_CHECK_EQUAL(version, versionRead);
     }
     {
-        OIIO_CHECK_NO_THROW(OCIO::CTFVersion::ReadVersion("1.1.0", versionRead));
+        OCIO_CHECK_NO_THROW(OCIO::CTFVersion::ReadVersion("1.1.0", versionRead));
         const OCIO::CTFVersion version(1, 1, 0);
-        OIIO_CHECK_EQUAL(version, versionRead);
+        OCIO_CHECK_EQUAL(version, versionRead);
     }
     {
-        OIIO_CHECK_NO_THROW(OCIO::CTFVersion::ReadVersion("1.01", versionRead));
+        OCIO_CHECK_NO_THROW(OCIO::CTFVersion::ReadVersion("1.01", versionRead));
         const OCIO::CTFVersion version(1, 1, 0);
-        OIIO_CHECK_EQUAL(version, versionRead);
+        OCIO_CHECK_EQUAL(version, versionRead);
     }
 
-    OIIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion("", versionRead),
+    OCIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion("", versionRead),
                           OCIO::Exception, 
                           "is not a valid version");
-    OIIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion("1 2", versionRead),
+    OCIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion("1 2", versionRead),
                           OCIO::Exception, 
                           "is not a valid version");
-    OIIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion("1-2", versionRead),
+    OCIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion("1-2", versionRead),
                           OCIO::Exception, 
                           "is not a valid version");
-    OIIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion("a", versionRead),
+    OCIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion("a", versionRead),
                           OCIO::Exception, 
                           "is not a valid version");
-    OIIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion("1.", versionRead),
+    OCIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion("1.", versionRead),
                           OCIO::Exception, 
                           "is not a valid version");
-    OIIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion(".2", versionRead),
+    OCIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion(".2", versionRead),
                           OCIO::Exception, 
                           "is not a valid version");
-    OIIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion("1.0 2", versionRead),
+    OCIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion("1.0 2", versionRead),
                           OCIO::Exception,
                           "is not a valid version");
-    OIIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion("-1", versionRead),
+    OCIO_CHECK_THROW_WHAT(OCIO::CTFVersion::ReadVersion("-1", versionRead),
                           OCIO::Exception,
                           "is not a valid version");
 }
 
-OIIO_ADD_TEST(CTFVersion, version_write)
+OCIO_ADD_TEST(CTFVersion, version_write)
 {
     {
         const OCIO::CTFVersion version(1, 2, 3);
         std::ostringstream ostream;
         ostream << version;
-        OIIO_CHECK_EQUAL(ostream.str(), "1.2.3");
+        OCIO_CHECK_EQUAL(ostream.str(), "1.2.3");
     }
     {
         const OCIO::CTFVersion version(1, 0, 3);
         std::ostringstream ostream;
         ostream << version;
-        OIIO_CHECK_EQUAL(ostream.str(), "1.0.3");
+        OCIO_CHECK_EQUAL(ostream.str(), "1.0.3");
     }
     {
         const OCIO::CTFVersion version(1, 2, 0);
         std::ostringstream ostream;
         ostream << version;
-        OIIO_CHECK_EQUAL(ostream.str(), "1.2");
+        OCIO_CHECK_EQUAL(ostream.str(), "1.2");
     }
     {
         const OCIO::CTFVersion version(1, 20, 0);
         std::ostringstream ostream;
         ostream << version;
-        OIIO_CHECK_EQUAL(ostream.str(), "1.20");
+        OCIO_CHECK_EQUAL(ostream.str(), "1.20");
     }
     {
         const OCIO::CTFVersion version(1, 0, 0);
         std::ostringstream ostream;
         ostream << version;
-        OIIO_CHECK_EQUAL(ostream.str(), "1");
+        OCIO_CHECK_EQUAL(ostream.str(), "1");
     }
     {
         const OCIO::CTFVersion version(0, 0, 0);
         std::ostringstream ostream;
         ostream << version;
-        OIIO_CHECK_EQUAL(ostream.str(), "0");
+        OCIO_CHECK_EQUAL(ostream.str(), "0");
     }
 }
 
-OIIO_ADD_TEST(CTFReaderTransform, accessors)
+OCIO_ADD_TEST(CTFReaderTransform, accessors)
 {
     OCIO::CTFReaderTransform t;
     {
@@ -358,25 +358,25 @@ OIIO_ADD_TEST(CTFReaderTransform, accessors)
         OCIO::Metadata & info = t.getInfo();
         const OCIO::Metadata & cinfo = t.getInfo();
 
-        OIIO_CHECK_EQUAL(info.getName(), "Info");
-        OIIO_CHECK_EQUAL(cinfo.getName(), "Info");
+        OCIO_CHECK_EQUAL(info.getName(), "Info");
+        OCIO_CHECK_EQUAL(cinfo.getName(), "Info");
 
-        OIIO_CHECK_EQUAL(t.getID(), "");
-        OIIO_CHECK_EQUAL(ct.getID(), "");
-        OIIO_CHECK_EQUAL(t.getName(), "");
-        OIIO_CHECK_EQUAL(ct.getName(), "");
-        OIIO_CHECK_EQUAL(t.getInverseOfId(), "");
-        OIIO_CHECK_EQUAL(ct.getInverseOfId(), "");
-        OIIO_CHECK_EQUAL(t.getInputDescriptor(), "");
-        OIIO_CHECK_EQUAL(ct.getInputDescriptor(), "");
-        OIIO_CHECK_EQUAL(t.getOutputDescriptor(), "");
-        OIIO_CHECK_EQUAL(ct.getOutputDescriptor(), "");
+        OCIO_CHECK_EQUAL(t.getID(), "");
+        OCIO_CHECK_EQUAL(ct.getID(), "");
+        OCIO_CHECK_EQUAL(t.getName(), "");
+        OCIO_CHECK_EQUAL(ct.getName(), "");
+        OCIO_CHECK_EQUAL(t.getInverseOfId(), "");
+        OCIO_CHECK_EQUAL(ct.getInverseOfId(), "");
+        OCIO_CHECK_EQUAL(t.getInputDescriptor(), "");
+        OCIO_CHECK_EQUAL(ct.getInputDescriptor(), "");
+        OCIO_CHECK_EQUAL(t.getOutputDescriptor(), "");
+        OCIO_CHECK_EQUAL(ct.getOutputDescriptor(), "");
 
-        OIIO_CHECK_ASSERT(t.getOps().empty());
-        OIIO_CHECK_ASSERT(ct.getOps().empty());
+        OCIO_CHECK_ASSERT(t.getOps().empty());
+        OCIO_CHECK_ASSERT(ct.getOps().empty());
 
-        OIIO_CHECK_ASSERT(t.getDescriptions().empty());
-        OIIO_CHECK_ASSERT(ct.getDescriptions().empty());
+        OCIO_CHECK_ASSERT(t.getDescriptions().empty());
+        OCIO_CHECK_ASSERT(ct.getDescriptions().empty());
     }
     t.setName("Name");
     t.setID("123");
@@ -393,30 +393,30 @@ OIIO_ADD_TEST(CTFReaderTransform, accessors)
     {
         const OCIO::CTFReaderTransform & ct = t;
 
-        OIIO_CHECK_EQUAL(t.getID(), "123");
-        OIIO_CHECK_EQUAL(ct.getID(), "123");
-        OIIO_CHECK_EQUAL(t.getName(), "Name");
-        OIIO_CHECK_EQUAL(ct.getName(), "Name");
-        OIIO_CHECK_EQUAL(t.getInverseOfId(), "654");
-        OIIO_CHECK_EQUAL(ct.getInverseOfId(), "654");
-        OIIO_CHECK_EQUAL(t.getInputDescriptor(), "input");
-        OIIO_CHECK_EQUAL(ct.getInputDescriptor(), "input");
-        OIIO_CHECK_EQUAL(t.getOutputDescriptor(), "output");
-        OIIO_CHECK_EQUAL(ct.getOutputDescriptor(), "output");
+        OCIO_CHECK_EQUAL(t.getID(), "123");
+        OCIO_CHECK_EQUAL(ct.getID(), "123");
+        OCIO_CHECK_EQUAL(t.getName(), "Name");
+        OCIO_CHECK_EQUAL(ct.getName(), "Name");
+        OCIO_CHECK_EQUAL(t.getInverseOfId(), "654");
+        OCIO_CHECK_EQUAL(ct.getInverseOfId(), "654");
+        OCIO_CHECK_EQUAL(t.getInputDescriptor(), "input");
+        OCIO_CHECK_EQUAL(ct.getInputDescriptor(), "input");
+        OCIO_CHECK_EQUAL(t.getOutputDescriptor(), "output");
+        OCIO_CHECK_EQUAL(ct.getOutputDescriptor(), "output");
 
-        OIIO_CHECK_EQUAL(t.getOps().size(), 1);
-        OIIO_CHECK_EQUAL(ct.getOps().size(), 1);
+        OCIO_CHECK_EQUAL(t.getOps().size(), 1);
+        OCIO_CHECK_EQUAL(ct.getOps().size(), 1);
 
-        OIIO_CHECK_EQUAL(t.getDescriptions().size(), 2);
-        OIIO_CHECK_EQUAL(ct.getDescriptions().size(), 2);
-        OIIO_CHECK_EQUAL(t.getDescriptions()[0], "One");
-        OIIO_CHECK_EQUAL(ct.getDescriptions()[0], "One");
-        OIIO_CHECK_EQUAL(t.getDescriptions()[1], "Two");
-        OIIO_CHECK_EQUAL(ct.getDescriptions()[1], "Two");
+        OCIO_CHECK_EQUAL(t.getDescriptions().size(), 2);
+        OCIO_CHECK_EQUAL(ct.getDescriptions().size(), 2);
+        OCIO_CHECK_EQUAL(t.getDescriptions()[0], "One");
+        OCIO_CHECK_EQUAL(ct.getDescriptions()[0], "One");
+        OCIO_CHECK_EQUAL(t.getDescriptions()[1], "Two");
+        OCIO_CHECK_EQUAL(ct.getDescriptions()[1], "Two");
     }
 }
 
-OIIO_ADD_TEST(CTFReaderTransform, validate)
+OCIO_ADD_TEST(CTFReaderTransform, validate)
 {
     OCIO::CTFReaderTransform t;
     auto matrix = std::make_shared<OCIO::MatrixOpData>(OCIO::BIT_DEPTH_UINT10,
@@ -428,17 +428,17 @@ OIIO_ADD_TEST(CTFReaderTransform, validate)
 
     t.getOps().push_back(matrix);
 
-    OIIO_CHECK_NO_THROW(t.validate());
+    OCIO_CHECK_NO_THROW(t.validate());
 
     matrix = std::make_shared<OCIO::MatrixOpData>(OCIO::BIT_DEPTH_F16,
                                                   OCIO::BIT_DEPTH_F32);
     t.getOps().push_back(matrix);
 
-    OIIO_CHECK_THROW_WHAT(t.validate(), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(t.validate(), OCIO::Exception,
                           "Bitdepth missmatch between ops");
 
     matrix->setInputBitDepth(OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_NO_THROW(t.validate());
+    OCIO_CHECK_NO_THROW(t.validate());
 }
 
 

--- a/src/OpenColorIO/fileformats/xmlutils/XMLReaderUtils.cpp
+++ b/src/OpenColorIO/fileformats/xmlutils/XMLReaderUtils.cpp
@@ -147,27 +147,27 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 
 #include "MathUtils.h"
-#include "unittest.h"
+#include "UnitTest.h"
 
 #define EXPECTED_PRECISION 1e-11f
 
-OIIO_ADD_TEST(XMLReaderHelper, string_to_float)
+OCIO_ADD_TEST(XMLReaderHelper, string_to_float)
 {
     float value = 0.0f;
     const char str[] = "12345";
     const size_t len = strlen(str);
 
-    OIIO_CHECK_NO_THROW(OCIO::ParseNumber(str, 0, len, value));
-    OIIO_CHECK_EQUAL(value, 12345.0f);
+    OCIO_CHECK_NO_THROW(OCIO::ParseNumber(str, 0, len, value));
+    OCIO_CHECK_EQUAL(value, 12345.0f);
 }
 
-OIIO_ADD_TEST(XMLReaderHelper, string_to_float_failure)
+OCIO_ADD_TEST(XMLReaderHelper, string_to_float_failure)
 {
     float value = 0.0f;
     const char str[] = "ABDSCSGFDS";
     const size_t len = strlen(str);
 
-    OIIO_CHECK_THROW_WHAT(OCIO::ParseNumber(str, 0, len, value),
+    OCIO_CHECK_THROW_WHAT(OCIO::ParseNumber(str, 0, len, value),
                           OCIO::Exception,
                           "are illegal");
 
@@ -175,19 +175,19 @@ OIIO_ADD_TEST(XMLReaderHelper, string_to_float_failure)
     const char str1[] = "10 ";
     const size_t len1 = strlen(str1);
 
-    OIIO_CHECK_THROW_WHAT(OCIO::ParseNumber(str1, 0, len1, value),
+    OCIO_CHECK_THROW_WHAT(OCIO::ParseNumber(str1, 0, len1, value),
                           OCIO::Exception,
                           "followed by characters");
 
     // 2 characters are parsed and this is the length required.
-    OIIO_CHECK_NO_THROW(OCIO::ParseNumber(str1, 0, 2, value));
+    OCIO_CHECK_NO_THROW(OCIO::ParseNumber(str1, 0, 2, value));
 
     const char str2[] = "12345";
     const size_t len2 = strlen(str2);
     // All characters are parsed and this is more than the required length.
     // The string to double function strtod does not stop at a given length,
     // but we detect that strtod did read too many characters.
-    OIIO_CHECK_THROW_WHAT(OCIO::ParseNumber(str2, 0, len2 - 2, value),
+    OCIO_CHECK_THROW_WHAT(OCIO::ParseNumber(str2, 0, len2 - 2, value),
                           OCIO::Exception,
                           "followed by characters");
 
@@ -196,21 +196,21 @@ OIIO_ADD_TEST(XMLReaderHelper, string_to_float_failure)
     const size_t len3 = strlen(str3);
     // Strtod will stop after parsing 123 and this happens to be the
     // excact length that is required to be parsed.
-    OIIO_CHECK_NO_THROW(OCIO::ParseNumber(str3, 0, len3 - 2, value));
+    OCIO_CHECK_NO_THROW(OCIO::ParseNumber(str3, 0, len3 - 2, value));
 }
 
-OIIO_ADD_TEST(XMLReaderHelper, get_numbers)
+OCIO_ADD_TEST(XMLReaderHelper, get_numbers)
 {
     const char str[] = "1.0 , 2.0     3.0,4";
     const size_t len = strlen(str);
 
     std::vector<float> values;
-    OIIO_CHECK_NO_THROW(values = OCIO::GetNumbers<float>(str, len));
-    OIIO_REQUIRE_EQUAL(values.size(), 4);
-    OIIO_CHECK_EQUAL(values[0], 1.0f);
-    OIIO_CHECK_EQUAL(values[1], 2.0f);
-    OIIO_CHECK_EQUAL(values[2], 3.0f);
-    OIIO_CHECK_EQUAL(values[3], 4.0f);
+    OCIO_CHECK_NO_THROW(values = OCIO::GetNumbers<float>(str, len));
+    OCIO_REQUIRE_EQUAL(values.size(), 4);
+    OCIO_CHECK_EQUAL(values[0], 1.0f);
+    OCIO_CHECK_EQUAL(values[1], 2.0f);
+    OCIO_CHECK_EQUAL(values[2], 3.0f);
+    OCIO_CHECK_EQUAL(values[3], 4.0f);
 
     // Same test without a null terminated string:
     // Copy the string into a buffer that will not be null terminated.
@@ -218,36 +218,36 @@ OIIO_ADD_TEST(XMLReaderHelper, get_numbers)
     char * buffer = new char[len+1];
     memcpy(buffer, str, len * sizeof(char));
     buffer[len] = '\n';
-    OIIO_CHECK_NO_THROW(values = OCIO::GetNumbers<float>(buffer, len));
-    OIIO_REQUIRE_EQUAL(values.size(), 4);
-    OIIO_CHECK_EQUAL(values[0], 1.0f);
-    OIIO_CHECK_EQUAL(values[1], 2.0f);
-    OIIO_CHECK_EQUAL(values[2], 3.0f);
-    OIIO_CHECK_EQUAL(values[3], 4.0f);
+    OCIO_CHECK_NO_THROW(values = OCIO::GetNumbers<float>(buffer, len));
+    OCIO_REQUIRE_EQUAL(values.size(), 4);
+    OCIO_CHECK_EQUAL(values[0], 1.0f);
+    OCIO_CHECK_EQUAL(values[1], 2.0f);
+    OCIO_CHECK_EQUAL(values[2], 3.0f);
+    OCIO_CHECK_EQUAL(values[3], 4.0f);
 
     // Testing with more values.
     const char str1[] = "inf, -infinity 1.0, -2.0 0x42 nan  , -nan 5.0";
     const size_t len1 = strlen(str1);
 
-    OIIO_CHECK_NO_THROW(values = OCIO::GetNumbers<float>(str1, len1));
-    OIIO_REQUIRE_EQUAL(values.size(), 8);
-    OIIO_CHECK_EQUAL(values[2], 1.0f);
-    OIIO_CHECK_EQUAL(values[4], 66.0f); // 0x42
+    OCIO_CHECK_NO_THROW(values = OCIO::GetNumbers<float>(str1, len1));
+    OCIO_REQUIRE_EQUAL(values.size(), 8);
+    OCIO_CHECK_EQUAL(values[2], 1.0f);
+    OCIO_CHECK_EQUAL(values[4], 66.0f); // 0x42
 
     // It is valid to start with delimiters.
     const char str2[] = ",  ,, , 0 2.0 3.0";
     const size_t len2 = strlen(str2);
 
-    OIIO_CHECK_NO_THROW(values = OCIO::GetNumbers<float>(str2, len2));
-    OIIO_REQUIRE_EQUAL(values.size(), 3);
-    OIIO_CHECK_EQUAL(values[0], 0.0f);
-    OIIO_CHECK_EQUAL(values[2], 3.0f);
+    OCIO_CHECK_NO_THROW(values = OCIO::GetNumbers<float>(str2, len2));
+    OCIO_REQUIRE_EQUAL(values.size(), 3);
+    OCIO_CHECK_EQUAL(values[0], 0.0f);
+    OCIO_CHECK_EQUAL(values[2], 3.0f);
 
     // Error: text is not a number.
     const char str3[] = "0   error 2.0 3.0";
     const size_t len3 = strlen(str3);
 
-    OIIO_CHECK_THROW_WHAT(values = OCIO::GetNumbers<float>(str3, len3),
+    OCIO_CHECK_THROW_WHAT(values = OCIO::GetNumbers<float>(str3, len3),
                           OCIO::Exception,
                           "are illegal");
 
@@ -255,271 +255,271 @@ OIIO_ADD_TEST(XMLReaderHelper, get_numbers)
     const char str4[] = "0   1.0error 2.0 3.0";
     const size_t len4 = strlen(str4);
 
-    OIIO_CHECK_THROW_WHAT(values = OCIO::GetNumbers<float>(str4, len4),
+    OCIO_CHECK_THROW_WHAT(values = OCIO::GetNumbers<float>(str4, len4),
                           OCIO::Exception,
                           "followed by characters");
 }
 
-OIIO_ADD_TEST(XMLReaderHelper, trim)
+OCIO_ADD_TEST(XMLReaderHelper, trim)
 {
     const std::string original1("    some text    ");
     const std::string original2(" \n \r some text  \t \v \f ");
     {
         std::string value(original1);
         OCIO::Trim(value);
-        OIIO_CHECK_ASSERT(0 == strcmp("some text", value.c_str()));
+        OCIO_CHECK_ASSERT(0 == strcmp("some text", value.c_str()));
         value = original2;
         OCIO::Trim(value);
-        OIIO_CHECK_ASSERT(0 == strcmp("some text", value.c_str()));
+        OCIO_CHECK_ASSERT(0 == strcmp("some text", value.c_str()));
     }
 
     {
         std::string value(original1);
         OCIO::RTrim(value);
-        OIIO_CHECK_ASSERT(0 == strcmp("    some text", value.c_str()));
+        OCIO_CHECK_ASSERT(0 == strcmp("    some text", value.c_str()));
         value = original2;
         OCIO::RTrim(value);
-        OIIO_CHECK_ASSERT(0 == strcmp(" \n \r some text", value.c_str()));
+        OCIO_CHECK_ASSERT(0 == strcmp(" \n \r some text", value.c_str()));
     }
 
     {
         std::string value(original1);
         OCIO::LTrim(value);
-        OIIO_CHECK_ASSERT(0 == strcmp("some text    ", value.c_str()));
+        OCIO_CHECK_ASSERT(0 == strcmp("some text    ", value.c_str()));
         value = original2;
         OCIO::LTrim(value);
-        OIIO_CHECK_ASSERT(0 == strcmp("some text  \t \v \f ", value.c_str()));
+        OCIO_CHECK_ASSERT(0 == strcmp("some text  \t \v \f ", value.c_str()));
     }
 }
 
-OIIO_ADD_TEST(XMLReaderHelper, parse_number)
+OCIO_ADD_TEST(XMLReaderHelper, parse_number)
 {
     float data = 0.0f;
     {
         std::string buffer("1 0");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, 1, data));
-        OIIO_CHECK_EQUAL(data, 1.0f);
+        OCIO_CHECK_EQUAL(data, 1.0f);
     }
     {
         std::string buffer("1.0 0");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, 3, data));
-        OIIO_CHECK_EQUAL(data, 1.0f);
+        OCIO_CHECK_EQUAL(data, 1.0f);
     }
     {
         std::string buffer("1.0000 0");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, 6, data));
-        OIIO_CHECK_EQUAL(data, 1.0f);
+        OCIO_CHECK_EQUAL(data, 1.0f);
     }
     {
         std::string buffer("1.0");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, 3, data));
-        OIIO_CHECK_EQUAL(data, 1.0f);
+        OCIO_CHECK_EQUAL(data, 1.0f);
     }
     {
         std::string buffer("1");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, 1, data);)
-        OIIO_CHECK_EQUAL(data, 1.0f);
+        OCIO_CHECK_EQUAL(data, 1.0f);
     }
     {
         std::string buffer("10.0e-1");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, 1.0f);
+        OCIO_CHECK_EQUAL(data, 1.0f);
     }
     {
         std::string buffer("0.1e+1");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, 1.0f);
+        OCIO_CHECK_EQUAL(data, 1.0f);
     }
     {
         std::string buffer("-1 0");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, 2, data));
-        OIIO_CHECK_EQUAL(data, -1.0f);
+        OCIO_CHECK_EQUAL(data, -1.0f);
     }
     {
         std::string buffer("-1.0 0");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, 4, data));
-        OIIO_CHECK_EQUAL(data, -1.0f);
+        OCIO_CHECK_EQUAL(data, -1.0f);
     }
     {
         std::string buffer("-1.0000 0");
         size_t end = OCIO::FindDelim(buffer.c_str(), buffer.size(), 0);
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, end, data));
-        OIIO_CHECK_EQUAL(data, -1.0f);
+        OCIO_CHECK_EQUAL(data, -1.0f);
     }
     {
         std::string buffer("  -1.0");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, -1.0f);
+        OCIO_CHECK_EQUAL(data, -1.0f);
     }
     {
         std::string buffer("   -1");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data);)
-            OIIO_CHECK_EQUAL(data, -1.0f);
+            OCIO_CHECK_EQUAL(data, -1.0f);
     }
     {
         std::string buffer(" -10.0e-1");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, -1.0f);
+        OCIO_CHECK_EQUAL(data, -1.0f);
     }
     {
         std::string buffer("-0.1e+1");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, -1.0f);
+        OCIO_CHECK_EQUAL(data, -1.0f);
     }
     {
         std::string buffer("INF");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, 3, data));
-        OIIO_CHECK_EQUAL(data, std::numeric_limits<float>::infinity());
+        OCIO_CHECK_EQUAL(data, std::numeric_limits<float>::infinity());
     }
     {
         std::string buffer("INF 1.0 2.0");
         size_t pos = 0;
         const size_t size = buffer.size();
         size_t nextPos = OCIO::FindDelim(buffer.c_str(), size, pos);
-        OIIO_CHECK_EQUAL(nextPos, 3);
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_EQUAL(nextPos, 3);
+        OCIO_CHECK_NO_THROW(
             OCIO::ParseNumber(buffer.c_str(),
                               pos, nextPos, data));
-        OIIO_CHECK_EQUAL(data, std::numeric_limits<float>::infinity());
+        OCIO_CHECK_EQUAL(data, std::numeric_limits<float>::infinity());
         pos = OCIO::FindNextTokenStart(buffer.c_str(), size, nextPos);
-        OIIO_CHECK_EQUAL(pos, 4);
+        OCIO_CHECK_EQUAL(pos, 4);
         nextPos = OCIO::FindDelim(buffer.c_str(), size, pos);
-        OIIO_CHECK_EQUAL(nextPos, 7);
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_EQUAL(nextPos, 7);
+        OCIO_CHECK_NO_THROW(
             OCIO::ParseNumber(buffer.c_str(),
                               pos, nextPos, data));
-        OIIO_CHECK_EQUAL(data, 1.0f);
+        OCIO_CHECK_EQUAL(data, 1.0f);
         pos = OCIO::FindNextTokenStart(buffer.c_str(), size, nextPos);
-        OIIO_CHECK_EQUAL(pos, 8);
+        OCIO_CHECK_EQUAL(pos, 8);
         nextPos = OCIO::FindDelim(buffer.c_str(), size, pos);
-        OIIO_CHECK_EQUAL(nextPos, 11);
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_EQUAL(nextPos, 11);
+        OCIO_CHECK_NO_THROW(
             OCIO::ParseNumber(buffer.c_str(),
                               pos, nextPos, data));
-        OIIO_CHECK_EQUAL(data, 2.0f);
+        OCIO_CHECK_EQUAL(data, 2.0f);
     }
     {
         std::string buffer("INFINITY");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, std::numeric_limits<float>::infinity());
+        OCIO_CHECK_EQUAL(data, std::numeric_limits<float>::infinity());
     }
     {
         std::string buffer("-INF");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, -std::numeric_limits<float>::infinity());
+        OCIO_CHECK_EQUAL(data, -std::numeric_limits<float>::infinity());
     }
     {
         std::string buffer("-INFINITY");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, -std::numeric_limits<float>::infinity());
+        OCIO_CHECK_EQUAL(data, -std::numeric_limits<float>::infinity());
     }
     {
         std::string buffer("NAN");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_ASSERT(OCIO::IsNan(data));
+        OCIO_CHECK_ASSERT(OCIO::IsNan(data));
     }
     {
         std::string buffer("-NAN");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_ASSERT(OCIO::IsNan(data));
+        OCIO_CHECK_ASSERT(OCIO::IsNan(data));
     }
     {
         std::string buffer("0.001");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, 0.001f);
+        OCIO_CHECK_EQUAL(data, 0.001f);
     }
     {
         std::string buffer("-0.001");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, -0.001f);
+        OCIO_CHECK_EQUAL(data, -0.001f);
     }
     {
         std::string buffer(".001");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, 0.001f);
+        OCIO_CHECK_EQUAL(data, 0.001f);
     }
     {
         std::string buffer("-.001");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, -0.001f);
+        OCIO_CHECK_EQUAL(data, -0.001f);
     }
     {
         std::string buffer(".01e-1");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, 0.001f);
+        OCIO_CHECK_EQUAL(data, 0.001f);
     }
     {
         std::string buffer("-.01e-1");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, -0.001f);
+        OCIO_CHECK_EQUAL(data, -0.001f);
     }
     {
         std::string buffer("-.01e-1,");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size() - 1, data));
-        OIIO_CHECK_EQUAL(data, -0.001f);
+        OCIO_CHECK_EQUAL(data, -0.001f);
     }
     {
         std::string buffer("-.01e-1\n");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size() - 1, data));
-        OIIO_CHECK_EQUAL(data, -0.001f);
+        OCIO_CHECK_EQUAL(data, -0.001f);
     }
     {
         std::string buffer("-.01e-1\t");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size() - 1, data));
-        OIIO_CHECK_EQUAL(data, -0.001f);
+        OCIO_CHECK_EQUAL(data, -0.001f);
     }
     {
         std::string buffer("10E-1");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, 1.0f);
+        OCIO_CHECK_EQUAL(data, 1.0f);
     }
     {
         std::string buffer("0.10E01");
-        OIIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_NO_THROW(OCIO::ParseNumber(buffer.c_str(),
                                               0, buffer.size(), data));
-        OIIO_CHECK_EQUAL(data, 1.0f);
+        OCIO_CHECK_EQUAL(data, 1.0f);
     }
 
     {
         std::string buffer("XY");
-        OIIO_CHECK_THROW_WHAT(OCIO::ParseNumber(buffer.c_str(),
+        OCIO_CHECK_THROW_WHAT(OCIO::ParseNumber(buffer.c_str(),
                                                 0, 2, data),
                               OCIO::Exception,
                               "are illegal");
     }
 }
 
-OIIO_ADD_TEST(XMLReaderHelper, find_sub_string)
+OCIO_ADD_TEST(XMLReaderHelper, find_sub_string)
 {
     {
         //                        012345678901234
@@ -529,8 +529,8 @@ OIIO_ADD_TEST(XMLReaderHelper, find_sub_string)
                             buffer.size(),
                             start,
                             end);
-        OIIO_CHECK_EQUAL(start, 3);
-        OIIO_CHECK_EQUAL(end, 12);
+        OCIO_CHECK_EQUAL(start, 3);
+        OCIO_CHECK_EQUAL(end, 12);
     }
     {
         //                        012345678901234
@@ -540,8 +540,8 @@ OIIO_ADD_TEST(XMLReaderHelper, find_sub_string)
                             buffer.size(),
                             start,
                             end);
-        OIIO_CHECK_EQUAL(start, 0);
-        OIIO_CHECK_EQUAL(end, 9);
+        OCIO_CHECK_EQUAL(start, 0);
+        OCIO_CHECK_EQUAL(end, 9);
     }
     {
         //                        012345678901234
@@ -551,8 +551,8 @@ OIIO_ADD_TEST(XMLReaderHelper, find_sub_string)
                             buffer.size(),
                             start,
                             end);
-        OIIO_CHECK_EQUAL(start, 3);
-        OIIO_CHECK_EQUAL(end, 12);
+        OCIO_CHECK_EQUAL(start, 3);
+        OCIO_CHECK_EQUAL(end, 12);
     }
     {
         //                        012345678901234
@@ -562,8 +562,8 @@ OIIO_ADD_TEST(XMLReaderHelper, find_sub_string)
                             buffer.size(),
                             start,
                             end);
-        OIIO_CHECK_EQUAL(start, 0);
-        OIIO_CHECK_EQUAL(end, 9);
+        OCIO_CHECK_EQUAL(start, 0);
+        OCIO_CHECK_EQUAL(end, 9);
     }
     {
         const std::string buffer("");
@@ -572,8 +572,8 @@ OIIO_ADD_TEST(XMLReaderHelper, find_sub_string)
                             buffer.size(),
                             start,
                             end);
-        OIIO_CHECK_EQUAL(start, 0);
-        OIIO_CHECK_EQUAL(end, 0);
+        OCIO_CHECK_EQUAL(start, 0);
+        OCIO_CHECK_EQUAL(end, 0);
     }
     {
         const std::string buffer("      ");
@@ -582,8 +582,8 @@ OIIO_ADD_TEST(XMLReaderHelper, find_sub_string)
                             buffer.size(),
                             start,
                             end);
-        OIIO_CHECK_EQUAL(start, 0);
-        OIIO_CHECK_EQUAL(end, 0);
+        OCIO_CHECK_EQUAL(start, 0);
+        OCIO_CHECK_EQUAL(end, 0);
     }
     {
         const std::string buffer("   \t123    ");
@@ -592,8 +592,8 @@ OIIO_ADD_TEST(XMLReaderHelper, find_sub_string)
                             buffer.size(),
                             start,
                             end);
-        OIIO_CHECK_EQUAL(start, 4);
-        OIIO_CHECK_EQUAL(end, 7);
+        OCIO_CHECK_EQUAL(start, 4);
+        OCIO_CHECK_EQUAL(end, 7);
     }
     {
         const std::string buffer("1   \t \n \r");
@@ -602,8 +602,8 @@ OIIO_ADD_TEST(XMLReaderHelper, find_sub_string)
                             buffer.size(),
                             start,
                             end);
-        OIIO_CHECK_EQUAL(start, 0);
-        OIIO_CHECK_EQUAL(end, 1);
+        OCIO_CHECK_EQUAL(start, 0);
+        OCIO_CHECK_EQUAL(end, 1);
     }
     {
         const std::string buffer("\t");
@@ -612,8 +612,8 @@ OIIO_ADD_TEST(XMLReaderHelper, find_sub_string)
                             buffer.size(),
                             start,
                             end);
-        OIIO_CHECK_EQUAL(start, 0);
-        OIIO_CHECK_EQUAL(end, 0);
+        OCIO_CHECK_EQUAL(start, 0);
+        OCIO_CHECK_EQUAL(end, 0);
     }
 }
 

--- a/src/OpenColorIO/ops/Allocation/AllocationOp.cpp
+++ b/src/OpenColorIO/ops/Allocation/AllocationOp.cpp
@@ -136,69 +136,69 @@ OCIO_NAMESPACE_EXIT
 OCIO_NAMESPACE_USING
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(AllocationOps, Create)
+OCIO_ADD_TEST(AllocationOps, Create)
 {
     OpRcPtrVec ops;
     AllocationData allocData;
     allocData.allocation = ALLOCATION_UNKNOWN;
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_FORWARD),
                             OCIO::Exception, "Unsupported Allocation Type");
-    OIIO_CHECK_EQUAL(ops.size(), 0);
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_THROW_WHAT(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_INVERSE),
                             OCIO::Exception, "Unsupported Allocation Type");
-    OIIO_CHECK_EQUAL(ops.size(), 0);
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_THROW_WHAT(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_UNKNOWN),
                             OCIO::Exception, "Unsupported Allocation Type");
-    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_EQUAL(ops.size(), 0);
 
     allocData.allocation = ALLOCATION_UNIFORM;
     // No allocation data leads to identity, not transform will be created
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_UNKNOWN));
-    OIIO_CHECK_EQUAL(ops.size(), 0);
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_NO_THROW(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 0);
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_NO_THROW(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_EQUAL(ops.size(), 0);
 
     // adding data to avoid identity. Fit transform will be created (if valid).
     allocData.vars.push_back(0.0f);
     allocData.vars.push_back(10.0f);
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_UNKNOWN),
                             OCIO::Exception, "unspecified transform direction");
-    OIIO_CHECK_EQUAL(ops.size(), 0);
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_NO_THROW(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops.size(), 1);
     const OpRcPtr forwardFitOp = ops[0];
     ops.clear();
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
     OCIO::ConstOpRcPtr op0 = ops[0];
-    OIIO_CHECK_EQUAL(forwardFitOp->isInverse(op0), true);
+    OCIO_CHECK_EQUAL(forwardFitOp->isInverse(op0), true);
     ops.clear();
 
     allocData.allocation = ALLOCATION_LG2;
 
     // default is not identity
     allocData.vars.clear();
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     OCIO::ConstOpRcPtr op1 = ops[1];
     // second op is a fit transform
-    OIIO_CHECK_EQUAL(forwardFitOp->isSameType(op1), true);
-    OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_EQUAL(forwardFitOp->isSameType(op1), true);
+    OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     ConstOpRcPtr defaultLogOp = ops[0];
     ConstOpRcPtr defaultFitOp = ops[1];
 
@@ -230,7 +230,7 @@ OIIO_ADD_TEST(AllocationOps, Create)
 
     for (unsigned idx = 0; idx<(NB_PIXELS * 4); ++idx)
     {
-        OIIO_CHECK_CLOSE(dstLog[idx], tmp[idx], error);
+        OCIO_CHECK_CLOSE(dstLog[idx], tmp[idx], error);
     }
 
     memcpy(tmp, &src[0], 4 * NB_PIXELS * sizeof(float));
@@ -239,51 +239,51 @@ OIIO_ADD_TEST(AllocationOps, Create)
 
     for (unsigned idx = 0; idx<(NB_PIXELS * 4); ++idx)
     {
-        OIIO_CHECK_CLOSE(dstFit[idx], tmp[idx], error);
+        OCIO_CHECK_CLOSE(dstFit[idx], tmp[idx], error);
     }
 
     ops.clear();
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     op0 = ops[0];
     op1 = ops[1];
-    OIIO_CHECK_EQUAL(defaultFitOp->isInverse(op0), true);
-    OIIO_CHECK_EQUAL(defaultLogOp->isInverse(op1), true);
+    OCIO_CHECK_EQUAL(defaultFitOp->isInverse(op0), true);
+    OCIO_CHECK_EQUAL(defaultLogOp->isInverse(op1), true);
 
     ops.clear();
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_UNKNOWN),
                             OCIO::Exception, "unspecified transform direction");
-    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_EQUAL(ops.size(), 0);
 
     // adding data to target identity, only Log op is created (if valid)
     allocData.vars.push_back(0.0f);
     allocData.vars.push_back(1.0f);
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
     op0 = ops[0];
-    OIIO_CHECK_EQUAL(defaultLogOp->isSameType(op0), true);
+    OCIO_CHECK_EQUAL(defaultLogOp->isSameType(op0), true);
     ops.clear();
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
     op0 = ops[0];
-    OIIO_CHECK_EQUAL(defaultLogOp->isSameType(op0), true);
+    OCIO_CHECK_EQUAL(defaultLogOp->isSameType(op0), true);
     ops.clear();
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_UNKNOWN),
                             OCIO::Exception, "unspecified transform direction");
-    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_EQUAL(ops.size(), 0);
 
     // change log intercept
     allocData.vars.push_back(10.0f);
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateAllocationOps(ops, allocData, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops.size(), 1);
     ops[0]->finalize();
 
     memcpy(tmp, &src[0], 4 * NB_PIXELS * sizeof(float));
@@ -297,7 +297,7 @@ OIIO_ADD_TEST(AllocationOps, Create)
 
     for (unsigned idx = 0; idx<(NB_PIXELS * 4); ++idx)
     {
-        OIIO_CHECK_CLOSE(dstLogShift[idx], tmp[idx], error);
+        OCIO_CHECK_CLOSE(dstLogShift[idx], tmp[idx], error);
     }
 
 }

--- a/src/OpenColorIO/ops/CDL/CDLOpData.cpp
+++ b/src/OpenColorIO/ops/CDL/CDLOpData.cpp
@@ -430,9 +430,9 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(CDLOpData, accessors)
+OCIO_ADD_TEST(CDLOpData, accessors)
 {
     OCIO::CDLOpData::ChannelParams slopeParams(1.35, 1.1, 0.71);
     OCIO::CDLOpData::ChannelParams offsetParams(0.05, -0.23, 0.11);
@@ -446,63 +446,63 @@ OIIO_ADD_TEST(CDLOpData, accessors)
     OCIO::CDLOpData::ChannelParams newSlopeParams(0.66);
     cdlOp.setSlopeParams(newSlopeParams);
 
-    OIIO_CHECK_ASSERT(cdlOp.getSlopeParams() == newSlopeParams);
-    OIIO_CHECK_ASSERT(cdlOp.getOffsetParams() == offsetParams);
-    OIIO_CHECK_ASSERT(cdlOp.getPowerParams() == powerParams);
-    OIIO_CHECK_EQUAL(cdlOp.getSaturation(), 1.23);
+    OCIO_CHECK_ASSERT(cdlOp.getSlopeParams() == newSlopeParams);
+    OCIO_CHECK_ASSERT(cdlOp.getOffsetParams() == offsetParams);
+    OCIO_CHECK_ASSERT(cdlOp.getPowerParams() == powerParams);
+    OCIO_CHECK_EQUAL(cdlOp.getSaturation(), 1.23);
 
     // Update offset parameters with the same value
     OCIO::CDLOpData::ChannelParams newOffsetParams(0.09);
     cdlOp.setOffsetParams(newOffsetParams);
 
-    OIIO_CHECK_ASSERT(cdlOp.getSlopeParams() == newSlopeParams);
-    OIIO_CHECK_ASSERT(cdlOp.getOffsetParams() == newOffsetParams);
-    OIIO_CHECK_ASSERT(cdlOp.getPowerParams() == powerParams);
-    OIIO_CHECK_EQUAL(cdlOp.getSaturation(), 1.23);
+    OCIO_CHECK_ASSERT(cdlOp.getSlopeParams() == newSlopeParams);
+    OCIO_CHECK_ASSERT(cdlOp.getOffsetParams() == newOffsetParams);
+    OCIO_CHECK_ASSERT(cdlOp.getPowerParams() == powerParams);
+    OCIO_CHECK_EQUAL(cdlOp.getSaturation(), 1.23);
 
     // Update power parameters with the same value
     OCIO::CDLOpData::ChannelParams newPowerParams(1.1);
     cdlOp.setPowerParams(newPowerParams);
 
-    OIIO_CHECK_ASSERT(cdlOp.getSlopeParams() == newSlopeParams);
-    OIIO_CHECK_ASSERT(cdlOp.getOffsetParams() == newOffsetParams);
-    OIIO_CHECK_ASSERT(cdlOp.getPowerParams() == newPowerParams);
-    OIIO_CHECK_EQUAL(cdlOp.getSaturation(), 1.23);
+    OCIO_CHECK_ASSERT(cdlOp.getSlopeParams() == newSlopeParams);
+    OCIO_CHECK_ASSERT(cdlOp.getOffsetParams() == newOffsetParams);
+    OCIO_CHECK_ASSERT(cdlOp.getPowerParams() == newPowerParams);
+    OCIO_CHECK_EQUAL(cdlOp.getSaturation(), 1.23);
 
     // Update the saturation parameter
     cdlOp.setSaturation(0.99);
 
-    OIIO_CHECK_ASSERT(cdlOp.getSlopeParams() == newSlopeParams);
-    OIIO_CHECK_ASSERT(cdlOp.getOffsetParams() == newOffsetParams);
-    OIIO_CHECK_ASSERT(cdlOp.getPowerParams() == newPowerParams);
-    OIIO_CHECK_EQUAL(cdlOp.getSaturation(), 0.99);
+    OCIO_CHECK_ASSERT(cdlOp.getSlopeParams() == newSlopeParams);
+    OCIO_CHECK_ASSERT(cdlOp.getOffsetParams() == newOffsetParams);
+    OCIO_CHECK_ASSERT(cdlOp.getPowerParams() == newPowerParams);
+    OCIO_CHECK_EQUAL(cdlOp.getSaturation(), 0.99);
 
 }
 
-OIIO_ADD_TEST(CDLOpData, constructors)
+OCIO_ADD_TEST(CDLOpData, constructors)
 {
     // Check default constructor
     OCIO::CDLOpData cdlOpDefault;
 
-    OIIO_CHECK_EQUAL(cdlOpDefault.getType(), OCIO::CDLOpData::CDLType);
-    OIIO_CHECK_EQUAL(cdlOpDefault.getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(cdlOpDefault.getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(cdlOpDefault.getType(), OCIO::CDLOpData::CDLType);
+    OCIO_CHECK_EQUAL(cdlOpDefault.getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(cdlOpDefault.getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_EQUAL(cdlOpDefault.getID(), "");
-    OIIO_CHECK_ASSERT(cdlOpDefault.getDescriptions().empty());
+    OCIO_CHECK_EQUAL(cdlOpDefault.getID(), "");
+    OCIO_CHECK_ASSERT(cdlOpDefault.getDescriptions().empty());
 
-    OIIO_CHECK_EQUAL(cdlOpDefault.getStyle(),
+    OCIO_CHECK_EQUAL(cdlOpDefault.getStyle(),
                      OCIO::CDLOpData::CDL_V1_2_FWD);
 
-    OIIO_CHECK_ASSERT(!cdlOpDefault.isReverse());
+    OCIO_CHECK_ASSERT(!cdlOpDefault.isReverse());
 
-    OIIO_CHECK_ASSERT(cdlOpDefault.getSlopeParams()
+    OCIO_CHECK_ASSERT(cdlOpDefault.getSlopeParams()
         == OCIO::CDLOpData::ChannelParams(1.0));
-    OIIO_CHECK_ASSERT(cdlOpDefault.getOffsetParams() 
+    OCIO_CHECK_ASSERT(cdlOpDefault.getOffsetParams() 
         == OCIO::CDLOpData::ChannelParams(0.0));
-    OIIO_CHECK_ASSERT(cdlOpDefault.getPowerParams()
+    OCIO_CHECK_ASSERT(cdlOpDefault.getPowerParams()
         == OCIO::CDLOpData::ChannelParams(1.0));
-    OIIO_CHECK_EQUAL(cdlOpDefault.getSaturation(), 1.0);
+    OCIO_CHECK_EQUAL(cdlOpDefault.getSaturation(), 1.0);
 
     // Check complete constructor
     OCIO::OpData::Descriptions descriptions;
@@ -517,28 +517,28 @@ OIIO_ADD_TEST(CDLOpData, constructors)
                                   OCIO::CDLOpData::ChannelParams(0.93, 0.81, 1.27),
                                   1.23);
 
-    OIIO_CHECK_EQUAL(cdlOpComplete.getType(), OCIO::OpData::CDLType);
-    OIIO_CHECK_EQUAL(cdlOpComplete.getInputBitDepth(), OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_EQUAL(cdlOpComplete.getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(cdlOpComplete.getType(), OCIO::OpData::CDLType);
+    OCIO_CHECK_EQUAL(cdlOpComplete.getInputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(cdlOpComplete.getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 
-    OIIO_CHECK_EQUAL(cdlOpComplete.getID(), "test_id");
-    OIIO_CHECK_ASSERT(cdlOpComplete.getDescriptions() == descriptions);
+    OCIO_CHECK_EQUAL(cdlOpComplete.getID(), "test_id");
+    OCIO_CHECK_ASSERT(cdlOpComplete.getDescriptions() == descriptions);
 
-    OIIO_CHECK_EQUAL(cdlOpComplete.getStyle(),
+    OCIO_CHECK_EQUAL(cdlOpComplete.getStyle(),
                      OCIO::CDLOpData::CDL_NO_CLAMP_REV);
 
-    OIIO_CHECK_ASSERT(cdlOpComplete.isReverse());
+    OCIO_CHECK_ASSERT(cdlOpComplete.isReverse());
 
-    OIIO_CHECK_ASSERT(cdlOpComplete.getSlopeParams()
+    OCIO_CHECK_ASSERT(cdlOpComplete.getSlopeParams()
         == OCIO::CDLOpData::ChannelParams(1.35, 1.1, 0.71));
-    OIIO_CHECK_ASSERT(cdlOpComplete.getOffsetParams()
+    OCIO_CHECK_ASSERT(cdlOpComplete.getOffsetParams()
         == OCIO::CDLOpData::ChannelParams(0.05, -0.23, 0.11));
-    OIIO_CHECK_ASSERT(cdlOpComplete.getPowerParams()
+    OCIO_CHECK_ASSERT(cdlOpComplete.getPowerParams()
         == OCIO::CDLOpData::ChannelParams(0.93, 0.81, 1.27));
-    OIIO_CHECK_EQUAL(cdlOpComplete.getSaturation(), 1.23);
+    OCIO_CHECK_EQUAL(cdlOpComplete.getSaturation(), 1.23);
 }
 
-OIIO_ADD_TEST(CDLOpData, inverse)
+OCIO_ADD_TEST(CDLOpData, inverse)
 {
     OCIO::CDLOpData cdlOp(OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_UINT12,
                           "test_id", 
@@ -555,29 +555,29 @@ OIIO_ADD_TEST(CDLOpData, inverse)
         const OCIO::CDLOpDataRcPtr invOp = cdlOp.inverse();
 
         // Ensure bit depths are swapped
-        OIIO_CHECK_EQUAL(invOp->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-        OIIO_CHECK_EQUAL(invOp->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
+        OCIO_CHECK_EQUAL(invOp->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+        OCIO_CHECK_EQUAL(invOp->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
 
         // Ensure id, name and descriptions are empty
-        OIIO_CHECK_EQUAL(invOp->getID(), "");
-        OIIO_CHECK_ASSERT(invOp->getDescriptions().empty());
+        OCIO_CHECK_EQUAL(invOp->getID(), "");
+        OCIO_CHECK_ASSERT(invOp->getDescriptions().empty());
 
         // Ensure style is inverted
-        OIIO_CHECK_EQUAL(invOp->getStyle(), OCIO::CDLOpData::CDL_V1_2_REV);
+        OCIO_CHECK_EQUAL(invOp->getStyle(), OCIO::CDLOpData::CDL_V1_2_REV);
 
-        OIIO_CHECK_ASSERT(invOp->isReverse());
+        OCIO_CHECK_ASSERT(invOp->isReverse());
 
         // Ensure CDL parameters are unchanged
-        OIIO_CHECK_ASSERT(invOp->getSlopeParams()
+        OCIO_CHECK_ASSERT(invOp->getSlopeParams()
                           == OCIO::CDLOpData::ChannelParams(1.35, 1.1, 0.71));
 
-        OIIO_CHECK_ASSERT(invOp->getOffsetParams()
+        OCIO_CHECK_ASSERT(invOp->getOffsetParams()
                          == OCIO::CDLOpData::ChannelParams(0.05, -0.23, 0.11));
 
-        OIIO_CHECK_ASSERT(invOp->getPowerParams()
+        OCIO_CHECK_ASSERT(invOp->getPowerParams()
                           == OCIO::CDLOpData::ChannelParams(0.93, 0.81, 1.27));
 
-        OIIO_CHECK_EQUAL(invOp->getSaturation(), 1.23);
+        OCIO_CHECK_EQUAL(invOp->getSaturation(), 1.23);
     }
 
     // Test CDL_V1_2_REV inverse
@@ -586,29 +586,29 @@ OIIO_ADD_TEST(CDLOpData, inverse)
         const OCIO::CDLOpDataRcPtr invOp = cdlOp.inverse();
 
         // Ensure bit depths are swapped
-        OIIO_CHECK_EQUAL(invOp->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-        OIIO_CHECK_EQUAL(invOp->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
+        OCIO_CHECK_EQUAL(invOp->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+        OCIO_CHECK_EQUAL(invOp->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
 
         // Ensure id, name and descriptions are empty
-        OIIO_CHECK_EQUAL(invOp->getID(), "");
-        OIIO_CHECK_ASSERT(invOp->getDescriptions().empty());
+        OCIO_CHECK_EQUAL(invOp->getID(), "");
+        OCIO_CHECK_ASSERT(invOp->getDescriptions().empty());
 
         // Ensure style is inverted
-        OIIO_CHECK_EQUAL(invOp->getStyle(), OCIO::CDLOpData::CDL_V1_2_FWD);
+        OCIO_CHECK_EQUAL(invOp->getStyle(), OCIO::CDLOpData::CDL_V1_2_FWD);
 
-        OIIO_CHECK_EQUAL(invOp->isReverse(), false);
+        OCIO_CHECK_EQUAL(invOp->isReverse(), false);
 
         // Ensure CDL parameters are unchanged
-        OIIO_CHECK_ASSERT(invOp->getSlopeParams()
+        OCIO_CHECK_ASSERT(invOp->getSlopeParams()
                           == OCIO::CDLOpData::ChannelParams(1.35, 1.1, 0.71));
 
-        OIIO_CHECK_ASSERT(invOp->getOffsetParams()
+        OCIO_CHECK_ASSERT(invOp->getOffsetParams()
                           == OCIO::CDLOpData::ChannelParams(0.05, -0.23, 0.11));
 
-        OIIO_CHECK_ASSERT(invOp->getPowerParams()
+        OCIO_CHECK_ASSERT(invOp->getPowerParams()
                           == OCIO::CDLOpData::ChannelParams(0.93, 0.81, 1.27));
 
-        OIIO_CHECK_EQUAL(invOp->getSaturation(), 1.23);
+        OCIO_CHECK_EQUAL(invOp->getSaturation(), 1.23);
     }
 
     // Test CDL_NO_CLAMP_FWD inverse
@@ -617,28 +617,28 @@ OIIO_ADD_TEST(CDLOpData, inverse)
         const OCIO::CDLOpDataRcPtr invOp = cdlOp.inverse();
 
         // Ensure bit depths are swapped
-        OIIO_CHECK_EQUAL(invOp->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-        OIIO_CHECK_EQUAL(invOp->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
+        OCIO_CHECK_EQUAL(invOp->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+        OCIO_CHECK_EQUAL(invOp->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
 
         // Ensure id, name and descriptions are empty
-        OIIO_CHECK_EQUAL(invOp->getID(), "");
-        OIIO_CHECK_ASSERT(invOp->getDescriptions().empty());
+        OCIO_CHECK_EQUAL(invOp->getID(), "");
+        OCIO_CHECK_ASSERT(invOp->getDescriptions().empty());
 
         // Ensure style is inverted
-        OIIO_CHECK_EQUAL(invOp->getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_REV);
-        OIIO_CHECK_ASSERT(invOp->isReverse());
+        OCIO_CHECK_EQUAL(invOp->getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_REV);
+        OCIO_CHECK_ASSERT(invOp->isReverse());
 
         // Ensure CDL parameters are unchanged
-        OIIO_CHECK_ASSERT(invOp->getSlopeParams()
+        OCIO_CHECK_ASSERT(invOp->getSlopeParams()
                            == OCIO::CDLOpData::ChannelParams(1.35, 1.1, 0.71));
 
-        OIIO_CHECK_ASSERT(invOp->getOffsetParams()
+        OCIO_CHECK_ASSERT(invOp->getOffsetParams()
                            == OCIO::CDLOpData::ChannelParams(0.05, -0.23, 0.11));
 
-        OIIO_CHECK_ASSERT(invOp->getPowerParams()
+        OCIO_CHECK_ASSERT(invOp->getPowerParams()
                            == OCIO::CDLOpData::ChannelParams(0.93, 0.81, 1.27));
 
-        OIIO_CHECK_EQUAL(invOp->getSaturation(), 1.23);
+        OCIO_CHECK_EQUAL(invOp->getSaturation(), 1.23);
     }
 
     // Test CDL_NO_CLAMP_REV inverse
@@ -647,65 +647,65 @@ OIIO_ADD_TEST(CDLOpData, inverse)
         const OCIO::CDLOpDataRcPtr invOp = cdlOp.inverse();
 
         // Ensure bit depths are swapped
-        OIIO_CHECK_EQUAL(invOp->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-        OIIO_CHECK_EQUAL(invOp->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
+        OCIO_CHECK_EQUAL(invOp->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+        OCIO_CHECK_EQUAL(invOp->getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
 
         // Ensure id, name and descriptions are empty
-        OIIO_CHECK_EQUAL(invOp->getID(), "");
-        OIIO_CHECK_ASSERT(invOp->getDescriptions().empty());
+        OCIO_CHECK_EQUAL(invOp->getID(), "");
+        OCIO_CHECK_ASSERT(invOp->getDescriptions().empty());
 
         // Ensure style is inverted
-        OIIO_CHECK_EQUAL(invOp->getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_FWD);
-        OIIO_CHECK_ASSERT(!invOp->isReverse());
+        OCIO_CHECK_EQUAL(invOp->getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_FWD);
+        OCIO_CHECK_ASSERT(!invOp->isReverse());
 
         // Ensure CDL parameters are unchanged
-        OIIO_CHECK_ASSERT(invOp->getSlopeParams()
+        OCIO_CHECK_ASSERT(invOp->getSlopeParams()
                           == OCIO::CDLOpData::ChannelParams(1.35, 1.1, 0.71));
 
-        OIIO_CHECK_ASSERT(invOp->getOffsetParams()
+        OCIO_CHECK_ASSERT(invOp->getOffsetParams()
                           == OCIO::CDLOpData::ChannelParams(0.05, -0.23, 0.11));
 
-        OIIO_CHECK_ASSERT(invOp->getPowerParams()
+        OCIO_CHECK_ASSERT(invOp->getPowerParams()
                           == OCIO::CDLOpData::ChannelParams(0.93, 0.81, 1.27));
 
-        OIIO_CHECK_EQUAL(invOp->getSaturation(), 1.23);
+        OCIO_CHECK_EQUAL(invOp->getSaturation(), 1.23);
     }
 }
 
 
-OIIO_ADD_TEST(CDLOpData, style)
+OCIO_ADD_TEST(CDLOpData, style)
 {
     // Check default constructor
     OCIO::CDLOpData cdlOp;
 
     // Check CDL_V1_2_FWD
     cdlOp.setStyle(OCIO::CDLOpData::CDL_V1_2_FWD);
-    OIIO_CHECK_EQUAL(cdlOp.getStyle(), OCIO::CDLOpData::CDL_V1_2_FWD);
-    OIIO_CHECK_ASSERT(!cdlOp.isReverse());
+    OCIO_CHECK_EQUAL(cdlOp.getStyle(), OCIO::CDLOpData::CDL_V1_2_FWD);
+    OCIO_CHECK_ASSERT(!cdlOp.isReverse());
 
     // Check CDL_V1_2_REV
     cdlOp.setStyle(OCIO::CDLOpData::CDL_V1_2_REV);
-    OIIO_CHECK_EQUAL(cdlOp.getStyle(), OCIO::CDLOpData::CDL_V1_2_REV);
-    OIIO_CHECK_ASSERT(cdlOp.isReverse());
+    OCIO_CHECK_EQUAL(cdlOp.getStyle(), OCIO::CDLOpData::CDL_V1_2_REV);
+    OCIO_CHECK_ASSERT(cdlOp.isReverse());
 
     // Check CDL_NO_CLAMP_FWD
     cdlOp.setStyle(OCIO::CDLOpData::CDL_NO_CLAMP_FWD);
-    OIIO_CHECK_EQUAL(cdlOp.getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_FWD);
-    OIIO_CHECK_ASSERT(!cdlOp.isReverse());
+    OCIO_CHECK_EQUAL(cdlOp.getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_FWD);
+    OCIO_CHECK_ASSERT(!cdlOp.isReverse());
 
     // Check CDL_NO_CLAMP_REV
     cdlOp.setStyle(OCIO::CDLOpData::CDL_NO_CLAMP_REV);
-    OIIO_CHECK_EQUAL(cdlOp.getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_REV);
-    OIIO_CHECK_ASSERT(cdlOp.isReverse());
+    OCIO_CHECK_EQUAL(cdlOp.getStyle(), OCIO::CDLOpData::CDL_NO_CLAMP_REV);
+    OCIO_CHECK_ASSERT(cdlOp.isReverse());
 
     // Check unknown style
-    OIIO_CHECK_THROW_WHAT(OCIO::CDLOpData::GetStyle("unknown_style"),
+    OCIO_CHECK_THROW_WHAT(OCIO::CDLOpData::GetStyle("unknown_style"),
                           OCIO::Exception, 
                           "Unknown style for CDL");
 }
 
 
-OIIO_ADD_TEST(CDLOpData, validation_success)
+OCIO_ADD_TEST(CDLOpData, validation_success)
 {
     OCIO::CDLOpData cdlOp;
 
@@ -721,10 +721,10 @@ OIIO_ADD_TEST(CDLOpData, validation_success)
     cdlOp.setPowerParams(powerParams);
     cdlOp.setSaturation(1.22);
 
-    OIIO_CHECK_ASSERT(!cdlOp.isIdentity());
-    OIIO_CHECK_ASSERT(!cdlOp.isNoOp());
+    OCIO_CHECK_ASSERT(!cdlOp.isIdentity());
+    OCIO_CHECK_ASSERT(!cdlOp.isNoOp());
 
-    OIIO_CHECK_NO_THROW(cdlOp.validate());
+    OCIO_CHECK_NO_THROW(cdlOp.validate());
 
     // Set an identity operation
     cdlOp.setSlopeParams(OCIO::kOneParams);
@@ -732,14 +732,14 @@ OIIO_ADD_TEST(CDLOpData, validation_success)
     cdlOp.setPowerParams(OCIO::kOneParams);
     cdlOp.setSaturation(1.0);
 
-    OIIO_CHECK_ASSERT(cdlOp.isIdentity());
-    OIIO_CHECK_ASSERT(!cdlOp.isNoOp());
+    OCIO_CHECK_ASSERT(cdlOp.isIdentity());
+    OCIO_CHECK_ASSERT(!cdlOp.isNoOp());
     // Set to non clamping
     cdlOp.setStyle(OCIO::CDLOpData::CDL_NO_CLAMP_FWD);
-    OIIO_CHECK_ASSERT(cdlOp.isIdentity());
-    OIIO_CHECK_ASSERT(cdlOp.isNoOp());
+    OCIO_CHECK_ASSERT(cdlOp.isIdentity());
+    OCIO_CHECK_ASSERT(cdlOp.isNoOp());
 
-    OIIO_CHECK_NO_THROW(cdlOp.validate());
+    OCIO_CHECK_NO_THROW(cdlOp.validate());
 
     // Check for slope = 0
     cdlOp.setSlopeParams(OCIO::CDLOpData::ChannelParams(0.0));
@@ -749,10 +749,10 @@ OIIO_ADD_TEST(CDLOpData, validation_success)
 
     cdlOp.setStyle(OCIO::CDLOpData::CDL_V1_2_FWD);
 
-    OIIO_CHECK_ASSERT(!cdlOp.isIdentity());
-    OIIO_CHECK_ASSERT(!cdlOp.isNoOp());
+    OCIO_CHECK_ASSERT(!cdlOp.isIdentity());
+    OCIO_CHECK_ASSERT(!cdlOp.isNoOp());
 
-    OIIO_CHECK_NO_THROW(cdlOp.validate());
+    OCIO_CHECK_NO_THROW(cdlOp.validate());
 
     // Check for saturation = 0
     cdlOp.setSlopeParams(slopeParams);
@@ -760,13 +760,13 @@ OIIO_ADD_TEST(CDLOpData, validation_success)
     cdlOp.setPowerParams(powerParams);
     cdlOp.setSaturation(0.0);
 
-    OIIO_CHECK_ASSERT(!cdlOp.isIdentity());
-    OIIO_CHECK_ASSERT(!cdlOp.isNoOp());
+    OCIO_CHECK_ASSERT(!cdlOp.isIdentity());
+    OCIO_CHECK_ASSERT(!cdlOp.isNoOp());
 
-    OIIO_CHECK_NO_THROW(cdlOp.validate());
+    OCIO_CHECK_NO_THROW(cdlOp.validate());
 }
 
-OIIO_ADD_TEST(CDLOpData, validation_failure)
+OCIO_ADD_TEST(CDLOpData, validation_failure)
 {
     OCIO::CDLOpData cdlOp;
 
@@ -776,7 +776,7 @@ OIIO_ADD_TEST(CDLOpData, validation_failure)
     cdlOp.setPowerParams(OCIO::CDLOpData::ChannelParams(1.2));
     cdlOp.setSaturation(1.17);
 
-    OIIO_CHECK_THROW_WHAT(cdlOp.validate(), OCIO::Exception, "should be greater than 0");
+    OCIO_CHECK_THROW_WHAT(cdlOp.validate(), OCIO::Exception, "should be greater than 0");
 
     // Fail: invalid power
     cdlOp.setSlopeParams(OCIO::CDLOpData::ChannelParams(0.9));
@@ -784,7 +784,7 @@ OIIO_ADD_TEST(CDLOpData, validation_failure)
     cdlOp.setPowerParams(OCIO::CDLOpData::ChannelParams(-1.2));
     cdlOp.setSaturation(1.17);
 
-    OIIO_CHECK_THROW_WHAT(cdlOp.validate(), OCIO::Exception, "should be greater than 0");
+    OCIO_CHECK_THROW_WHAT(cdlOp.validate(), OCIO::Exception, "should be greater than 0");
 
     // Fail: invalid saturation
     cdlOp.setSlopeParams(OCIO::CDLOpData::ChannelParams(0.9));
@@ -792,7 +792,7 @@ OIIO_ADD_TEST(CDLOpData, validation_failure)
     cdlOp.setPowerParams(OCIO::CDLOpData::ChannelParams(1.2));
     cdlOp.setSaturation(-1.17);
 
-    OIIO_CHECK_THROW_WHAT(cdlOp.validate(), OCIO::Exception, "should be greater than 0");
+    OCIO_CHECK_THROW_WHAT(cdlOp.validate(), OCIO::Exception, "should be greater than 0");
 
     // Check for power = 0
     cdlOp.setSlopeParams(OCIO::CDLOpData::ChannelParams(0.7));
@@ -800,18 +800,18 @@ OIIO_ADD_TEST(CDLOpData, validation_failure)
     cdlOp.setPowerParams(OCIO::CDLOpData::ChannelParams(0.0));
     cdlOp.setSaturation(1.4);
 
-    OIIO_CHECK_THROW_WHAT(cdlOp.validate(), OCIO::Exception, "should be greater than 0");
+    OCIO_CHECK_THROW_WHAT(cdlOp.validate(), OCIO::Exception, "should be greater than 0");
 }
 
 // TODO: CDLOp_inverse_bypass_test is missing
 
-OIIO_ADD_TEST(CDLOpData, channel)
+OCIO_ADD_TEST(CDLOpData, channel)
 {
   {
     OCIO::CDLOpData cdlOp;
 
     // False: identity
-    OIIO_CHECK_ASSERT(!cdlOp.hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(!cdlOp.hasChannelCrosstalk());
   }
 
   {
@@ -821,7 +821,7 @@ OIIO_ADD_TEST(CDLOpData, channel)
     cdlOp.setPowerParams(OCIO::CDLOpData::ChannelParams(1.2));
 
     // False: slope, offset, and power 
-    OIIO_CHECK_ASSERT(!cdlOp.hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(!cdlOp.hasChannelCrosstalk());
   }
 
   {
@@ -829,7 +829,7 @@ OIIO_ADD_TEST(CDLOpData, channel)
     cdlOp.setSaturation(1.17);
 
     // True: saturation
-    OIIO_CHECK_ASSERT(cdlOp.hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(cdlOp.hasChannelCrosstalk());
   }
 }
 

--- a/src/OpenColorIO/ops/CDL/CDLOps.cpp
+++ b/src/OpenColorIO/ops/CDL/CDLOps.cpp
@@ -417,7 +417,7 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 
 #include <limits>
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
 OCIO_NAMESPACE_USING
@@ -434,7 +434,7 @@ void ApplyCDL(float * in, const float * ref, unsigned numPixels,
                       style, slope, offset, power, saturation, 
                       OCIO::TRANSFORM_DIR_FORWARD);
 
-    OIIO_CHECK_NO_THROW(cdlOp.finalize());
+    OCIO_CHECK_NO_THROW(cdlOp.finalize());
 
     cdlOp.apply(in, in, numPixels);
 
@@ -453,7 +453,7 @@ void ApplyCDL(float * in, const float * ref, unsigned numPixels,
             message << "Index: " << idx;
             message << " - Values: " << in[idx] << " and: " << ref[idx];
             message << " - Threshold: " << errorThreshold;
-            OIIO_CHECK_ASSERT_MESSAGE(0, message.str());
+            OCIO_CHECK_ASSERT_MESSAGE(0, message.str());
         }
     }
 
@@ -471,7 +471,7 @@ namespace CDL_DATA_1
     const double saturation = 1.23;
 };
 
-OIIO_ADD_TEST(CDLOps, computed_identifier)
+OCIO_ADD_TEST(CDLOps, computed_identifier)
 {
     OpRcPtrVec ops;
 
@@ -481,7 +481,7 @@ OIIO_ADD_TEST(CDLOps, computed_identifier)
                 CDL_DATA_1::slope, CDL_DATA_1::offset,
                 CDL_DATA_1::power, CDL_DATA_1::saturation, 
                 OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
 
     CreateCDLOp(ops, 
                 "", OCIO::OpData::Descriptions(),
@@ -489,12 +489,12 @@ OIIO_ADD_TEST(CDLOps, computed_identifier)
                 CDL_DATA_1::slope, CDL_DATA_1::offset,
                 CDL_DATA_1::power, CDL_DATA_1::saturation, 
                 OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
 
-    OIIO_CHECK_NO_THROW( ops[0]->finalize() );
-    OIIO_CHECK_NO_THROW( ops[1]->finalize() );
+    OCIO_CHECK_NO_THROW( ops[0]->finalize() );
+    OCIO_CHECK_NO_THROW( ops[1]->finalize() );
 
-    OIIO_CHECK_EQUAL( ops[0]->getCacheID(), ops[1]->getCacheID() );
+    OCIO_CHECK_EQUAL( ops[0]->getCacheID(), ops[1]->getCacheID() );
 
 
     CreateCDLOp(ops, 
@@ -503,26 +503,12 @@ OIIO_ADD_TEST(CDLOps, computed_identifier)
                 CDL_DATA_1::slope, CDL_DATA_1::offset,
                 CDL_DATA_1::power, CDL_DATA_1::saturation, 
                 OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_REQUIRE_EQUAL(ops.size(), 3);
+    OCIO_REQUIRE_EQUAL(ops.size(), 3);
 
-    OIIO_CHECK_NO_THROW( ops[2]->finalize() );
+    OCIO_CHECK_NO_THROW( ops[2]->finalize() );
 
-    OIIO_CHECK_ASSERT( ops[0]->getCacheID() != ops[2]->getCacheID() );
-    OIIO_CHECK_ASSERT( ops[1]->getCacheID() != ops[2]->getCacheID() );
-
-    CreateCDLOp(ops, 
-                "1", OCIO::OpData::Descriptions(),
-                OCIO::CDLOpData::CDL_V1_2_FWD, 
-                CDL_DATA_1::slope, CDL_DATA_1::offset,
-                CDL_DATA_1::power, CDL_DATA_1::saturation + 0.002f, 
-                OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_REQUIRE_EQUAL(ops.size(), 4);
-
-    OIIO_CHECK_NO_THROW( ops[3]->finalize() );
-
-    OIIO_CHECK_ASSERT( ops[0]->getCacheID() != ops[3]->getCacheID() );
-    OIIO_CHECK_ASSERT( ops[1]->getCacheID() != ops[3]->getCacheID() );
-    OIIO_CHECK_ASSERT( ops[2]->getCacheID() != ops[3]->getCacheID() );
+    OCIO_CHECK_ASSERT( ops[0]->getCacheID() != ops[2]->getCacheID() );
+    OCIO_CHECK_ASSERT( ops[1]->getCacheID() != ops[2]->getCacheID() );
 
     CreateCDLOp(ops, 
                 "1", OCIO::OpData::Descriptions(),
@@ -530,14 +516,28 @@ OIIO_ADD_TEST(CDLOps, computed_identifier)
                 CDL_DATA_1::slope, CDL_DATA_1::offset,
                 CDL_DATA_1::power, CDL_DATA_1::saturation + 0.002f, 
                 OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_REQUIRE_EQUAL(ops.size(), 5);
+    OCIO_REQUIRE_EQUAL(ops.size(), 4);
 
-    OIIO_CHECK_NO_THROW( ops[4]->finalize() );
+    OCIO_CHECK_NO_THROW( ops[3]->finalize() );
 
-    OIIO_CHECK_ASSERT( ops[0]->getCacheID() != ops[4]->getCacheID() );
-    OIIO_CHECK_ASSERT( ops[1]->getCacheID() != ops[4]->getCacheID() );
-    OIIO_CHECK_ASSERT( ops[2]->getCacheID() != ops[4]->getCacheID() );
-    OIIO_CHECK_ASSERT( ops[3]->getCacheID() == ops[4]->getCacheID() );
+    OCIO_CHECK_ASSERT( ops[0]->getCacheID() != ops[3]->getCacheID() );
+    OCIO_CHECK_ASSERT( ops[1]->getCacheID() != ops[3]->getCacheID() );
+    OCIO_CHECK_ASSERT( ops[2]->getCacheID() != ops[3]->getCacheID() );
+
+    CreateCDLOp(ops, 
+                "1", OCIO::OpData::Descriptions(),
+                OCIO::CDLOpData::CDL_V1_2_FWD, 
+                CDL_DATA_1::slope, CDL_DATA_1::offset,
+                CDL_DATA_1::power, CDL_DATA_1::saturation + 0.002f, 
+                OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_REQUIRE_EQUAL(ops.size(), 5);
+
+    OCIO_CHECK_NO_THROW( ops[4]->finalize() );
+
+    OCIO_CHECK_ASSERT( ops[0]->getCacheID() != ops[4]->getCacheID() );
+    OCIO_CHECK_ASSERT( ops[1]->getCacheID() != ops[4]->getCacheID() );
+    OCIO_CHECK_ASSERT( ops[2]->getCacheID() != ops[4]->getCacheID() );
+    OCIO_CHECK_ASSERT( ops[3]->getCacheID() == ops[4]->getCacheID() );
 
     CreateCDLOp(ops, 
                 "1", OCIO::OpData::Descriptions(),
@@ -545,15 +545,15 @@ OIIO_ADD_TEST(CDLOps, computed_identifier)
                 CDL_DATA_1::slope, CDL_DATA_1::offset,
                 CDL_DATA_1::power, CDL_DATA_1::saturation + 0.002f, 
                 OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_REQUIRE_EQUAL(ops.size(), 6);
+    OCIO_REQUIRE_EQUAL(ops.size(), 6);
 
-    OIIO_CHECK_NO_THROW( ops[5]->finalize() );
+    OCIO_CHECK_NO_THROW( ops[5]->finalize() );
 
-    OIIO_CHECK_ASSERT( ops[3]->getCacheID() != ops[5]->getCacheID() );
-    OIIO_CHECK_ASSERT( ops[4]->getCacheID() != ops[5]->getCacheID() );
+    OCIO_CHECK_ASSERT( ops[3]->getCacheID() != ops[5]->getCacheID() );
+    OCIO_CHECK_ASSERT( ops[4]->getCacheID() != ops[5]->getCacheID() );
 }
 
-OIIO_ADD_TEST(CDLOps, is_inverse)
+OCIO_ADD_TEST(CDLOps, is_inverse)
 {
     OpRcPtrVec ops;
 
@@ -563,7 +563,7 @@ OIIO_ADD_TEST(CDLOps, is_inverse)
                 CDL_DATA_1::slope, CDL_DATA_1::offset,
                 CDL_DATA_1::power, CDL_DATA_1::saturation, 
                 OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
 
     CreateCDLOp(ops, 
                 "", OCIO::OpData::Descriptions(),
@@ -571,13 +571,13 @@ OIIO_ADD_TEST(CDLOps, is_inverse)
                 CDL_DATA_1::slope, CDL_DATA_1::offset,
                 CDL_DATA_1::power, CDL_DATA_1::saturation, 
                 OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
 
     OCIO::ConstOpRcPtr op0 = ops[0];
     OCIO::ConstOpRcPtr op1 = ops[1];
 
-    OIIO_CHECK_ASSERT(ops[0]->isInverse(op1));
-    OIIO_CHECK_ASSERT(ops[1]->isInverse(op0));
+    OCIO_CHECK_ASSERT(ops[0]->isInverse(op1));
+    OCIO_CHECK_ASSERT(ops[1]->isInverse(op0));
 
     CreateCDLOp(ops, 
                 "", OCIO::OpData::Descriptions(),
@@ -585,13 +585,13 @@ OIIO_ADD_TEST(CDLOps, is_inverse)
                 CDL_DATA_1::slope, CDL_DATA_1::offset, 
                 CDL_DATA_1::power, 1.30, 
                 OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_REQUIRE_EQUAL(ops.size(), 3);
+    OCIO_REQUIRE_EQUAL(ops.size(), 3);
     OCIO::ConstOpRcPtr op2 = ops[2];
 
-    OIIO_CHECK_ASSERT(!ops[0]->isInverse(op2));
-    OIIO_CHECK_ASSERT(!ops[1]->isInverse(op2));
-    OIIO_CHECK_ASSERT(!ops[2]->isInverse(op0));
-    OIIO_CHECK_ASSERT(!ops[2]->isInverse(op1));
+    OCIO_CHECK_ASSERT(!ops[0]->isInverse(op2));
+    OCIO_CHECK_ASSERT(!ops[1]->isInverse(op2));
+    OCIO_CHECK_ASSERT(!ops[2]->isInverse(op0));
+    OCIO_CHECK_ASSERT(!ops[2]->isInverse(op1));
 
     CreateCDLOp(ops, 
                 "", OCIO::OpData::Descriptions(),
@@ -599,10 +599,10 @@ OIIO_ADD_TEST(CDLOps, is_inverse)
                 CDL_DATA_1::slope, CDL_DATA_1::offset, 
                 CDL_DATA_1::power, 1.30, 
                 OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_REQUIRE_EQUAL(ops.size(), 4);
+    OCIO_REQUIRE_EQUAL(ops.size(), 4);
     OCIO::ConstOpRcPtr op3 = ops[3];
 
-    OIIO_CHECK_ASSERT(ops[2]->isInverse(op3));
+    OCIO_CHECK_ASSERT(ops[2]->isInverse(op3));
 
     CreateCDLOp(ops, 
                 "", OCIO::OpData::Descriptions(),
@@ -610,11 +610,11 @@ OIIO_ADD_TEST(CDLOps, is_inverse)
                 CDL_DATA_1::slope, CDL_DATA_1::offset, 
                 CDL_DATA_1::power, 1.30, 
                 OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_REQUIRE_EQUAL(ops.size(), 5);
+    OCIO_REQUIRE_EQUAL(ops.size(), 5);
     OCIO::ConstOpRcPtr op4 = ops[4];
 
-    OIIO_CHECK_ASSERT(!ops[2]->isInverse(op4));
-    OIIO_CHECK_ASSERT(ops[3]->isInverse(op4));
+    OCIO_CHECK_ASSERT(!ops[2]->isInverse(op4));
+    OCIO_CHECK_ASSERT(ops[3]->isInverse(op4));
 
     CreateCDLOp(ops, 
                 "", OCIO::OpData::Descriptions(),
@@ -622,12 +622,12 @@ OIIO_ADD_TEST(CDLOps, is_inverse)
                 CDL_DATA_1::slope, CDL_DATA_1::offset, 
                 CDL_DATA_1::power, 1.30, 
                 OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_REQUIRE_EQUAL(ops.size(), 6);
+    OCIO_REQUIRE_EQUAL(ops.size(), 6);
     OCIO::ConstOpRcPtr op5 = ops[5];
 
-    OIIO_CHECK_ASSERT(!ops[2]->isInverse(op5));
-    OIIO_CHECK_ASSERT(!ops[3]->isInverse(op5));
-    OIIO_CHECK_ASSERT(!ops[4]->isInverse(op5));
+    OCIO_CHECK_ASSERT(!ops[2]->isInverse(op5));
+    OCIO_CHECK_ASSERT(!ops[3]->isInverse(op5));
+    OCIO_CHECK_ASSERT(!ops[4]->isInverse(op5));
 
     CreateCDLOp(ops, 
                 "", OCIO::OpData::Descriptions(),
@@ -635,13 +635,13 @@ OIIO_ADD_TEST(CDLOps, is_inverse)
                 CDL_DATA_1::slope, CDL_DATA_1::offset, 
                 CDL_DATA_1::power, 1.30, 
                 OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_REQUIRE_EQUAL(ops.size(), 7);
+    OCIO_REQUIRE_EQUAL(ops.size(), 7);
     OCIO::ConstOpRcPtr op6 = ops[6];
 
-    OIIO_CHECK_ASSERT(!ops[2]->isInverse(op6));
-    OIIO_CHECK_ASSERT(!ops[3]->isInverse(op6));
-    OIIO_CHECK_ASSERT(!ops[4]->isInverse(op6));
-    OIIO_CHECK_ASSERT(ops[5]->isInverse(op6));
+    OCIO_CHECK_ASSERT(!ops[2]->isInverse(op6));
+    OCIO_CHECK_ASSERT(!ops[3]->isInverse(op6));
+    OCIO_CHECK_ASSERT(!ops[4]->isInverse(op6));
+    OCIO_CHECK_ASSERT(ops[5]->isInverse(op6));
 }
 
 // The expected values below were calculated via an independent ASC CDL
@@ -651,7 +651,7 @@ OIIO_ADD_TEST(CDLOps, is_inverse)
 // of the power function.
 // TODO: The NaN and Inf handling is probably not ideal, as shown by the 
 // tests below, and could be improved.
-OIIO_ADD_TEST(CDLOps, apply_clamp_fwd)
+OCIO_ADD_TEST(CDLOps, apply_clamp_fwd)
 {
     const float qnan = std::numeric_limits<float>::quiet_NaN();
     const float inf = std::numeric_limits<float>::infinity();
@@ -690,7 +690,7 @@ OIIO_ADD_TEST(CDLOps, apply_clamp_fwd)
 #endif
 }
 
-OIIO_ADD_TEST(CDLOps, apply_clamp_rev)
+OCIO_ADD_TEST(CDLOps, apply_clamp_rev)
 {
     const float qnan = std::numeric_limits<float>::quiet_NaN();
     const float inf = std::numeric_limits<float>::infinity();
@@ -729,7 +729,7 @@ OIIO_ADD_TEST(CDLOps, apply_clamp_rev)
 #endif
 }
 
-OIIO_ADD_TEST(CDLOps, apply_noclamp_fwd)
+OCIO_ADD_TEST(CDLOps, apply_noclamp_fwd)
 {
     const float qnan = std::numeric_limits<float>::quiet_NaN();
     const float inf = std::numeric_limits<float>::infinity();
@@ -768,7 +768,7 @@ OIIO_ADD_TEST(CDLOps, apply_noclamp_fwd)
 #endif
 }
 
-OIIO_ADD_TEST(CDLOps, apply_noclamp_rev)
+OCIO_ADD_TEST(CDLOps, apply_noclamp_rev)
 {
     const float qnan = std::numeric_limits<float>::quiet_NaN();
     const float inf = std::numeric_limits<float>::infinity();
@@ -815,7 +815,7 @@ namespace CDL_DATA_2
     const double saturation = 0.87;
 };
 
-OIIO_ADD_TEST(CDLOps, apply_clamp_fwd_2)
+OCIO_ADD_TEST(CDLOps, apply_clamp_fwd_2)
 {
     const float qnan = std::numeric_limits<float>::quiet_NaN();
     const float inf = std::numeric_limits<float>::infinity();
@@ -856,7 +856,7 @@ namespace CDL_DATA_3
     const double saturation = 0.99;
 };
 
-OIIO_ADD_TEST(CDLOps, apply_clamp_fwd_3)
+OCIO_ADD_TEST(CDLOps, apply_clamp_fwd_3)
 {
     const float qnan = std::numeric_limits<float>::quiet_NaN();
     const float inf = std::numeric_limits<float>::infinity();
@@ -923,7 +923,7 @@ OIIO_ADD_TEST(CDLOps, apply_clamp_fwd_3)
 #endif
 }
 
-OIIO_ADD_TEST(CDLOps, apply_noclamp_fwd_3)
+OCIO_ADD_TEST(CDLOps, apply_noclamp_fwd_3)
 {
     const float qnan = std::numeric_limits<float>::quiet_NaN();
     const float inf = std::numeric_limits<float>::infinity();

--- a/src/OpenColorIO/ops/Exponent/ExponentOps.cpp
+++ b/src/OpenColorIO/ops/Exponent/ExponentOps.cpp
@@ -330,23 +330,23 @@ OCIO_NAMESPACE_EXIT
 
 #ifdef OCIO_UNIT_TEST
 
-#include "unittest.h"
+#include "UnitTest.h"
 #include "ops/NoOp/NoOps.h"
 
 OCIO_NAMESPACE_USING
 
-OIIO_ADD_TEST(ExponentOps, Value)
+OCIO_ADD_TEST(ExponentOps, Value)
 {
     const double exp1[4] = { 1.2, 1.3, 1.4, 1.5 };
     
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_EQUAL(ops.size(), 2);
     
     for(unsigned int i=0; i<ops.size(); ++i)
     {
-        OIIO_CHECK_NO_THROW(ops[i]->finalize());
+        OCIO_CHECK_NO_THROW(ops[i]->finalize());
     }
     
     float error = 1e-6f;
@@ -362,13 +362,13 @@ OIIO_ADD_TEST(ExponentOps, Value)
     
     for(unsigned int i=0; i<4; ++i)
     {
-        OIIO_CHECK_CLOSE(tmp[i], result1[i], error);
+        OCIO_CHECK_CLOSE(tmp[i], result1[i], error);
     }
     
     ops[1]->apply(tmp, tmp, 1);
     for(unsigned int i=0; i<4; ++i)
     {
-        OIIO_CHECK_CLOSE(tmp[i], source[i], error);
+        OCIO_CHECK_CLOSE(tmp[i], source[i], error);
     }
 }
 
@@ -380,18 +380,18 @@ void ValidateOp(const float * source, const OpRcPtr op, const float * result, co
 
     for (unsigned int i = 0; i<4; ++i)
     {
-        OIIO_CHECK_CLOSE(tmp[i], result[i], error);
+        OCIO_CHECK_CLOSE(tmp[i], result[i], error);
     }
 }
 
-OIIO_ADD_TEST(ExponentOps, ValueLimits)
+OCIO_ADD_TEST(ExponentOps, ValueLimits)
 {
     const double exp1[4] = { 0., 2., -2., 1.5 };
 
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
 
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
 
     float error = 1e-6f;
 
@@ -412,41 +412,41 @@ OIIO_ADD_TEST(ExponentOps, ValueLimits)
     ValidateOp(source4, ops[0], result4, error);
 }
 
-OIIO_ADD_TEST(ExponentOps, Inverse)
+OCIO_ADD_TEST(ExponentOps, Inverse)
 {
     const double exp1[4] = { 2.0, 1.02345, 5.651321, 0.12345678910 };
     const double exp2[4] = { 2.0, 2.0,     2.0,      2.0 };
     
     OpRcPtrVec ops;
     
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp2, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp2, TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp2, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp2, TRANSFORM_DIR_INVERSE));
     
-    OIIO_REQUIRE_EQUAL(ops.size(), 4);
+    OCIO_REQUIRE_EQUAL(ops.size(), 4);
     ConstOpRcPtr op0 = ops[0];
     ConstOpRcPtr op1 = ops[1];
     ConstOpRcPtr op2 = ops[2];
     ConstOpRcPtr op3 = ops[3];
 
-    OIIO_CHECK_ASSERT(ops[0]->isSameType(op1));
-    OIIO_CHECK_ASSERT(ops[0]->isSameType(op2));
+    OCIO_CHECK_ASSERT(ops[0]->isSameType(op1));
+    OCIO_CHECK_ASSERT(ops[0]->isSameType(op2));
     ConstOpRcPtr op3Cloned = ops[3]->clone();
-    OIIO_CHECK_ASSERT(ops[0]->isSameType(op3Cloned));
+    OCIO_CHECK_ASSERT(ops[0]->isSameType(op3Cloned));
     
-    OIIO_CHECK_EQUAL(ops[0]->isInverse(op0), false);
-    OIIO_CHECK_EQUAL(ops[0]->isInverse(op1), true);
-    OIIO_CHECK_EQUAL(ops[1]->isInverse(op0), true);
-    OIIO_CHECK_EQUAL(ops[0]->isInverse(op2), false);
-    OIIO_CHECK_EQUAL(ops[0]->isInverse(op3), false);
-    OIIO_CHECK_EQUAL(ops[3]->isInverse(op0), false);
-    OIIO_CHECK_EQUAL(ops[2]->isInverse(op3), true);
-    OIIO_CHECK_EQUAL(ops[3]->isInverse(op2), true);
-    OIIO_CHECK_EQUAL(ops[3]->isInverse(op3), false);
+    OCIO_CHECK_EQUAL(ops[0]->isInverse(op0), false);
+    OCIO_CHECK_EQUAL(ops[0]->isInverse(op1), true);
+    OCIO_CHECK_EQUAL(ops[1]->isInverse(op0), true);
+    OCIO_CHECK_EQUAL(ops[0]->isInverse(op2), false);
+    OCIO_CHECK_EQUAL(ops[0]->isInverse(op3), false);
+    OCIO_CHECK_EQUAL(ops[3]->isInverse(op0), false);
+    OCIO_CHECK_EQUAL(ops[2]->isInverse(op3), true);
+    OCIO_CHECK_EQUAL(ops[3]->isInverse(op2), true);
+    OCIO_CHECK_EQUAL(ops[3]->isInverse(op3), false);
 }
 
-OIIO_ADD_TEST(ExponentOps, Combining)
+OCIO_ADD_TEST(ExponentOps, Combining)
 {
     const float error = 1e-6f;
     {
@@ -454,9 +454,9 @@ OIIO_ADD_TEST(ExponentOps, Combining)
     const double exp2[4] = { 1.2, 1.2, 1.2, 1.0 };
     
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp2, TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp2, TRANSFORM_DIR_FORWARD));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     ConstOpRcPtr op1 = ops[1];
 
     const float source[] = {  0.9f, 0.4f, 0.1f, 0.5f, };
@@ -470,12 +470,12 @@ OIIO_ADD_TEST(ExponentOps, Combining)
     
     for(unsigned int i=0; i<4; ++i)
     {
-        OIIO_CHECK_CLOSE(tmp[i], result[i], error);
+        OCIO_CHECK_CLOSE(tmp[i], result[i], error);
     }
     
     OpRcPtrVec combined;
-    OIIO_CHECK_NO_THROW(ops[0]->combineWith(combined, op1));
-    OIIO_CHECK_EQUAL(combined.size(), 1);
+    OCIO_CHECK_NO_THROW(ops[0]->combineWith(combined, op1));
+    OCIO_CHECK_EQUAL(combined.size(), 1);
     
     float tmp2[4];
     memcpy(tmp2, source, 4*sizeof(float));
@@ -483,7 +483,7 @@ OIIO_ADD_TEST(ExponentOps, Combining)
     
     for(unsigned int i=0; i<4; ++i)
     {
-        OIIO_CHECK_CLOSE(tmp2[i], result[i], error);
+        OCIO_CHECK_CLOSE(tmp2[i], result[i], error);
     }
     }
     
@@ -492,17 +492,17 @@ OIIO_ADD_TEST(ExponentOps, Combining)
     const double exp1[4] = {1.037289, 1.019015, 0.966082, 1.0};
     
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_INVERSE));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     ConstOpRcPtr op1 = ops[1];
 
     const bool isInverse = ops[0]->isInverse(op1);
-    OIIO_CHECK_EQUAL(isInverse, true);
+    OCIO_CHECK_EQUAL(isInverse, true);
 
     OpRcPtrVec combined;
-    OIIO_CHECK_NO_THROW(ops[0]->combineWith(combined, op1));
-    OIIO_CHECK_EQUAL(combined.empty(), true);
+    OCIO_CHECK_NO_THROW(ops[0]->combineWith(combined, op1));
+    OCIO_CHECK_EQUAL(combined.empty(), true);
 
     }
 
@@ -510,13 +510,13 @@ OIIO_ADD_TEST(ExponentOps, Combining)
     const double exp1[4] = { 1.037289, 1.019015, 0.966082, 1.0 };
 
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 3);
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_EQUAL(ops.size(), 3);
 
-    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
-    OIIO_CHECK_EQUAL(ops.size(), 3);
+    OCIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
+    OCIO_CHECK_EQUAL(ops.size(), 3);
 
     const float source[] = { 0.1f, 0.5f, 0.9f, 0.5f, };
     const float result[] = { 0.0765437484f, 0.480251998f,
@@ -530,85 +530,85 @@ OIIO_ADD_TEST(ExponentOps, Combining)
 
     for (unsigned int i = 0; i<4; ++i)
     {
-        OIIO_CHECK_CLOSE(tmp[i], result[i], error);
+        OCIO_CHECK_CLOSE(tmp[i], result[i], error);
     }
 
-    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
-    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OCIO_CHECK_NO_THROW(FinalizeOpVec(ops));
+    OCIO_CHECK_EQUAL(ops.size(), 1);
 
     memcpy(tmp, source, 4 * sizeof(float));
     ops[0]->apply(tmp, tmp, 1);
 
     for (unsigned int i = 0; i<4; ++i)
     {
-        OIIO_CHECK_CLOSE(tmp[i], result[i], error);
+        OCIO_CHECK_CLOSE(tmp[i], result[i], error);
     }
     }
 }
 
-OIIO_ADD_TEST(ExponentOps, ThrowCreate)
+OCIO_ADD_TEST(ExponentOps, ThrowCreate)
 {
     const double exp1[4] = { 0.0, 1.3, 1.4, 1.5 };
 
     OpRcPtrVec ops;
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         CreateExponentOp(ops, exp1, TRANSFORM_DIR_UNKNOWN),
         OpenColorIO::Exception, "unspecified transform direction");
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         CreateExponentOp(ops, exp1, TRANSFORM_DIR_INVERSE),
         OpenColorIO::Exception, "Cannot apply 0.0 exponent in the inverse");
 }
 
-OIIO_ADD_TEST(ExponentOps, ThrowCombine)
+OCIO_ADD_TEST(ExponentOps, ThrowCombine)
 {
     const double exp1[4] = { 0.0, 1.3, 1.4, 1.5 };
 
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     ConstOpRcPtr op1 = ops[1];
 
     OpRcPtrVec combinedOps;
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         ops[0]->combineWith(combinedOps, op1),
         OpenColorIO::Exception, "can only be combined with other ExponentOps");
 }
 
-OIIO_ADD_TEST(ExponentOps, NoOp)
+OCIO_ADD_TEST(ExponentOps, NoOp)
 {
     const double exp1[4] = { 1.0, 1.0, 1.0, 1.0 };
 
     // CreateExponentOp will not create a NoOp
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_INVERSE));
 
-    OIIO_CHECK_EQUAL(ops.empty(), true);
+    OCIO_CHECK_EQUAL(ops.empty(), true);
 }
 
-OIIO_ADD_TEST(ExponentOps, CacheID)
+OCIO_ADD_TEST(ExponentOps, CacheID)
 {
     const double exp1[4] = { 2.0, 2.1, 3.0, 3.1 };
     const double exp2[4] = { 4.0, 4.1, 5.0, 5.1 };
 
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp2, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp2, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateExponentOp(ops, exp1, TRANSFORM_DIR_FORWARD));
 
-    OIIO_CHECK_EQUAL(ops.size(), 3);
+    OCIO_CHECK_EQUAL(ops.size(), 3);
 
 
-    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
+    OCIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
 
     const std::string opCacheID0 = ops[0]->getCacheID();
     const std::string opCacheID1 = ops[1]->getCacheID();
     const std::string opCacheID2 = ops[2]->getCacheID();
 
-    OIIO_CHECK_EQUAL(opCacheID0, opCacheID2);
-    OIIO_CHECK_NE(opCacheID0, opCacheID1);
+    OCIO_CHECK_EQUAL(opCacheID0, opCacheID2);
+    OCIO_CHECK_NE(opCacheID0, opCacheID1);
 }
 
 

--- a/src/OpenColorIO/ops/FixedFunction/FixedFunctionOpCPU.cpp
+++ b/src/OpenColorIO/ops/FixedFunction/FixedFunctionOpCPU.cpp
@@ -749,7 +749,7 @@ namespace OCIO = OCIO_NAMESPACE;
 #include <cstring>
 
 #include "MathUtils.h"
-#include "unittest.h"
+#include "UnitTest.h"
 
 
 void ApplyFixedFunction(float * input_32f, 
@@ -759,8 +759,8 @@ void ApplyFixedFunction(float * input_32f,
                         float errorThreshold)
 {
     OCIO::OpCPURcPtr op;
-    OIIO_CHECK_NO_THROW(op = OCIO::GetFixedFunctionCPURenderer(fnData));
-    OIIO_CHECK_NO_THROW(op->apply(input_32f, input_32f, numSamples));
+    OCIO_CHECK_NO_THROW(op = OCIO::GetFixedFunctionCPURenderer(fnData));
+    OCIO_CHECK_NO_THROW(op->apply(input_32f, input_32f, numSamples));
 
     for(unsigned idx=0; idx<(numSamples*4); ++idx)
     {
@@ -778,12 +778,12 @@ void ApplyFixedFunction(float * input_32f,
             errorMsg << "Index: " << idx;
             errorMsg << " - Values: " << input_32f[idx] << " and: " << expected_32f[idx];
             errorMsg << " - Threshold: " << errorThreshold;
-            OIIO_CHECK_ASSERT_MESSAGE(0, errorMsg.str());
+            OCIO_CHECK_ASSERT_MESSAGE(0, errorMsg.str());
         }
     }
 }
 
-OIIO_ADD_TEST(FixedFunctionOpCPU, aces_red_mod_03)
+OCIO_ADD_TEST(FixedFunctionOpCPU, aces_red_mod_03)
 {
     const unsigned num_samples = 4;
 
@@ -829,7 +829,7 @@ OIIO_ADD_TEST(FixedFunctionOpCPU, aces_red_mod_03)
     }
 }
 
-OIIO_ADD_TEST(FixedFunctionOpCPU, aces_red_mod_10)
+OCIO_ADD_TEST(FixedFunctionOpCPU, aces_red_mod_10)
 {
     const unsigned num_samples = 4;
 
@@ -885,7 +885,7 @@ OIIO_ADD_TEST(FixedFunctionOpCPU, aces_red_mod_10)
     }
 }
 
-OIIO_ADD_TEST(FixedFunctionOpCPU, aces_glow_03)
+OCIO_ADD_TEST(FixedFunctionOpCPU, aces_glow_03)
 {
     const unsigned num_samples = 4;
 
@@ -931,7 +931,7 @@ OIIO_ADD_TEST(FixedFunctionOpCPU, aces_glow_03)
     }
 }
 
-OIIO_ADD_TEST(FixedFunctionOpCPU, aces_glow_10)
+OCIO_ADD_TEST(FixedFunctionOpCPU, aces_glow_10)
 {
     const unsigned num_samples = 4;
 
@@ -977,7 +977,7 @@ OIIO_ADD_TEST(FixedFunctionOpCPU, aces_glow_10)
     }
 }
 
-OIIO_ADD_TEST(FixedFunctionOpCPU, aces_dark_to_dim_10)
+OCIO_ADD_TEST(FixedFunctionOpCPU, aces_dark_to_dim_10)
 {
     const unsigned num_samples = 4;
 
@@ -1023,7 +1023,7 @@ OIIO_ADD_TEST(FixedFunctionOpCPU, aces_dark_to_dim_10)
     }
 }   
 
-OIIO_ADD_TEST(FixedFunctionOpCPU, rec2100_surround)
+OCIO_ADD_TEST(FixedFunctionOpCPU, rec2100_surround)
 {
     const unsigned num_samples = 4;
 

--- a/src/OpenColorIO/ops/FixedFunction/FixedFunctionOpData.cpp
+++ b/src/OpenColorIO/ops/FixedFunction/FixedFunctionOpData.cpp
@@ -340,113 +340,113 @@ OCIO_NAMESPACE_EXIT
 
 namespace OCIO = OCIO_NAMESPACE;
 
-#include "unittest.h"
+#include "UnitTest.h"
 
 
-OIIO_ADD_TEST(FixedFunctionOpData, aces_red_mod_style)
+OCIO_ADD_TEST(FixedFunctionOpData, aces_red_mod_style)
 {
     OCIO::FixedFunctionOpData func;
-    OIIO_CHECK_NO_THROW(func.setInputBitDepth(OCIO::BIT_DEPTH_UINT8));
-    OIIO_CHECK_EQUAL(func.getStyle(), OCIO::FixedFunctionOpData::ACES_RED_MOD_03_FWD);
-    OIIO_CHECK_EQUAL(func.getParams().size(), 0);
-    OIIO_CHECK_NO_THROW(func.validate());
-    OIIO_CHECK_NO_THROW(func.finalize());
+    OCIO_CHECK_NO_THROW(func.setInputBitDepth(OCIO::BIT_DEPTH_UINT8));
+    OCIO_CHECK_EQUAL(func.getStyle(), OCIO::FixedFunctionOpData::ACES_RED_MOD_03_FWD);
+    OCIO_CHECK_EQUAL(func.getParams().size(), 0);
+    OCIO_CHECK_NO_THROW(func.validate());
+    OCIO_CHECK_NO_THROW(func.finalize());
     const std::string cacheID(func.getCacheID());
 
-    OIIO_CHECK_NO_THROW(func.setStyle(OCIO::FixedFunctionOpData::ACES_RED_MOD_10_FWD));
-    OIIO_CHECK_EQUAL(func.getStyle(), OCIO::FixedFunctionOpData::ACES_RED_MOD_10_FWD);
-    OIIO_CHECK_NO_THROW(func.validate());
-    OIIO_CHECK_NO_THROW(func.finalize());
+    OCIO_CHECK_NO_THROW(func.setStyle(OCIO::FixedFunctionOpData::ACES_RED_MOD_10_FWD));
+    OCIO_CHECK_EQUAL(func.getStyle(), OCIO::FixedFunctionOpData::ACES_RED_MOD_10_FWD);
+    OCIO_CHECK_NO_THROW(func.validate());
+    OCIO_CHECK_NO_THROW(func.finalize());
 
-    OIIO_CHECK_ASSERT(cacheID!=std::string(func.getCacheID()));
+    OCIO_CHECK_ASSERT(cacheID!=std::string(func.getCacheID()));
 
     OCIO::FixedFunctionOpDataRcPtr inv = func.inverse();
-    OIIO_CHECK_EQUAL(inv->getStyle(), OCIO::FixedFunctionOpData::ACES_RED_MOD_10_INV);
-    OIIO_CHECK_EQUAL(inv->getParams().size(), 0);
-    OIIO_CHECK_ASSERT(cacheID!=std::string(inv->getCacheID()));
-    OIIO_CHECK_EQUAL(inv->getInputBitDepth(), func.getOutputBitDepth());
-    OIIO_CHECK_EQUAL(inv->getOutputBitDepth(), func.getInputBitDepth());
+    OCIO_CHECK_EQUAL(inv->getStyle(), OCIO::FixedFunctionOpData::ACES_RED_MOD_10_INV);
+    OCIO_CHECK_EQUAL(inv->getParams().size(), 0);
+    OCIO_CHECK_ASSERT(cacheID!=std::string(inv->getCacheID()));
+    OCIO_CHECK_EQUAL(inv->getInputBitDepth(), func.getOutputBitDepth());
+    OCIO_CHECK_EQUAL(inv->getOutputBitDepth(), func.getInputBitDepth());
 
     OCIO::FixedFunctionOpData::Params p = func.getParams();
     p.push_back(1.);
-    OIIO_CHECK_NO_THROW(func.setParams(p));
-    OIIO_CHECK_THROW_WHAT(func.validate(), 
+    OCIO_CHECK_NO_THROW(func.setParams(p));
+    OCIO_CHECK_THROW_WHAT(func.validate(), 
                           OCIO::Exception, 
                           "The style 'ACES_RedMod10 (Forward)' must have zero parameters but 1 found.");
 }
 
-OIIO_ADD_TEST(FixedFunctionOpData, aces_dark_to_dim10_style)
+OCIO_ADD_TEST(FixedFunctionOpData, aces_dark_to_dim10_style)
 {
     OCIO::FixedFunctionOpData func(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_F32, 
                                    OCIO::FixedFunctionOpData::Params(), 
                                    OCIO::FixedFunctionOpData::ACES_DARK_TO_DIM_10_FWD);
 
-    OIIO_CHECK_EQUAL(func.getStyle(), OCIO::FixedFunctionOpData::ACES_DARK_TO_DIM_10_FWD);
-    OIIO_CHECK_EQUAL(func.getParams().size(), 0);
-    OIIO_CHECK_NO_THROW(func.validate());
-    OIIO_CHECK_NO_THROW(func.finalize());
+    OCIO_CHECK_EQUAL(func.getStyle(), OCIO::FixedFunctionOpData::ACES_DARK_TO_DIM_10_FWD);
+    OCIO_CHECK_EQUAL(func.getParams().size(), 0);
+    OCIO_CHECK_NO_THROW(func.validate());
+    OCIO_CHECK_NO_THROW(func.finalize());
     const std::string cacheID(func.getCacheID());
 
     OCIO::FixedFunctionOpDataRcPtr inv = func.inverse();
-    OIIO_CHECK_EQUAL(inv->getStyle(), OCIO::FixedFunctionOpData::ACES_DARK_TO_DIM_10_INV);
-    OIIO_CHECK_EQUAL(inv->getParams().size(), 0);
-    OIIO_CHECK_ASSERT(cacheID!=std::string(inv->getCacheID()));
-    OIIO_CHECK_EQUAL(inv->getInputBitDepth(), func.getOutputBitDepth());
-    OIIO_CHECK_EQUAL(inv->getOutputBitDepth(), func.getInputBitDepth());
+    OCIO_CHECK_EQUAL(inv->getStyle(), OCIO::FixedFunctionOpData::ACES_DARK_TO_DIM_10_INV);
+    OCIO_CHECK_EQUAL(inv->getParams().size(), 0);
+    OCIO_CHECK_ASSERT(cacheID!=std::string(inv->getCacheID()));
+    OCIO_CHECK_EQUAL(inv->getInputBitDepth(), func.getOutputBitDepth());
+    OCIO_CHECK_EQUAL(inv->getOutputBitDepth(), func.getInputBitDepth());
 
     OCIO::FixedFunctionOpData::Params p = func.getParams();
     p.push_back(1.);
-    OIIO_CHECK_NO_THROW(func.setParams(p));
-    OIIO_CHECK_THROW_WHAT(func.validate(), 
+    OCIO_CHECK_NO_THROW(func.setParams(p));
+    OCIO_CHECK_THROW_WHAT(func.validate(), 
                           OCIO::Exception, 
                           "The style 'ACES_DarkToDim10 (Forward)' must have zero parameters but 1 found.");
 }
 
-OIIO_ADD_TEST(FixedFunctionOpData, rec2100_surround_style)
+OCIO_ADD_TEST(FixedFunctionOpData, rec2100_surround_style)
 {
     OCIO::FixedFunctionOpData::Params params = { 2.0 };
         OCIO::FixedFunctionOpData func(OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_F32, 
                                    params, OCIO::FixedFunctionOpData::REC2100_SURROUND);
-    OIIO_CHECK_NO_THROW(func.validate());
-    OIIO_CHECK_NO_THROW(func.finalize());
+    OCIO_CHECK_NO_THROW(func.validate());
+    OCIO_CHECK_NO_THROW(func.finalize());
     const std::string cacheID(func.getCacheID());
-    OIIO_CHECK_ASSERT(func.getParams() == params);
+    OCIO_CHECK_ASSERT(func.getParams() == params);
 
     OCIO::FixedFunctionOpDataRcPtr inv = func.inverse();
-    OIIO_CHECK_EQUAL(inv->getParams()[0], 1. / func.getParams()[0]);
-    OIIO_CHECK_EQUAL(inv->getInputBitDepth(), func.getOutputBitDepth());
-    OIIO_CHECK_EQUAL(inv->getOutputBitDepth(), func.getInputBitDepth());
-    OIIO_CHECK_ASSERT(cacheID!=std::string(inv->getCacheID()));
+    OCIO_CHECK_EQUAL(inv->getParams()[0], 1. / func.getParams()[0]);
+    OCIO_CHECK_EQUAL(inv->getInputBitDepth(), func.getOutputBitDepth());
+    OCIO_CHECK_EQUAL(inv->getOutputBitDepth(), func.getInputBitDepth());
+    OCIO_CHECK_ASSERT(cacheID!=std::string(inv->getCacheID()));
 
-    OIIO_CHECK_ASSERT(func == func);
-    OIIO_CHECK_ASSERT(!(func == *inv));
+    OCIO_CHECK_ASSERT(func == func);
+    OCIO_CHECK_ASSERT(!(func == *inv));
 
     params = func.getParams();
     params[0] = 120.;
-    OIIO_CHECK_NO_THROW(func.setParams(params));
-    OIIO_CHECK_THROW_WHAT(func.validate(), 
+    OCIO_CHECK_NO_THROW(func.setParams(params));
+    OCIO_CHECK_THROW_WHAT(func.validate(), 
                           OCIO::Exception,
                           "Parameter 120 is greater than upper bound 100");
 
     params = func.getParams();
     params[0] = 0.00001;
-    OIIO_CHECK_NO_THROW(func.setParams(params));
-    OIIO_CHECK_THROW_WHAT(func.validate(),
+    OCIO_CHECK_NO_THROW(func.setParams(params));
+    OCIO_CHECK_THROW_WHAT(func.validate(),
                           OCIO::Exception,
                           "Parameter 1e-05 is less than lower bound 0.001");
 
     params = func.getParams();
     params.push_back(12);
-    OIIO_CHECK_NO_THROW(func.setParams(params));
-    OIIO_CHECK_THROW_WHAT(func.validate(),
+    OCIO_CHECK_NO_THROW(func.setParams(params));
+    OCIO_CHECK_THROW_WHAT(func.validate(),
                           OCIO::Exception,
                           "The style 'REC2100_Surround' must have "
                           "one parameter but 2 found.");
 
     params = func.getParams();
     params.clear();
-    OIIO_CHECK_NO_THROW(func.setParams(params));
-    OIIO_CHECK_THROW_WHAT(func.validate(),
+    OCIO_CHECK_NO_THROW(func.setParams(params));
+    OCIO_CHECK_THROW_WHAT(func.validate(),
                           OCIO::Exception,
                           "The style 'REC2100_Surround' must have "
                           "one parameter but 0 found.");

--- a/src/OpenColorIO/ops/FixedFunction/FixedFunctionOps.cpp
+++ b/src/OpenColorIO/ops/FixedFunction/FixedFunctionOps.cpp
@@ -223,34 +223,34 @@ namespace OCIO = OCIO_NAMESPACE;
 
 #include "MathUtils.h"
 #include "pystring/pystring.h"
-#include "unittest.h"
+#include "UnitTest.h"
 
 
-OIIO_ADD_TEST(FixedFunctionOps, basic)
+OCIO_ADD_TEST(FixedFunctionOps, basic)
 {
     OCIO::OpRcPtrVec ops;
     OCIO::FixedFunctionOpData::Params params;
 
-    OIIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, params, 
+    OCIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, params, 
                                                     OCIO::FixedFunctionOpData::ACES_RED_MOD_10_FWD));
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
     OCIO::ConstFixedFunctionOpRcPtr func
         = OCIO::DynamicPtrCast<OCIO::FixedFunctionOp>(ops[0]);
 
-    OIIO_REQUIRE_EQUAL(func->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_REQUIRE_EQUAL(func->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_REQUIRE_EQUAL(func->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_REQUIRE_EQUAL(func->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_ASSERT(!func->isNoOp());
-    OIIO_CHECK_ASSERT(!func->isIdentity());
+    OCIO_CHECK_ASSERT(!func->isNoOp());
+    OCIO_CHECK_ASSERT(!func->isIdentity());
 
     OCIO::ConstFixedFunctionOpDataRcPtr funcData 
         = OCIO::DynamicPtrCast<const OCIO::FixedFunctionOpData>(func->data());
-    OIIO_REQUIRE_EQUAL(funcData->getStyle(), OCIO::FixedFunctionOpData::ACES_RED_MOD_10_FWD);
-    OIIO_REQUIRE_ASSERT(funcData->getParams() == params);
+    OCIO_REQUIRE_EQUAL(funcData->getStyle(), OCIO::FixedFunctionOpData::ACES_RED_MOD_10_FWD);
+    OCIO_REQUIRE_ASSERT(funcData->getParams() == params);
 }
 
-OIIO_ADD_TEST(FixedFunctionOps, glow03_cpu_engine)
+OCIO_ADD_TEST(FixedFunctionOps, glow03_cpu_engine)
 {
     // Validate that the right CPU OP is created.
 
@@ -262,15 +262,15 @@ OIIO_ADD_TEST(FixedFunctionOps, glow03_cpu_engine)
                                                 data, style);
 
     OCIO::FixedFunctionOp func(funcData);
-    OIIO_CHECK_NO_THROW(func.finalize());
+    OCIO_CHECK_NO_THROW(func.finalize());
 
     OCIO::ConstOpCPURcPtr cpuOp = func.getCPUOp();
     const OCIO::OpCPU & c = *cpuOp;
     const std::string typeName(typeid(c).name());
-    OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "Renderer_ACES_Glow03_Fwd"));
+    OCIO_CHECK_NE(-1, pystring::find(typeName, "Renderer_ACES_Glow03_Fwd"));
 }
 
-OIIO_ADD_TEST(FixedFunctionOps, darktodim10_cpu_engine)
+OCIO_ADD_TEST(FixedFunctionOps, darktodim10_cpu_engine)
 {
     // Validate that the right CPU OP is created.
 
@@ -282,121 +282,121 @@ OIIO_ADD_TEST(FixedFunctionOps, darktodim10_cpu_engine)
                                                       data, style);
 
     OCIO::FixedFunctionOp func(funcData);
-    OIIO_CHECK_NO_THROW(func.finalize());
+    OCIO_CHECK_NO_THROW(func.finalize());
 
     OCIO::ConstOpCPURcPtr cpuOp = func.getCPUOp();
     const OCIO::OpCPU & c = *cpuOp;
     const std::string typeName(typeid(c).name());
-    OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "Renderer_ACES_DarkToDim10_Fwd"));
+    OCIO_CHECK_NE(-1, pystring::find(typeName, "Renderer_ACES_DarkToDim10_Fwd"));
 }
 
-OIIO_ADD_TEST(FixedFunctionOps, aces_red_mod_inv)
+OCIO_ADD_TEST(FixedFunctionOps, aces_red_mod_inv)
 {
     OCIO::OpRcPtrVec ops;
 
-    OIIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, {}, 
+    OCIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, {}, 
                                                     OCIO::FixedFunctionOpData::ACES_RED_MOD_03_INV));
 
-    OIIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, {}, 
+    OCIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, {}, 
                                                     OCIO::FixedFunctionOpData::ACES_RED_MOD_03_FWD));
 
-    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
 
     OCIO::ConstOpRcPtr op0 = ops[0];
     OCIO::ConstOpRcPtr op1 = ops[1];
 
-    OIIO_CHECK_ASSERT(!op0->isIdentity());
-    OIIO_CHECK_ASSERT(!op1->isIdentity());
+    OCIO_CHECK_ASSERT(!op0->isIdentity());
+    OCIO_CHECK_ASSERT(!op1->isIdentity());
 
-    OIIO_CHECK_ASSERT(op0->isSameType(op1));
-    OIIO_CHECK_ASSERT(op0->isInverse(op1));
-    OIIO_CHECK_ASSERT(op1->isInverse(op0));
+    OCIO_CHECK_ASSERT(op0->isSameType(op1));
+    OCIO_CHECK_ASSERT(op0->isInverse(op1));
+    OCIO_CHECK_ASSERT(op1->isInverse(op0));
 }
 
-OIIO_ADD_TEST(FixedFunctionOps, aces_glow_inv)
+OCIO_ADD_TEST(FixedFunctionOps, aces_glow_inv)
 {
     OCIO::OpRcPtrVec ops;
 
-    OIIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, {}, 
+    OCIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, {}, 
                                                     OCIO::FixedFunctionOpData::ACES_GLOW_03_INV));
 
-    OIIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, {}, 
+    OCIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, {}, 
                                                     OCIO::FixedFunctionOpData::ACES_GLOW_03_FWD));
 
-    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
 
     OCIO::ConstOpRcPtr op0 = ops[0];
     OCIO::ConstOpRcPtr op1 = ops[1];
 
-    OIIO_CHECK_ASSERT(!op0->isIdentity());
-    OIIO_CHECK_ASSERT(!op1->isIdentity());
+    OCIO_CHECK_ASSERT(!op0->isIdentity());
+    OCIO_CHECK_ASSERT(!op1->isIdentity());
 
-    OIIO_CHECK_ASSERT(op0->isSameType(op1));
-    OIIO_CHECK_ASSERT(op0->isInverse(op1));
-    OIIO_CHECK_ASSERT(op1->isInverse(op0));
+    OCIO_CHECK_ASSERT(op0->isSameType(op1));
+    OCIO_CHECK_ASSERT(op0->isInverse(op1));
+    OCIO_CHECK_ASSERT(op1->isInverse(op0));
 }
 
-OIIO_ADD_TEST(FixedFunctionOps, aces_darktodim10_inv)
+OCIO_ADD_TEST(FixedFunctionOps, aces_darktodim10_inv)
 {
     OCIO::OpRcPtrVec ops;
 
-    OIIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, {}, 
+    OCIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, {}, 
                                                     OCIO::FixedFunctionOpData::ACES_DARK_TO_DIM_10_INV));
 
-    OIIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, {}, 
+    OCIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, {}, 
                                                     OCIO::FixedFunctionOpData::ACES_DARK_TO_DIM_10_FWD));
 
-    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
 
     OCIO::ConstOpRcPtr op0 = ops[0];
     OCIO::ConstOpRcPtr op1 = ops[1];
 
-    OIIO_CHECK_ASSERT(!op0->isIdentity());
-    OIIO_CHECK_ASSERT(!op1->isIdentity());
+    OCIO_CHECK_ASSERT(!op0->isIdentity());
+    OCIO_CHECK_ASSERT(!op1->isIdentity());
 
-    OIIO_CHECK_ASSERT(op0->isSameType(op1));
-    OIIO_CHECK_ASSERT(op0->isInverse(op1));
-    OIIO_CHECK_ASSERT(op1->isInverse(op0));
+    OCIO_CHECK_ASSERT(op0->isSameType(op1));
+    OCIO_CHECK_ASSERT(op0->isInverse(op1));
+    OCIO_CHECK_ASSERT(op1->isInverse(op0));
 }
 
-OIIO_ADD_TEST(FixedFunctionOps, rec2100_surround_inv)
+OCIO_ADD_TEST(FixedFunctionOps, rec2100_surround_inv)
 {
     OCIO::OpRcPtrVec ops;
 
-    OIIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, { 2. }, 
+    OCIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, { 2. }, 
                                                     OCIO::FixedFunctionOpData::REC2100_SURROUND));
 
-    OIIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, { 1. / 2. }, 
+    OCIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, { 1. / 2. }, 
                                                     OCIO::FixedFunctionOpData::REC2100_SURROUND));
 
-    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     {
         OCIO::ConstOpRcPtr op0 = ops[0];
         OCIO::ConstOpRcPtr op1 = ops[1];
 
-        OIIO_CHECK_ASSERT(!op0->isIdentity());
-        OIIO_CHECK_ASSERT(!op1->isIdentity());
+        OCIO_CHECK_ASSERT(!op0->isIdentity());
+        OCIO_CHECK_ASSERT(!op1->isIdentity());
 
-        OIIO_CHECK_ASSERT(op0->isSameType(op1));
-        OIIO_CHECK_ASSERT(op0->isInverse(op1));
-        OIIO_CHECK_ASSERT(op1->isInverse(op0));
+        OCIO_CHECK_ASSERT(op0->isSameType(op1));
+        OCIO_CHECK_ASSERT(op0->isInverse(op1));
+        OCIO_CHECK_ASSERT(op1->isInverse(op0));
     }
-    OIIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, { 2.01 }, 
+    OCIO_CHECK_NO_THROW(OCIO::CreateFixedFunctionOp(ops, { 2.01 }, 
                                                     OCIO::FixedFunctionOpData::REC2100_SURROUND));
 
-    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
-    OIIO_REQUIRE_EQUAL(ops.size(), 3);
+    OCIO_CHECK_NO_THROW(FinalizeOpVec(ops, false));
+    OCIO_REQUIRE_EQUAL(ops.size(), 3);
     {
         OCIO::ConstOpRcPtr op0 = ops[0];
         OCIO::ConstOpRcPtr op1 = ops[1];
         OCIO::ConstOpRcPtr op2 = ops[2];
 
-        OIIO_CHECK_ASSERT(!op0->isInverse(op2));
-        OIIO_CHECK_ASSERT(!op1->isInverse(op2));
+        OCIO_CHECK_ASSERT(!op0->isInverse(op2));
+        OCIO_CHECK_ASSERT(!op1->isInverse(op2));
     }
 }
 

--- a/src/OpenColorIO/ops/FixedFunction/FixedFunctionOps.cpp
+++ b/src/OpenColorIO/ops/FixedFunction/FixedFunctionOps.cpp
@@ -267,7 +267,7 @@ OCIO_ADD_TEST(FixedFunctionOps, glow03_cpu_engine)
     OCIO::ConstOpCPURcPtr cpuOp = func.getCPUOp();
     const OCIO::OpCPU & c = *cpuOp;
     const std::string typeName(typeid(c).name());
-    OCIO_CHECK_NE(-1, pystring::find(typeName, "Renderer_ACES_Glow03_Fwd"));
+    OCIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "Renderer_ACES_Glow03_Fwd"));
 }
 
 OCIO_ADD_TEST(FixedFunctionOps, darktodim10_cpu_engine)
@@ -287,7 +287,7 @@ OCIO_ADD_TEST(FixedFunctionOps, darktodim10_cpu_engine)
     OCIO::ConstOpCPURcPtr cpuOp = func.getCPUOp();
     const OCIO::OpCPU & c = *cpuOp;
     const std::string typeName(typeid(c).name());
-    OCIO_CHECK_NE(-1, pystring::find(typeName, "Renderer_ACES_DarkToDim10_Fwd"));
+    OCIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "Renderer_ACES_DarkToDim10_Fwd"));
 }
 
 OCIO_ADD_TEST(FixedFunctionOps, aces_red_mod_inv)

--- a/src/OpenColorIO/ops/Gamma/GammaOpData.cpp
+++ b/src/OpenColorIO/ops/Gamma/GammaOpData.cpp
@@ -592,7 +592,7 @@ OCIO_NAMESPACE_EXIT
 
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 
 namespace
@@ -605,7 +605,7 @@ namespace
 }
 
 
-OIIO_ADD_TEST(GammaOpData, accessors)
+OCIO_ADD_TEST(GammaOpData, accessors)
 {
     const OCIO::GammaOpData::Params paramsR = { 2.4, 0.1 };
     const OCIO::GammaOpData::Params paramsG = { 2.2, 0.2 };
@@ -616,56 +616,56 @@ OIIO_ADD_TEST(GammaOpData, accessors)
                          OCIO::GammaOpData::MONCURVE_FWD,
                          paramsR, paramsG, paramsB, paramsA);
 
-    OIIO_CHECK_EQUAL(g1.getType(), OCIO::OpData::GammaType);
-    OIIO_CHECK_EQUAL(g1.getInputBitDepth(), inBitDepth);
-    OIIO_CHECK_EQUAL(g1.getOutputBitDepth(), outBitDepth);
+    OCIO_CHECK_EQUAL(g1.getType(), OCIO::OpData::GammaType);
+    OCIO_CHECK_EQUAL(g1.getInputBitDepth(), inBitDepth);
+    OCIO_CHECK_EQUAL(g1.getOutputBitDepth(), outBitDepth);
 
-    OIIO_CHECK_ASSERT(g1.getRedParams()   == paramsR);
-    OIIO_CHECK_ASSERT(g1.getGreenParams() == paramsG);
-    OIIO_CHECK_ASSERT(g1.getBlueParams()  == paramsB);
-    OIIO_CHECK_ASSERT(g1.getAlphaParams() == paramsA);
+    OCIO_CHECK_ASSERT(g1.getRedParams()   == paramsR);
+    OCIO_CHECK_ASSERT(g1.getGreenParams() == paramsG);
+    OCIO_CHECK_ASSERT(g1.getBlueParams()  == paramsB);
+    OCIO_CHECK_ASSERT(g1.getAlphaParams() == paramsA);
 
-    OIIO_CHECK_EQUAL(g1.getStyle(), OCIO::GammaOpData::MONCURVE_FWD);
+    OCIO_CHECK_EQUAL(g1.getStyle(), OCIO::GammaOpData::MONCURVE_FWD);
 
-    OIIO_CHECK_ASSERT( ! g1.areAllComponentsEqual() );
-    OIIO_CHECK_ASSERT( ! g1.isNonChannelDependent() );
-    OIIO_CHECK_ASSERT( ! g1.isAlphaComponentIdentity() );
+    OCIO_CHECK_ASSERT( ! g1.areAllComponentsEqual() );
+    OCIO_CHECK_ASSERT( ! g1.isNonChannelDependent() );
+    OCIO_CHECK_ASSERT( ! g1.isAlphaComponentIdentity() );
 
 
     // Set R, G and B params to paramsR, A set to identity.
     g1.setParams(paramsR);
 
-    OIIO_CHECK_ASSERT(!g1.areAllComponentsEqual());
-    OIIO_CHECK_ASSERT(g1.isNonChannelDependent());
-    OIIO_CHECK_ASSERT(g1.isAlphaComponentIdentity());
+    OCIO_CHECK_ASSERT(!g1.areAllComponentsEqual());
+    OCIO_CHECK_ASSERT(g1.isNonChannelDependent());
+    OCIO_CHECK_ASSERT(g1.isAlphaComponentIdentity());
 
-    OIIO_CHECK_ASSERT(g1.getGreenParams() == paramsR);
-    OIIO_CHECK_ASSERT(
+    OCIO_CHECK_ASSERT(g1.getGreenParams() == paramsR);
+    OCIO_CHECK_ASSERT(
         OCIO::GammaOpData::isIdentityParameters(g1.getAlphaParams(), 
                                                 g1.getStyle()));
 
     g1.setAlphaParams(paramsR);
-    OIIO_CHECK_ASSERT(g1.areAllComponentsEqual());
+    OCIO_CHECK_ASSERT(g1.areAllComponentsEqual());
 
     g1.setBlueParams(paramsB);
-    OIIO_CHECK_ASSERT(g1.getBlueParams() == paramsB);
+    OCIO_CHECK_ASSERT(g1.getBlueParams() == paramsB);
 
-    OIIO_CHECK_ASSERT(!g1.areAllComponentsEqual());
+    OCIO_CHECK_ASSERT(!g1.areAllComponentsEqual());
 
     g1.setRedParams(paramsB);
-    OIIO_CHECK_ASSERT(g1.getRedParams() == paramsB);
+    OCIO_CHECK_ASSERT(g1.getRedParams() == paramsB);
 
     g1.setGreenParams(paramsB);
-    OIIO_CHECK_ASSERT(g1.getGreenParams() == paramsB);
+    OCIO_CHECK_ASSERT(g1.getGreenParams() == paramsB);
 
     g1.setAlphaParams(paramsA);
-    OIIO_CHECK_ASSERT(g1.getAlphaParams() == paramsA);
+    OCIO_CHECK_ASSERT(g1.getAlphaParams() == paramsA);
 
     g1.setStyle(OCIO::GammaOpData::MONCURVE_REV);
-    OIIO_CHECK_EQUAL(g1.getStyle(), OCIO::GammaOpData::MONCURVE_REV);
+    OCIO_CHECK_EQUAL(g1.getStyle(), OCIO::GammaOpData::MONCURVE_REV);
 }
 
-OIIO_ADD_TEST(GammaOpData, identity_style_basic)
+OCIO_ADD_TEST(GammaOpData, identity_style_basic)
 {
     const OCIO::GammaOpData::Params IdentityParams
         = OCIO::GammaOpData::getIdentityParameters(OCIO::GammaOpData::BASIC_FWD);
@@ -678,9 +678,9 @@ OIIO_ADD_TEST(GammaOpData, identity_style_basic)
                             OCIO::GammaOpData::BASIC_FWD,
                             IdentityParams, IdentityParams,
                             IdentityParams, IdentityParams);
-        OIIO_CHECK_ASSERT(g.isIdentity());
-        OIIO_CHECK_ASSERT(!g.isNoOp()); // inBitDepth != outBitDepth
-        OIIO_CHECK_ASSERT(g.isChannelIndependent());
+        OCIO_CHECK_ASSERT(g.isIdentity());
+        OCIO_CHECK_ASSERT(!g.isNoOp()); // inBitDepth != outBitDepth
+        OCIO_CHECK_ASSERT(g.isChannelIndependent());
     }
 
     {
@@ -693,10 +693,10 @@ OIIO_ADD_TEST(GammaOpData, identity_style_basic)
         g.setOutputBitDepth(outBitDepth);
         g.setParams(IdentityParams);
         g.validate();
-        OIIO_CHECK_EQUAL(g.getStyle(), OCIO::GammaOpData::BASIC_FWD);
-        OIIO_CHECK_ASSERT(g.isIdentity());
-        OIIO_CHECK_ASSERT(!g.isNoOp()); // inBitDepth != outBitDepth
-        OIIO_CHECK_ASSERT(g.isChannelIndependent());
+        OCIO_CHECK_EQUAL(g.getStyle(), OCIO::GammaOpData::BASIC_FWD);
+        OCIO_CHECK_ASSERT(g.isIdentity());
+        OCIO_CHECK_ASSERT(!g.isNoOp()); // inBitDepth != outBitDepth
+        OCIO_CHECK_ASSERT(g.isChannelIndependent());
     }
 
     const OCIO::GammaOpData::Params paramsR = { 1.2 };
@@ -711,9 +711,9 @@ OIIO_ADD_TEST(GammaOpData, identity_style_basic)
         OCIO::GammaOpData g(inBitDepth, outBitDepth, id, desc,
                             OCIO::GammaOpData::BASIC_FWD,
                             paramsR, paramsG, paramsB, paramsA);
-        OIIO_CHECK_ASSERT(!g.isIdentity());
-        OIIO_CHECK_ASSERT(!g.isNoOp());
-        OIIO_CHECK_ASSERT(g.isChannelIndependent());
+        OCIO_CHECK_ASSERT(!g.isIdentity());
+        OCIO_CHECK_ASSERT(!g.isNoOp());
+        OCIO_CHECK_ASSERT(g.isChannelIndependent());
     }
 
     {
@@ -722,21 +722,21 @@ OIIO_ADD_TEST(GammaOpData, identity_style_basic)
         // Default gamma op is BASIC_FWD, in/out bitDepth 32f.
         //
         OCIO::GammaOpData g;
-        OIIO_CHECK_ASSERT(g.isIdentity());
-        OIIO_CHECK_ASSERT(!g.isNoOp()); // basic style clamps, so it isn't a no-op
-        OIIO_CHECK_ASSERT(g.isChannelIndependent());
+        OCIO_CHECK_ASSERT(g.isIdentity());
+        OCIO_CHECK_ASSERT(!g.isNoOp()); // basic style clamps, so it isn't a no-op
+        OCIO_CHECK_ASSERT(g.isChannelIndependent());
 
         g.setParams(paramsR);
         g.validate();
 
-        OIIO_CHECK_EQUAL(g.getStyle(), OCIO::GammaOpData::BASIC_FWD);
-        OIIO_CHECK_ASSERT(!g.isIdentity());
-        OIIO_CHECK_ASSERT(!g.isNoOp());
-        OIIO_CHECK_ASSERT(g.isChannelIndependent());
+        OCIO_CHECK_EQUAL(g.getStyle(), OCIO::GammaOpData::BASIC_FWD);
+        OCIO_CHECK_ASSERT(!g.isIdentity());
+        OCIO_CHECK_ASSERT(!g.isNoOp());
+        OCIO_CHECK_ASSERT(g.isChannelIndependent());
     }
 }
 
-OIIO_ADD_TEST(GammaOpData, identity_style_moncurve)
+OCIO_ADD_TEST(GammaOpData, identity_style_moncurve)
 {
     const OCIO::GammaOpData::Params IdentityParams
       = OCIO::GammaOpData::getIdentityParameters(OCIO::GammaOpData::MONCURVE_FWD);
@@ -749,9 +749,9 @@ OIIO_ADD_TEST(GammaOpData, identity_style_moncurve)
                             OCIO::GammaOpData::MONCURVE_FWD,
                             IdentityParams, IdentityParams,
                             IdentityParams, IdentityParams);
-        OIIO_CHECK_ASSERT(g.isIdentity());
-        OIIO_CHECK_ASSERT(!g.isNoOp()); // inBitDepth != outBitDepth
-        OIIO_CHECK_ASSERT(g.isChannelIndependent());
+        OCIO_CHECK_ASSERT(g.isIdentity());
+        OCIO_CHECK_ASSERT(!g.isNoOp()); // inBitDepth != outBitDepth
+        OCIO_CHECK_ASSERT(g.isChannelIndependent());
     }
 
     {
@@ -763,9 +763,9 @@ OIIO_ADD_TEST(GammaOpData, identity_style_moncurve)
         g.setStyle(OCIO::GammaOpData::MONCURVE_FWD);
         g.setParams(IdentityParams);
         g.validate();
-        OIIO_CHECK_ASSERT(g.isIdentity());
-        OIIO_CHECK_ASSERT(g.isNoOp());
-        OIIO_CHECK_ASSERT(g.isChannelIndependent());
+        OCIO_CHECK_ASSERT(g.isIdentity());
+        OCIO_CHECK_ASSERT(g.isNoOp());
+        OCIO_CHECK_ASSERT(g.isChannelIndependent());
     }
 
     const OCIO::GammaOpData::Params paramsR = { 1.2, 0.2 };
@@ -780,9 +780,9 @@ OIIO_ADD_TEST(GammaOpData, identity_style_moncurve)
         OCIO::GammaOpData g(inBitDepth, outBitDepth, id, desc,
                             OCIO::GammaOpData::MONCURVE_FWD,
                             paramsR, paramsG, paramsB, paramsA);
-        OIIO_CHECK_ASSERT(!g.isIdentity());
-        OIIO_CHECK_ASSERT(!g.isNoOp());
-        OIIO_CHECK_ASSERT(g.isChannelIndependent());
+        OCIO_CHECK_ASSERT(!g.isIdentity());
+        OCIO_CHECK_ASSERT(!g.isNoOp());
+        OCIO_CHECK_ASSERT(g.isChannelIndependent());
     }
 
     {
@@ -795,13 +795,13 @@ OIIO_ADD_TEST(GammaOpData, identity_style_moncurve)
         g.setParams(paramsR);
         g.validate();
 
-        OIIO_CHECK_ASSERT(!g.isIdentity());
-        OIIO_CHECK_ASSERT(!g.isNoOp());
-        OIIO_CHECK_ASSERT(g.isChannelIndependent());
+        OCIO_CHECK_ASSERT(!g.isIdentity());
+        OCIO_CHECK_ASSERT(!g.isNoOp());
+        OCIO_CHECK_ASSERT(g.isChannelIndependent());
     }
 }
 
-OIIO_ADD_TEST(GammaOpData, noop_style_basic)
+OCIO_ADD_TEST(GammaOpData, noop_style_basic)
 {
     // Test basic gamma
     const OCIO::GammaOpData::Params IdentityParams
@@ -815,9 +815,9 @@ OIIO_ADD_TEST(GammaOpData, noop_style_basic)
                             OCIO::GammaOpData::BASIC_FWD,
                             IdentityParams, IdentityParams,
                             IdentityParams, IdentityParams);
-        OIIO_CHECK_ASSERT(g.isIdentity());
-        OIIO_CHECK_ASSERT(!g.isNoOp()); // basic style clamps, so it isn't a no-op
-        OIIO_CHECK_ASSERT(g.isChannelIndependent());
+        OCIO_CHECK_ASSERT(g.isIdentity());
+        OCIO_CHECK_ASSERT(!g.isNoOp()); // basic style clamps, so it isn't a no-op
+        OCIO_CHECK_ASSERT(g.isChannelIndependent());
     }
 
     const OCIO::GammaOpData::Params paramsR = { 1.2 };
@@ -832,14 +832,14 @@ OIIO_ADD_TEST(GammaOpData, noop_style_basic)
         OCIO::GammaOpData g(inBitDepth, outBitDepth, id, desc,
                             OCIO::GammaOpData::BASIC_FWD,
                             paramsR, paramsG, paramsB, paramsA);
-        OIIO_CHECK_ASSERT(!g.isIdentity());
-        OIIO_CHECK_ASSERT(!g.isNoOp());
-        OIIO_CHECK_ASSERT(g.isChannelIndependent());
+        OCIO_CHECK_ASSERT(!g.isIdentity());
+        OCIO_CHECK_ASSERT(!g.isNoOp());
+        OCIO_CHECK_ASSERT(g.isChannelIndependent());
     }
 
 }
 
-OIIO_ADD_TEST(GammaOpData, noop_style_moncurve)
+OCIO_ADD_TEST(GammaOpData, noop_style_moncurve)
 {
     // Test monCurve gamma
     const OCIO::GammaOpData::Params IdentityParams
@@ -853,9 +853,9 @@ OIIO_ADD_TEST(GammaOpData, noop_style_moncurve)
                             OCIO::GammaOpData::MONCURVE_FWD,
                             IdentityParams, IdentityParams,
                             IdentityParams, IdentityParams);
-        OIIO_CHECK_ASSERT(g.isIdentity());
-        OIIO_CHECK_ASSERT(g.isNoOp());
-        OIIO_CHECK_ASSERT(g.isChannelIndependent());
+        OCIO_CHECK_ASSERT(g.isIdentity());
+        OCIO_CHECK_ASSERT(g.isNoOp());
+        OCIO_CHECK_ASSERT(g.isChannelIndependent());
     }
 
     const OCIO::GammaOpData::Params paramsR = { 1.2, 0.2 };
@@ -870,14 +870,14 @@ OIIO_ADD_TEST(GammaOpData, noop_style_moncurve)
         OCIO::GammaOpData g(inBitDepth, outBitDepth, id, desc,
                             OCIO::GammaOpData::MONCURVE_FWD,
                             paramsR, paramsG, paramsB, paramsA);
-        OIIO_CHECK_ASSERT(!g.isIdentity());
-        OIIO_CHECK_ASSERT(!g.isNoOp());
-        OIIO_CHECK_ASSERT(g.isChannelIndependent());
+        OCIO_CHECK_ASSERT(!g.isIdentity());
+        OCIO_CHECK_ASSERT(!g.isNoOp());
+        OCIO_CHECK_ASSERT(g.isChannelIndependent());
     }
 
 }
 
-OIIO_ADD_TEST(GammaOpData, validate)
+OCIO_ADD_TEST(GammaOpData, validate)
 {
     const OCIO::GammaOpData::Params params = { 2.6 };
 
@@ -890,7 +890,7 @@ OIIO_ADD_TEST(GammaOpData, validate)
         OCIO::GammaOpData g1(inBitDepth, outBitDepth, id, desc,
                              OCIO::GammaOpData::MONCURVE_FWD,
                              paramsR, paramsG, params, paramsA);
-        OIIO_CHECK_THROW_WHAT(g1.validate(),
+        OCIO_CHECK_THROW_WHAT(g1.validate(),
                               OCIO::Exception,
                               "GammaOp: Wrong number of parameters");
     }
@@ -899,7 +899,7 @@ OIIO_ADD_TEST(GammaOpData, validate)
         OCIO::GammaOpData g1(inBitDepth, outBitDepth, id, desc,
                              OCIO::GammaOpData::BASIC_FWD,
                              paramsB, paramsB, paramsB, paramsB);
-        OIIO_CHECK_THROW_WHAT(g1.validate(),
+        OCIO_CHECK_THROW_WHAT(g1.validate(),
                               OCIO::Exception,
                               "GammaOp: Wrong number of parameters");
     }
@@ -910,7 +910,7 @@ OIIO_ADD_TEST(GammaOpData, validate)
         OCIO::GammaOpData g1(inBitDepth, outBitDepth, id, desc,
                              OCIO::GammaOpData::BASIC_FWD,
                              params1, params1, params1, params1);
-        OIIO_CHECK_THROW_WHAT(g1.validate(),
+        OCIO_CHECK_THROW_WHAT(g1.validate(),
                               OCIO::Exception,
                               "Parameter 0.006 is less than lower bound 0.01");
     }
@@ -921,7 +921,7 @@ OIIO_ADD_TEST(GammaOpData, validate)
         OCIO::GammaOpData g1(inBitDepth, outBitDepth, id, desc,
                              OCIO::GammaOpData::BASIC_FWD,
                              params1, params1, params1, params1);
-        OIIO_CHECK_THROW_WHAT(g1.validate(),
+        OCIO_CHECK_THROW_WHAT(g1.validate(),
                               OCIO::Exception,
                               "Parameter 110 is greater than upper bound 100");
     }
@@ -934,7 +934,7 @@ OIIO_ADD_TEST(GammaOpData, validate)
         OCIO::GammaOpData g1(inBitDepth, outBitDepth, id, desc,
                              OCIO::GammaOpData::MONCURVE_FWD,
                              params1, params1, params1, params1);
-        OIIO_CHECK_THROW_WHAT(g1.validate(),
+        OCIO_CHECK_THROW_WHAT(g1.validate(),
                               OCIO::Exception,
                               "Parameter 11 is greater than upper bound 0.9");
     }
@@ -947,7 +947,7 @@ OIIO_ADD_TEST(GammaOpData, validate)
                              OCIO::GammaOpData::MONCURVE_FWD,
                              params1, params1, params1, params1);
 
-        OIIO_CHECK_NO_THROW( g1.validate() );
+        OCIO_CHECK_NO_THROW( g1.validate() );
     }
 
     {
@@ -957,13 +957,13 @@ OIIO_ADD_TEST(GammaOpData, validate)
         OCIO::GammaOpData g1(inBitDepth, outBitDepth, id, desc,
                              OCIO::GammaOpData::MONCURVE_FWD,
                              params1, params1, params1, params1);
-        OIIO_CHECK_THROW_WHAT(g1.validate(),
+        OCIO_CHECK_THROW_WHAT(g1.validate(),
                               OCIO::Exception,
                               "Parameter -1e-06 is less than lower bound 0");
     }
 }
 
-OIIO_ADD_TEST(GammaOpData, equality)
+OCIO_ADD_TEST(GammaOpData, equality)
 {
     const OCIO::GammaOpData::Params paramsR1 = { 2.4, 0.1 };
     const OCIO::GammaOpData::Params paramsG1 = { 2.2, 0.2 };
@@ -983,24 +983,24 @@ OIIO_ADD_TEST(GammaOpData, equality)
                          OCIO::GammaOpData::MONCURVE_FWD,
                          paramsR2, paramsG2, paramsB2, paramsA2);
 
-    OIIO_CHECK_ASSERT(!(g1 == g2));
+    OCIO_CHECK_ASSERT(!(g1 == g2));
 
     OCIO::GammaOpData g3(inBitDepth, outBitDepth, id, desc, 
                          OCIO::GammaOpData::MONCURVE_REV,
                          paramsR1, paramsG1, paramsB1, paramsA1);
 
-    OIIO_CHECK_ASSERT(!(g3 == g1));
+    OCIO_CHECK_ASSERT(!(g3 == g1));
 
     g3.setStyle(g1.getStyle());
     g3.validate();
 
-    OIIO_CHECK_ASSERT(g3 == g1);
+    OCIO_CHECK_ASSERT(g3 == g1);
 
     OCIO::GammaOpData g4(inBitDepth, outBitDepth, id, desc,
                          OCIO::GammaOpData::MONCURVE_FWD,
                          paramsR1, paramsG1, paramsB1, paramsA1);
 
-    OIIO_CHECK_ASSERT(g4 == g1);
+    OCIO_CHECK_ASSERT(g4 == g1);
 }
 
 namespace
@@ -1029,25 +1029,25 @@ void CheckGammaInverse(OCIO::BitDepth in,
     OCIO::GammaOpDataRcPtr invOp = refGammaOp.inverse();
 
     // Inverse op should have its input/output bitdepth inverted ...
-    OIIO_CHECK_EQUAL(invOp->getInputBitDepth(), out);
-    OIIO_CHECK_EQUAL(invOp->getOutputBitDepth(), in);
+    OCIO_CHECK_EQUAL(invOp->getInputBitDepth(), out);
+    OCIO_CHECK_EQUAL(invOp->getOutputBitDepth(), in);
 
-    OIIO_CHECK_EQUAL(invOp->getStyle(), invStyle);
+    OCIO_CHECK_EQUAL(invOp->getStyle(), invStyle);
 
-    OIIO_CHECK_ASSERT(invOp->getRedParams()   == invParamsR);
-    OIIO_CHECK_ASSERT(invOp->getGreenParams() == invParamsG);
-    OIIO_CHECK_ASSERT(invOp->getBlueParams()  == invParamsB);
-    OIIO_CHECK_ASSERT(invOp->getAlphaParams() == invParamsA);
+    OCIO_CHECK_ASSERT(invOp->getRedParams()   == invParamsR);
+    OCIO_CHECK_ASSERT(invOp->getGreenParams() == invParamsG);
+    OCIO_CHECK_ASSERT(invOp->getBlueParams()  == invParamsB);
+    OCIO_CHECK_ASSERT(invOp->getAlphaParams() == invParamsA);
 
-    OIIO_CHECK_ASSERT(refGammaOp.isInverse(*invOp));
-    OIIO_CHECK_ASSERT(invOp->isInverse(refGammaOp));
-    OIIO_CHECK_ASSERT(!refGammaOp.isInverse(refGammaOp));
-    OIIO_CHECK_ASSERT(!invOp->isInverse(*invOp));
+    OCIO_CHECK_ASSERT(refGammaOp.isInverse(*invOp));
+    OCIO_CHECK_ASSERT(invOp->isInverse(refGammaOp));
+    OCIO_CHECK_ASSERT(!refGammaOp.isInverse(refGammaOp));
+    OCIO_CHECK_ASSERT(!invOp->isInverse(*invOp));
 }
 
 };
 
-OIIO_ADD_TEST(GammaOpData, basic_inverse)
+OCIO_ADD_TEST(GammaOpData, basic_inverse)
 {
     const OCIO::GammaOpData::Params paramsR = { 2.2 };
     const OCIO::GammaOpData::Params paramsG = { 2.4 };
@@ -1063,7 +1063,7 @@ OIIO_ADD_TEST(GammaOpData, basic_inverse)
                       OCIO::GammaOpData::BASIC_FWD, paramsR, paramsG, paramsB, paramsA);
 }
 
-OIIO_ADD_TEST(GammaOpData, moncurve_inverse)
+OCIO_ADD_TEST(GammaOpData, moncurve_inverse)
 {
     const OCIO::GammaOpData::Params paramsR = { 2.4, 0.1 };
     const OCIO::GammaOpData::Params paramsG = { 2.2, 0.2 };
@@ -1080,7 +1080,7 @@ OIIO_ADD_TEST(GammaOpData, moncurve_inverse)
                       OCIO::GammaOpData::MONCURVE_FWD, paramsR, paramsG, paramsB, paramsA);
 }
 
-OIIO_ADD_TEST(GammaOpData, is_inverse)
+OCIO_ADD_TEST(GammaOpData, is_inverse)
 {
     // NB: isInverse ignores bit-depth.
 
@@ -1102,8 +1102,8 @@ OIIO_ADD_TEST(GammaOpData, is_inverse)
                                OCIO::GammaOpData::BASIC_REV, 
                                paramsR, paramsG, paramsG, paramsR);
 
-    OIIO_CHECK_ASSERT(GammaOp1.isInverse(GammaOp2));
-    OIIO_CHECK_ASSERT(!GammaOp1.isInverse(GammaOp3));
+    OCIO_CHECK_ASSERT(GammaOp1.isInverse(GammaOp2));
+    OCIO_CHECK_ASSERT(!GammaOp1.isInverse(GammaOp3));
 
     paramsR.push_back(0.1);    // offset
     paramsG.push_back(0.1);    // offset
@@ -1121,11 +1121,11 @@ OIIO_ADD_TEST(GammaOpData, is_inverse)
                                 OCIO::GammaOpData::MONCURVE_REV, 
                                 paramsR, paramsG, paramsG, paramsR);
 
-    OIIO_CHECK_ASSERT(GammaOp1m.isInverse(GammaOp2m));
-    OIIO_CHECK_ASSERT(!GammaOp1m.isInverse(GammaOp3m));
+    OCIO_CHECK_ASSERT(GammaOp1m.isInverse(GammaOp2m));
+    OCIO_CHECK_ASSERT(!GammaOp1m.isInverse(GammaOp3m));
 }
 
-OIIO_ADD_TEST(GammaOpData, mayCompose)
+OCIO_ADD_TEST(GammaOpData, mayCompose)
 {
     OCIO::GammaOpData::Params params1 = { 1.  };
     OCIO::GammaOpData::Params params2 = { 2.2 };
@@ -1139,7 +1139,7 @@ OIIO_ADD_TEST(GammaOpData, mayCompose)
                              OCIO::GammaOpData::BASIC_FWD,
                              params2, params2, params2, params1);
         // Note: Bit-depths don't need to match.
-        OIIO_CHECK_ASSERT(g1.mayCompose(g2));
+        OCIO_CHECK_ASSERT(g1.mayCompose(g2));
     }
 
     {
@@ -1150,7 +1150,7 @@ OIIO_ADD_TEST(GammaOpData, mayCompose)
                              OCIO::GammaOpData::BASIC_FWD,
                              params2, params2, params2, params2);
         // Non-identity alpha.
-        OIIO_CHECK_ASSERT(!g1.mayCompose(g2));
+        OCIO_CHECK_ASSERT(!g1.mayCompose(g2));
     }
 
     {
@@ -1161,7 +1161,7 @@ OIIO_ADD_TEST(GammaOpData, mayCompose)
                              OCIO::GammaOpData::BASIC_REV,
                              params3, params3, params3, params1);
         // Basic may be fwd or rev.
-        OIIO_CHECK_ASSERT(g1.mayCompose(g2));
+        OCIO_CHECK_ASSERT(g1.mayCompose(g2));
     }
 
     {
@@ -1172,7 +1172,7 @@ OIIO_ADD_TEST(GammaOpData, mayCompose)
                              OCIO::GammaOpData::BASIC_FWD,
                              params2, params2, params2, params1);
         // R == G != B params.
-        OIIO_CHECK_ASSERT(!g1.mayCompose(g2));
+        OCIO_CHECK_ASSERT(!g1.mayCompose(g2));
     }
 
     {
@@ -1185,7 +1185,7 @@ OIIO_ADD_TEST(GammaOpData, mayCompose)
                              OCIO::GammaOpData::MONCURVE_FWD,
                              params3, params3, params3, params1);
         // Moncurve not allowed.
-        OIIO_CHECK_ASSERT(!g1.mayCompose(g2));
+        OCIO_CHECK_ASSERT(!g1.mayCompose(g2));
     }
 }
 
@@ -1211,20 +1211,20 @@ void CheckGammaCompose(OCIO::GammaOpData::Style style1,
 
     const OCIO::GammaOpDataRcPtr g3 = g1.compose(g2);
 
-    OIIO_CHECK_EQUAL(g3->getInputBitDepth(), inBitDepth);
-    OIIO_CHECK_EQUAL(g3->getOutputBitDepth(), outBitDepth);
+    OCIO_CHECK_EQUAL(g3->getInputBitDepth(), inBitDepth);
+    OCIO_CHECK_EQUAL(g3->getOutputBitDepth(), outBitDepth);
 
-    OIIO_CHECK_EQUAL(g3->getStyle(), refStyle);
+    OCIO_CHECK_EQUAL(g3->getStyle(), refStyle);
 
-    OIIO_CHECK_ASSERT(g3->getRedParams()   == refParams);
-    OIIO_CHECK_ASSERT(g3->getGreenParams() == refParams);
-    OIIO_CHECK_ASSERT(g3->getBlueParams()  == refParams);
-    OIIO_CHECK_ASSERT(g3->getAlphaParams() == paramsA);
+    OCIO_CHECK_ASSERT(g3->getRedParams()   == refParams);
+    OCIO_CHECK_ASSERT(g3->getGreenParams() == refParams);
+    OCIO_CHECK_ASSERT(g3->getBlueParams()  == refParams);
+    OCIO_CHECK_ASSERT(g3->getAlphaParams() == paramsA);
 }
 
 };
 
-OIIO_ADD_TEST(GammaOpData, compose)
+OCIO_ADD_TEST(GammaOpData, compose)
 {
     {
         const OCIO::GammaOpData::Params params1 = { 2. };
@@ -1280,7 +1280,7 @@ OIIO_ADD_TEST(GammaOpData, compose)
                              OCIO::GammaOpData::MONCURVE_REV, 
                              params2, params2, params2, paramsA);
 
-        OIIO_CHECK_THROW_WHAT(g1.compose(g2), 
+        OCIO_CHECK_THROW_WHAT(g1.compose(g2), 
                               OCIO::Exception, 
                               "GammaOp can only be combined with some GammaOps");
     }

--- a/src/OpenColorIO/ops/Gamma/GammaOpUtils.cpp
+++ b/src/OpenColorIO/ops/Gamma/GammaOpUtils.cpp
@@ -176,9 +176,9 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 
 #include "MathUtils.h"
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(GammaOpUtils, compute_params_forward)
+OCIO_ADD_TEST(GammaOpUtils, compute_params_forward)
 {
     const OCIO::GammaOpData::Params gParams = { 2.0f, 0.1f };
     OCIO::RendererParams rParams;
@@ -188,12 +188,12 @@ OIIO_ADD_TEST(GammaOpUtils, compute_params_forward)
     {
         ComputeParamsFwd(gParams, OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, rParams);
 
-        OIIO_CHECK_EQUAL(rParams.gamma,    2.0f);
-        OIIO_CHECK_EQUAL(rParams.offset,   float(0.1 / (1. + 0.1)));
-        OIIO_CHECK_EQUAL(rParams.breakPnt, float(0.1 / (2. - 1. )));
-        OIIO_CHECK_EQUAL(rParams.scale,    float(1.  / (1. + 0.1)));
+        OCIO_CHECK_EQUAL(rParams.gamma,    2.0f);
+        OCIO_CHECK_EQUAL(rParams.offset,   float(0.1 / (1. + 0.1)));
+        OCIO_CHECK_EQUAL(rParams.breakPnt, float(0.1 / (2. - 1. )));
+        OCIO_CHECK_EQUAL(rParams.scale,    float(1.  / (1. + 0.1)));
 
-        OIIO_CHECK_ASSERT(OCIO::EqualWithAbsError(rParams.slope, 0.33057851f, 1e-7f));
+        OCIO_CHECK_ASSERT(OCIO::EqualWithAbsError(rParams.slope, 0.33057851f, 1e-7f));
     }
 
     // UINT10 to F16
@@ -201,17 +201,17 @@ OIIO_ADD_TEST(GammaOpUtils, compute_params_forward)
     {
         ComputeParamsFwd(gParams, OCIO::BIT_DEPTH_UINT10, OCIO::BIT_DEPTH_F16, rParams);
 
-        OIIO_CHECK_EQUAL(rParams.gamma,    2.0f);
-        OIIO_CHECK_EQUAL(rParams.offset,   float( 0.1 / (1. + 0.1)));
-        OIIO_CHECK_EQUAL(rParams.breakPnt, float((0.1 / (2. - 1. )) * 1023.));
-        OIIO_CHECK_EQUAL(rParams.scale,    float((1.  / (1. + 0.1)) / 1023.));
+        OCIO_CHECK_EQUAL(rParams.gamma,    2.0f);
+        OCIO_CHECK_EQUAL(rParams.offset,   float( 0.1 / (1. + 0.1)));
+        OCIO_CHECK_EQUAL(rParams.breakPnt, float((0.1 / (2. - 1. )) * 1023.));
+        OCIO_CHECK_EQUAL(rParams.scale,    float((1.  / (1. + 0.1)) / 1023.));
 
-        OIIO_CHECK_ASSERT(OCIO::EqualWithAbsError(rParams.slope, 0.00032314f, 1e-7f));
+        OCIO_CHECK_ASSERT(OCIO::EqualWithAbsError(rParams.slope, 0.00032314f, 1e-7f));
     }
 }
 
 
-OIIO_ADD_TEST(GammaOpUtils, compute_params_reverse)
+OCIO_ADD_TEST(GammaOpUtils, compute_params_reverse)
 {
     const OCIO::GammaOpData::Params gParams = { 2.0f, 0.1f };
     OCIO::RendererParams rParams;
@@ -221,12 +221,12 @@ OIIO_ADD_TEST(GammaOpUtils, compute_params_reverse)
     {
         ComputeParamsRev(gParams, OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, rParams);
 
-        OIIO_CHECK_EQUAL(rParams.gamma,    0.5f );
-        OIIO_CHECK_EQUAL(rParams.offset,   0.1f);
-        OIIO_CHECK_EQUAL(rParams.scale,    1.0f + 0.1f);
+        OCIO_CHECK_EQUAL(rParams.gamma,    0.5f );
+        OCIO_CHECK_EQUAL(rParams.offset,   0.1f);
+        OCIO_CHECK_EQUAL(rParams.scale,    1.0f + 0.1f);
 
-        OIIO_CHECK_ASSERT(OCIO::EqualWithAbsError(rParams.breakPnt, 0.03305785f, 1e-7f));
-        OIIO_CHECK_ASSERT(OCIO::EqualWithAbsError(rParams.slope,    3.02499986f, 1e-7f));
+        OCIO_CHECK_ASSERT(OCIO::EqualWithAbsError(rParams.breakPnt, 0.03305785f, 1e-7f));
+        OCIO_CHECK_ASSERT(OCIO::EqualWithAbsError(rParams.slope,    3.02499986f, 1e-7f));
     }
 
     // UINT10 to F16
@@ -234,12 +234,12 @@ OIIO_ADD_TEST(GammaOpUtils, compute_params_reverse)
     {
         ComputeParamsRev(gParams, OCIO::BIT_DEPTH_UINT10, OCIO::BIT_DEPTH_F16, rParams);
 
-        OIIO_CHECK_EQUAL(rParams.gamma,    0.5f);
-        OIIO_CHECK_EQUAL(rParams.offset,   0.1f);
-        OIIO_CHECK_EQUAL(rParams.scale,    1.0f + 0.1f);
+        OCIO_CHECK_EQUAL(rParams.gamma,    0.5f);
+        OCIO_CHECK_EQUAL(rParams.offset,   0.1f);
+        OCIO_CHECK_EQUAL(rParams.scale,    1.0f + 0.1f);
 
-        OIIO_CHECK_ASSERT(OCIO::EqualWithAbsError(rParams.breakPnt, 33.81818390f, 1e-7f));
-        OIIO_CHECK_ASSERT(OCIO::EqualWithAbsError(rParams.slope,     0.00295698f, 1e-7f));
+        OCIO_CHECK_ASSERT(OCIO::EqualWithAbsError(rParams.breakPnt, 33.81818390f, 1e-7f));
+        OCIO_CHECK_ASSERT(OCIO::EqualWithAbsError(rParams.slope,     0.00295698f, 1e-7f));
     }
 
 }

--- a/src/OpenColorIO/ops/Gamma/GammaOps.cpp
+++ b/src/OpenColorIO/ops/Gamma/GammaOps.cpp
@@ -398,7 +398,7 @@ namespace OCIO = OCIO_NAMESPACE;
 
 #include "MathUtils.h"
 #include "ParseUtils.h"
-#include "unittest.h"
+#include "UnitTest.h"
 
 
 namespace
@@ -411,7 +411,7 @@ void ApplyGamma(const OCIO::OpRcPtr & op,
                 long numPixels, 
                 float errorThreshold)
 {
-    OIIO_CHECK_NO_THROW(op->apply(image, numPixels));
+    OCIO_CHECK_NO_THROW(op->apply(image, numPixels));
 
     for(long idx=0; idx<(numPixels*4); ++idx)
     {
@@ -432,14 +432,14 @@ void ApplyGamma(const OCIO::OpRcPtr & op,
                     << " - Values: " << image[idx]
                     << " and: " << result[idx]
                     << " - Threshold: " << errorThreshold;
-            OIIO_CHECK_ASSERT_MESSAGE(0, message.str());
+            OCIO_CHECK_ASSERT_MESSAGE(0, message.str());
         }
     }
 }
 
 };
 
-OIIO_ADD_TEST(GammaOps, apply_basic_style_fwd)
+OCIO_ADD_TEST(GammaOps, apply_basic_style_fwd)
 {
     const float errorThreshold = 1e-7f;
     const long numPixels = 6;
@@ -480,17 +480,17 @@ OIIO_ADD_TEST(GammaOps, apply_basic_style_fwd)
 
     OCIO::OpRcPtrVec ops;
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         OCIO::CreateGammaOp(ops, id, desc, OCIO::GammaOpData::BASIC_FWD,
                             &gamma4[0], nullptr));
 
     OCIO::FinalizeOpVec(ops, true);
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
 
     ApplyGamma(ops[0], input_32f, expected_32f, numPixels, errorThreshold);
 }
 
-OIIO_ADD_TEST(GammaOps, apply_basic_style_rev)
+OCIO_ADD_TEST(GammaOps, apply_basic_style_rev)
 {
     const float errorThreshold = 1e-7f;
     const long numPixels = 6;
@@ -531,17 +531,17 @@ OIIO_ADD_TEST(GammaOps, apply_basic_style_rev)
 
     OCIO::OpRcPtrVec ops;
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         OCIO::CreateGammaOp(ops, id, desc, OCIO::GammaOpData::BASIC_REV,
                             &gamma4[0], nullptr));
 
     OCIO::FinalizeOpVec(ops, true);
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
 
     ApplyGamma(ops[0], input_32f, expected_32f, numPixels, errorThreshold);
 }
 
-OIIO_ADD_TEST(GammaOps, apply_moncurve_style_fwd)
+OCIO_ADD_TEST(GammaOps, apply_moncurve_style_fwd)
 {
     const float errorThreshold = 1e-7f;
     const long numPixels = 6;
@@ -577,17 +577,17 @@ OIIO_ADD_TEST(GammaOps, apply_moncurve_style_fwd)
     const std::vector<double> gamma4 = { 2.4,   2.2, 2.0, 1.8 };
     const std::vector<double> offset4= { 0.055, 0.2, 0.4, 0.6 };
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         OCIO::CreateGammaOp(ops, id, desc, OCIO::GammaOpData::MONCURVE_FWD,
                             &gamma4[0], &offset4[0]));
 
     OCIO::FinalizeOpVec(ops, true);
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
 
     ApplyGamma(ops[0], input_32f, expected_32f, numPixels, errorThreshold);
 }
 
-OIIO_ADD_TEST(GammaOps, apply_moncurve_style_rev)
+OCIO_ADD_TEST(GammaOps, apply_moncurve_style_rev)
 {
     const float errorThreshold = 1e-6f;
     const long numPixels = 6;
@@ -629,112 +629,112 @@ OIIO_ADD_TEST(GammaOps, apply_moncurve_style_rev)
     const std::vector<double> gamma4 = { 2.4, 2.2, 2.0, 1.8 };
     const std::vector<double> offset4= { 0.1, 0.2, 0.4, 0.6 };
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         OCIO::CreateGammaOp(ops, id, desc, OCIO::GammaOpData::MONCURVE_REV,
                             &gamma4[0], &offset4[0]));
 
     OCIO::FinalizeOpVec(ops, true);
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
 
     ApplyGamma(ops[0], input_32f, expected_32f, numPixels, errorThreshold);
 }
 
-OIIO_ADD_TEST(GammaOps, combining)
+OCIO_ADD_TEST(GammaOps, combining)
 {
     OCIO::OpRcPtrVec ops;
 
     const std::vector<double> gamma4_1 = { 1.201, 1.201, 1.201, 1. };
     const std::vector<double> gamma4_2 = { 2.345, 2.345, 2.345, 1. };
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         OCIO::CreateGammaOp(ops, id, desc, OCIO::GammaOpData::BASIC_FWD,
                             &gamma4_1[0], nullptr));
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         OCIO::CreateGammaOp(ops, id, desc, OCIO::GammaOpData::BASIC_FWD,
                             &gamma4_2[0], nullptr));
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     OCIO::ConstOpRcPtr op1 = ops[1];
 
-    OIIO_CHECK_ASSERT(ops[0]->canCombineWith(op1));
-    OIIO_CHECK_NO_THROW(ops[0]->combineWith(ops, op1));
+    OCIO_CHECK_ASSERT(ops[0]->canCombineWith(op1));
+    OCIO_CHECK_NO_THROW(ops[0]->combineWith(ops, op1));
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 3);
+    OCIO_REQUIRE_EQUAL(ops.size(), 3);
     OCIO::ConstOpRcPtr op2 = ops[2];
 
-    OIIO_REQUIRE_EQUAL(op2->data()->getType(), OCIO::OpData::GammaType);
+    OCIO_REQUIRE_EQUAL(op2->data()->getType(), OCIO::OpData::GammaType);
 
     OCIO::ConstGammaOpDataRcPtr g = OCIO::DynamicPtrCast<const OCIO::GammaOpData>(op2->data());
 
-    OIIO_CHECK_EQUAL(g->getRedParams()[0],   gamma4_1[0]*gamma4_2[0]);
-    OIIO_CHECK_EQUAL(g->getGreenParams()[0], gamma4_1[1]*gamma4_2[1]);
-    OIIO_CHECK_EQUAL(g->getBlueParams()[0],  gamma4_1[2]*gamma4_2[2]);
-    OIIO_CHECK_EQUAL(g->getAlphaParams()[0], gamma4_1[3]*gamma4_2[3]);
+    OCIO_CHECK_EQUAL(g->getRedParams()[0],   gamma4_1[0]*gamma4_2[0]);
+    OCIO_CHECK_EQUAL(g->getGreenParams()[0], gamma4_1[1]*gamma4_2[1]);
+    OCIO_CHECK_EQUAL(g->getBlueParams()[0],  gamma4_1[2]*gamma4_2[2]);
+    OCIO_CHECK_EQUAL(g->getAlphaParams()[0], gamma4_1[3]*gamma4_2[3]);
 }
 
-OIIO_ADD_TEST(GammaOps, is_inverse)
+OCIO_ADD_TEST(GammaOps, is_inverse)
 {
     OCIO::OpRcPtrVec ops;
 
     const std::vector<double> gamma4 = { 1.001, 1., 1., 1. };
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         OCIO::CreateGammaOp(ops, id, desc, OCIO::GammaOpData::BASIC_FWD,
                             &gamma4[0], nullptr));
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         OCIO::CreateGammaOp(ops, id, desc, OCIO::GammaOpData::BASIC_REV,
                             &gamma4[0], nullptr));
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     OCIO::ConstOpRcPtr op1 = ops[1];
-    OIIO_CHECK_ASSERT(ops[0]->isInverse(op1));
+    OCIO_CHECK_ASSERT(ops[0]->isInverse(op1));
 }
 
-OIIO_ADD_TEST(GammaOps, computed_identifier)
+OCIO_ADD_TEST(GammaOps, computed_identifier)
 {
     OCIO::OpRcPtrVec ops;
 
     std::vector<double> gamma4 = { 1.001, 1., 1., 1. };
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         OCIO::CreateGammaOp(ops, id, desc, OCIO::GammaOpData::BASIC_FWD,
                             &gamma4[0], nullptr));
-    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops.size(), 1);
 
     gamma4[1] = 1.001;
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         OCIO::CreateGammaOp(ops, id, desc, OCIO::GammaOpData::BASIC_FWD,
                             &gamma4[0], nullptr));
-    OIIO_CHECK_EQUAL(ops.size(), 2);
+    OCIO_CHECK_EQUAL(ops.size(), 2);
 
     OCIO::FinalizeOpVec(ops, false); // no optimizations
 
-    OIIO_CHECK_ASSERT(ops[0]->getCacheID() != ops[1]->getCacheID());
+    OCIO_CHECK_ASSERT(ops[0]->getCacheID() != ops[1]->getCacheID());
 
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         OCIO::CreateGammaOp(ops, id, desc, OCIO::GammaOpData::BASIC_FWD,
                             &gamma4[0], nullptr));
-    OIIO_CHECK_EQUAL(ops.size(), 3);
+    OCIO_CHECK_EQUAL(ops.size(), 3);
 
     OCIO::FinalizeOpVec(ops, false); // no optimizations
 
-    OIIO_CHECK_ASSERT(ops[0]->getCacheID() != ops[2]->getCacheID());
-    OIIO_CHECK_ASSERT(ops[1]->getCacheID() == ops[2]->getCacheID());
+    OCIO_CHECK_ASSERT(ops[0]->getCacheID() != ops[2]->getCacheID());
+    OCIO_CHECK_ASSERT(ops[1]->getCacheID() == ops[2]->getCacheID());
 
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         OCIO::CreateGammaOp(ops, id, desc, OCIO::GammaOpData::BASIC_REV,
                             &gamma4[0], nullptr));
-    OIIO_CHECK_EQUAL(ops.size(), 4);
+    OCIO_CHECK_EQUAL(ops.size(), 4);
 
     OCIO::FinalizeOpVec(ops, false); // no optimizations
 
-    OIIO_CHECK_ASSERT(ops[0]->getCacheID() != ops[3]->getCacheID());
-    OIIO_CHECK_ASSERT(ops[1]->getCacheID() != ops[3]->getCacheID());
-    OIIO_CHECK_ASSERT(ops[2]->getCacheID() != ops[3]->getCacheID());
+    OCIO_CHECK_ASSERT(ops[0]->getCacheID() != ops[3]->getCacheID());
+    OCIO_CHECK_ASSERT(ops[1]->getCacheID() != ops[3]->getCacheID());
+    OCIO_CHECK_ASSERT(ops[2]->getCacheID() != ops[3]->getCacheID());
 }
 
 

--- a/src/OpenColorIO/ops/IndexMapping.cpp
+++ b/src/OpenColorIO/ops/IndexMapping.cpp
@@ -133,9 +133,9 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(IndexMapping, test_accessors)
+OCIO_ADD_TEST(IndexMapping, test_accessors)
 {
     OCIO::IndexMapping ref(4);
     ref.setPair(0u, 0.f, 0.f);
@@ -143,29 +143,29 @@ OIIO_ADD_TEST(IndexMapping, test_accessors)
     ref.setPair(2u, 200.f, 2.f);
     ref.setPair(3u, 300.f, 3.f);
 
-    OIIO_CHECK_THROW_WHAT(ref.setPair(5u, 300.f, 3.f),
+    OCIO_CHECK_THROW_WHAT(ref.setPair(5u, 300.f, 3.f),
                           OCIO::Exception,
                           "invalid. Should be less than");
 
     ref.validate();
 
-    OIIO_CHECK_EQUAL(ref.getDimension(), 4u);
+    OCIO_CHECK_EQUAL(ref.getDimension(), 4u);
     float first, second;
     ref.getPair(0u, first, second);
-    OIIO_CHECK_EQUAL(first, 0.f);  OIIO_CHECK_EQUAL(second, 0.f);
+    OCIO_CHECK_EQUAL(first, 0.f);  OCIO_CHECK_EQUAL(second, 0.f);
     ref.getPair(1u, first, second);
-    OIIO_CHECK_EQUAL(first, 100.f);  OIIO_CHECK_EQUAL(second, 1.f);
+    OCIO_CHECK_EQUAL(first, 100.f);  OCIO_CHECK_EQUAL(second, 1.f);
     ref.getPair(2u, first, second);
-    OIIO_CHECK_EQUAL(first, 200.f);  OIIO_CHECK_EQUAL(second, 2.f);
+    OCIO_CHECK_EQUAL(first, 200.f);  OCIO_CHECK_EQUAL(second, 2.f);
     ref.getPair(3u, first, second);
-    OIIO_CHECK_EQUAL(first, 300.f);  OIIO_CHECK_EQUAL(second, 3.f);
+    OCIO_CHECK_EQUAL(first, 300.f);  OCIO_CHECK_EQUAL(second, 3.f);
 
     ref.resize(8);
-    OIIO_CHECK_EQUAL(ref.getDimension(), 8u);
+    OCIO_CHECK_EQUAL(ref.getDimension(), 8u);
 
 }
 
-OIIO_ADD_TEST(IndexMapping, range_validation)
+OCIO_ADD_TEST(IndexMapping, range_validation)
 {
     OCIO::IndexMapping ref(4);
     ref.setPair(0u, 0.f, 0.f);
@@ -173,17 +173,17 @@ OIIO_ADD_TEST(IndexMapping, range_validation)
     ref.setPair(2u, 200.f, 2.f);
     ref.setPair(3u, 200.f, 3.f);  // illegal
 
-    OIIO_CHECK_THROW_WHAT(ref.validate(), 
+    OCIO_CHECK_THROW_WHAT(ref.validate(), 
                           OCIO::Exception, 
                           "Index values must be increasing");
 
     ref.setPair(3u, 300.f, 2.f);  // illegal
-    OIIO_CHECK_THROW_WHAT(ref.validate(), 
+    OCIO_CHECK_THROW_WHAT(ref.validate(), 
                           OCIO::Exception, 
                           "Index values must be increasing");
 }
 
-OIIO_ADD_TEST(IndexMapping, equality)
+OCIO_ADD_TEST(IndexMapping, equality)
 {
     OCIO::IndexMapping ref1(4);
     ref1.setPair(0u, 0.f, 0.f);
@@ -197,11 +197,11 @@ OIIO_ADD_TEST(IndexMapping, equality)
     ref2.setPair(2u, 200.f, 2.f);
     ref2.setPair(3u, 300.f, 3.f);
 
-    OIIO_CHECK_ASSERT(ref1 == ref2);
+    OCIO_CHECK_ASSERT(ref1 == ref2);
 
     ref2.setPair(2u, 200.f, 2.1f);
 
-    OIIO_CHECK_ASSERT(!(ref1 == ref2));
+    OCIO_CHECK_ASSERT(!(ref1 == ref2));
 }
 
 #endif

--- a/src/OpenColorIO/ops/Log/LogOpCPU.cpp
+++ b/src/OpenColorIO/ops/Log/LogOpCPU.cpp
@@ -564,7 +564,7 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 void TestLog(float logBase)
 {
@@ -608,27 +608,27 @@ void TestLog(float logBase)
             expected = logf(std::max(minValue, (float)expected)) / logf(logBase);
         }
 
-        OIIO_CHECK_CLOSE(result, expected, error);
+        OCIO_CHECK_CLOSE(result, expected, error);
     }
 
     const float resMin = logf(minValue) / logf(logBase);
-    OIIO_CHECK_CLOSE(rgba[8], resMin, error);
-    OIIO_CHECK_EQUAL(rgba[11], 0.0f);
-    OIIO_CHECK_CLOSE(rgba[12], resMin, error);
-    OIIO_CHECK_ASSERT(OCIO::IsNan(rgba[15]));
+    OCIO_CHECK_CLOSE(rgba[8], resMin, error);
+    OCIO_CHECK_EQUAL(rgba[11], 0.0f);
+    OCIO_CHECK_CLOSE(rgba[12], resMin, error);
+    OCIO_CHECK_ASSERT(OCIO::IsNan(rgba[15]));
     // SSE implementation of sseLog2 & sseExp2 do not behave like CPU for
     // infinity & NaN. Some tests had to be disabled.
-    //OIIO_CHECK_EQUAL(rgba[16], inf);
-    OIIO_CHECK_EQUAL(rgba[19], 0.0f);
-    OIIO_CHECK_CLOSE(rgba[20], resMin, error);
-    OIIO_CHECK_EQUAL(rgba[23], inf);
-    OIIO_CHECK_CLOSE(rgba[24], resMin, error);
-    OIIO_CHECK_EQUAL(rgba[27], 0.0f);
-    OIIO_CHECK_CLOSE(rgba[28], resMin, error);
-    OIIO_CHECK_EQUAL(rgba[31], -inf);
+    //OCIO_CHECK_EQUAL(rgba[16], inf);
+    OCIO_CHECK_EQUAL(rgba[19], 0.0f);
+    OCIO_CHECK_CLOSE(rgba[20], resMin, error);
+    OCIO_CHECK_EQUAL(rgba[23], inf);
+    OCIO_CHECK_CLOSE(rgba[24], resMin, error);
+    OCIO_CHECK_EQUAL(rgba[27], 0.0f);
+    OCIO_CHECK_CLOSE(rgba[28], resMin, error);
+    OCIO_CHECK_EQUAL(rgba[31], -inf);
 }
 
-OIIO_ADD_TEST(LogOpCPU, log_test)
+OCIO_ADD_TEST(LogOpCPU, log_test)
 {
     // Log base 10 case, no scaling.
     TestLog(10.0f);
@@ -675,23 +675,23 @@ void TestAntiLog(float logBase)
 
         // LogOpCPU implementation uses optimized logarithm approximation
         // cannot use strict comparison.
-        OIIO_CHECK_ASSERT(OCIO::EqualWithSafeRelError(result, expected, rtol, 1.0f));
+        OCIO_CHECK_ASSERT(OCIO::EqualWithSafeRelError(result, expected, rtol, 1.0f));
     }
-    //OIIO_CHECK_ASSERT(OCIO::IsNan(rgba[8]));
-    OIIO_CHECK_EQUAL(rgba[11], 0.0f);
-    OIIO_CHECK_CLOSE(rgba[12], 1.0f, rtol);
-    OIIO_CHECK_ASSERT(OCIO::IsNan(rgba[15]));
-    //OIIO_CHECK_EQUAL(rgba[16], inf);
-    OIIO_CHECK_EQUAL(rgba[19], 0.0f);
-    OIIO_CHECK_CLOSE(rgba[20], 1.0f, rtol);
-    OIIO_CHECK_EQUAL(rgba[23], inf);
-    //OIIO_CHECK_EQUAL(rgba[24], 0.0f);
-    OIIO_CHECK_EQUAL(rgba[27], 0.0f);
-    OIIO_CHECK_CLOSE(rgba[28], 1.0f, rtol);
-    OIIO_CHECK_EQUAL(rgba[31], -inf);
+    //OCIO_CHECK_ASSERT(OCIO::IsNan(rgba[8]));
+    OCIO_CHECK_EQUAL(rgba[11], 0.0f);
+    OCIO_CHECK_CLOSE(rgba[12], 1.0f, rtol);
+    OCIO_CHECK_ASSERT(OCIO::IsNan(rgba[15]));
+    //OCIO_CHECK_EQUAL(rgba[16], inf);
+    OCIO_CHECK_EQUAL(rgba[19], 0.0f);
+    OCIO_CHECK_CLOSE(rgba[20], 1.0f, rtol);
+    OCIO_CHECK_EQUAL(rgba[23], inf);
+    //OCIO_CHECK_EQUAL(rgba[24], 0.0f);
+    OCIO_CHECK_EQUAL(rgba[27], 0.0f);
+    OCIO_CHECK_CLOSE(rgba[28], 1.0f, rtol);
+    OCIO_CHECK_EQUAL(rgba[31], -inf);
 }
 
-OIIO_ADD_TEST(LogOpCPU, anti_log_test)
+OCIO_ADD_TEST(LogOpCPU, anti_log_test)
 {
     // Anti-Log base 10 case, no scaling.
     TestAntiLog(10.0f);
@@ -723,7 +723,7 @@ float ComputeLog2LinEval(float in, const OCIO::LogUtil::CTFParams::Params & para
            - offset + shadow;
 }
 
-OIIO_ADD_TEST(LogOpCPU, log2lin_test)
+OCIO_ADD_TEST(LogOpCPU, log2lin_test)
 {
     const float qnan = std::numeric_limits<float>::quiet_NaN();
     const float inf = std::numeric_limits<float>::infinity();
@@ -803,28 +803,28 @@ OIIO_ADD_TEST(LogOpCPU, log2lin_test)
 
         // LogOpCPU implementation uses optimized logarithm approximation
         // cannot use strict comparison.
-        OIIO_CHECK_ASSERT(OCIO::EqualWithSafeRelError(result, expected, rtol, 1.0f));
+        OCIO_CHECK_ASSERT(OCIO::EqualWithSafeRelError(result, expected, rtol, 1.0f));
     }
 
     const float res0 = ComputeLog2LinEval(0.0f, redP);
 
-    //OIIO_CHECK_ASSERT(OCIO::IsNan(rgba[8]));
-    OIIO_CHECK_EQUAL(rgba[11], 0.0f);
+    //OCIO_CHECK_ASSERT(OCIO::IsNan(rgba[8]));
+    OCIO_CHECK_EQUAL(rgba[11], 0.0f);
 
-    OIIO_CHECK_CLOSE(rgba[12], res0, rtol);
-    OIIO_CHECK_ASSERT(OCIO::IsNan(rgba[15]));
+    OCIO_CHECK_CLOSE(rgba[12], res0, rtol);
+    OCIO_CHECK_ASSERT(OCIO::IsNan(rgba[15]));
 
-    //OIIO_CHECK_EQUAL(rgba[16], inf);
-    OIIO_CHECK_EQUAL(rgba[19], 0.0f);
+    //OCIO_CHECK_EQUAL(rgba[16], inf);
+    OCIO_CHECK_EQUAL(rgba[19], 0.0f);
 
-    OIIO_CHECK_CLOSE(rgba[20], res0, rtol);
-    OIIO_CHECK_EQUAL(rgba[23], inf);
+    OCIO_CHECK_CLOSE(rgba[20], res0, rtol);
+    OCIO_CHECK_EQUAL(rgba[23], inf);
 
-    //OIIO_CHECK_CLOSE(rgba[24], ComputeLog2LinEval(-inf, redP), rtol);
-    OIIO_CHECK_EQUAL(rgba[27], 0.0f);
+    //OCIO_CHECK_CLOSE(rgba[24], ComputeLog2LinEval(-inf, redP), rtol);
+    OCIO_CHECK_EQUAL(rgba[27], 0.0f);
 
-    OIIO_CHECK_CLOSE(rgba[28], res0, rtol);
-    OIIO_CHECK_EQUAL(rgba[31], -inf);
+    OCIO_CHECK_CLOSE(rgba[28], res0, rtol);
+    OCIO_CHECK_EQUAL(rgba[31], -inf);
 }
 
 float ComputeLin2LogEval(float in, const OCIO::LogUtil::CTFParams::Params & params)
@@ -852,7 +852,7 @@ float ComputeLin2LogEval(float in, const OCIO::LogUtil::CTFParams::Params & para
            / mult_factor + refWhite;
 }
 
-OIIO_ADD_TEST(LogOpCPU, lin2log_test)
+OCIO_ADD_TEST(LogOpCPU, lin2log_test)
 {
     const float qnan = std::numeric_limits<float>::quiet_NaN();
     const float inf = std::numeric_limits<float>::infinity();
@@ -930,29 +930,29 @@ OIIO_ADD_TEST(LogOpCPU, lin2log_test)
 
         // LogOpCPU implementation uses optimized logarithm approximation
         // cannot use strict comparison
-        OIIO_CHECK_CLOSE(result, expected, error);
+        OCIO_CHECK_CLOSE(result, expected, error);
     }
 
     const float res0 = ComputeLin2LogEval(0.0f, redP);
     const float resMin = ComputeLin2LogEval(-100.0f, redP);
 
-    OIIO_CHECK_CLOSE(rgba[8], resMin, error);
-    OIIO_CHECK_EQUAL(rgba[11], 0.0f);
+    OCIO_CHECK_CLOSE(rgba[8], resMin, error);
+    OCIO_CHECK_EQUAL(rgba[11], 0.0f);
 
-    OIIO_CHECK_CLOSE(rgba[12], res0, error);
-    OIIO_CHECK_ASSERT(OCIO::IsNan(rgba[15]));
+    OCIO_CHECK_CLOSE(rgba[12], res0, error);
+    OCIO_CHECK_ASSERT(OCIO::IsNan(rgba[15]));
 
-    //OIIO_CHECK_EQUAL(rgba[16], inf);
-    OIIO_CHECK_EQUAL(rgba[19], 0.0f);
+    //OCIO_CHECK_EQUAL(rgba[16], inf);
+    OCIO_CHECK_EQUAL(rgba[19], 0.0f);
 
-    OIIO_CHECK_CLOSE(rgba[20], res0, error);
-    OIIO_CHECK_EQUAL(rgba[23], inf);
+    OCIO_CHECK_CLOSE(rgba[20], res0, error);
+    OCIO_CHECK_EQUAL(rgba[23], inf);
 
-    OIIO_CHECK_CLOSE(rgba[24], resMin, error);
-    OIIO_CHECK_EQUAL(rgba[27], 0.0f);
+    OCIO_CHECK_CLOSE(rgba[24], resMin, error);
+    OCIO_CHECK_EQUAL(rgba[27], 0.0f);
 
-    OIIO_CHECK_CLOSE(rgba[28], res0, error);
-    OIIO_CHECK_EQUAL(rgba[31], -inf);
+    OCIO_CHECK_CLOSE(rgba[28], res0, error);
+    OCIO_CHECK_EQUAL(rgba[31], -inf);
 }
 
 // TODO: Test bitdepth support scaling - (logOp_Log_withScaling_test)

--- a/src/OpenColorIO/ops/Log/LogOpData.cpp
+++ b/src/OpenColorIO/ops/Log/LogOpData.cpp
@@ -454,9 +454,9 @@ OCIO_NAMESPACE_EXIT
 
 namespace OCIO = OCIO_NAMESPACE;
 
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(LogOpData, accessor_test)
+OCIO_ADD_TEST(LogOpData, accessor_test)
 {
     OCIO::LogUtil::CTFParams ctfParams;
     auto & redP = ctfParams.get(OCIO::LogUtil::CTFParams::red);
@@ -492,15 +492,15 @@ OIIO_ADD_TEST(LogOpData, accessor_test)
     OCIO::LogOpData logOp(inBitDepth, outBitDepth, dir,
                           base, paramsR, paramsG, paramsB);
 
-    OIIO_CHECK_EQUAL(logOp.getType(), OCIO::OpData::LogType);
-    OIIO_CHECK_EQUAL(logOp.getInputBitDepth(), inBitDepth);
-    OIIO_CHECK_EQUAL(logOp.getOutputBitDepth(), outBitDepth);
+    OCIO_CHECK_EQUAL(logOp.getType(), OCIO::OpData::LogType);
+    OCIO_CHECK_EQUAL(logOp.getInputBitDepth(), inBitDepth);
+    OCIO_CHECK_EQUAL(logOp.getOutputBitDepth(), outBitDepth);
 
-    OIIO_CHECK_ASSERT(!logOp.allComponentsEqual());
-    OIIO_CHECK_EQUAL(logOp.getBase(), base);
-    OIIO_CHECK_ASSERT(logOp.getRedParams() == paramsR);
-    OIIO_CHECK_ASSERT(logOp.getGreenParams() == paramsG);
-    OIIO_CHECK_ASSERT(logOp.getBlueParams() == paramsB);
+    OCIO_CHECK_ASSERT(!logOp.allComponentsEqual());
+    OCIO_CHECK_EQUAL(logOp.getBase(), base);
+    OCIO_CHECK_ASSERT(logOp.getRedParams() == paramsR);
+    OCIO_CHECK_ASSERT(logOp.getGreenParams() == paramsG);
+    OCIO_CHECK_ASSERT(logOp.getBlueParams() == paramsB);
 
     // Update all channels with same parameters.
     greenP = redP;
@@ -510,10 +510,10 @@ OIIO_ADD_TEST(LogOpData, accessor_test)
     OCIO::LogOpData logOp2(inBitDepth, outBitDepth, dir,
                            base, paramsR, paramsG, paramsB);
 
-    OIIO_CHECK_ASSERT(logOp2.allComponentsEqual());
-    OIIO_CHECK_ASSERT(logOp2.getRedParams() == paramsR);
-    OIIO_CHECK_ASSERT(logOp2.getGreenParams() == paramsR);
-    OIIO_CHECK_ASSERT(logOp2.getBlueParams() == paramsR);
+    OCIO_CHECK_ASSERT(logOp2.allComponentsEqual());
+    OCIO_CHECK_ASSERT(logOp2.getRedParams() == paramsR);
+    OCIO_CHECK_ASSERT(logOp2.getGreenParams() == paramsR);
+    OCIO_CHECK_ASSERT(logOp2.getBlueParams() == paramsR);
 
     // Update only red channel with new parameters.
     redP[OCIO::LogUtil::CTFParams::gamma]     = 0.6; 
@@ -527,10 +527,10 @@ OIIO_ADD_TEST(LogOpData, accessor_test)
     OCIO::LogOpData logOp3(inBitDepth, outBitDepth, dir,
                            base, paramsR, paramsG, paramsB);
 
-    OIIO_CHECK_ASSERT(!logOp3.allComponentsEqual());
-    OIIO_CHECK_ASSERT(logOp3.getRedParams() == paramsR);
-    OIIO_CHECK_ASSERT(logOp3.getGreenParams() == paramsG);
-    OIIO_CHECK_ASSERT(logOp3.getBlueParams() == paramsB);
+    OCIO_CHECK_ASSERT(!logOp3.allComponentsEqual());
+    OCIO_CHECK_ASSERT(logOp3.getRedParams() == paramsR);
+    OCIO_CHECK_ASSERT(logOp3.getGreenParams() == paramsG);
+    OCIO_CHECK_ASSERT(logOp3.getBlueParams() == paramsB);
 
     // Update only green channel with new parameters.
     redP = greenP;
@@ -544,10 +544,10 @@ OIIO_ADD_TEST(LogOpData, accessor_test)
 
     OCIO::LogOpData logOp4(inBitDepth, outBitDepth, dir,
                            base, paramsR, paramsG, paramsB);
-    OIIO_CHECK_ASSERT(!logOp4.allComponentsEqual());
-    OIIO_CHECK_ASSERT(logOp4.getRedParams() == paramsR);
-    OIIO_CHECK_ASSERT(logOp4.getGreenParams() == paramsG);
-    OIIO_CHECK_ASSERT(logOp4.getBlueParams() == paramsB);
+    OCIO_CHECK_ASSERT(!logOp4.allComponentsEqual());
+    OCIO_CHECK_ASSERT(logOp4.getRedParams() == paramsR);
+    OCIO_CHECK_ASSERT(logOp4.getGreenParams() == paramsG);
+    OCIO_CHECK_ASSERT(logOp4.getBlueParams() == paramsB);
 
     // Update only blue channel with new parameters.
     greenP = redP;
@@ -561,21 +561,21 @@ OIIO_ADD_TEST(LogOpData, accessor_test)
 
     OCIO::LogOpData logOp5(inBitDepth, outBitDepth, dir,
                            base, paramsR, paramsG, paramsB);
-    OIIO_CHECK_ASSERT(!logOp5.allComponentsEqual());
-    OIIO_CHECK_ASSERT(logOp5.getRedParams() == paramsR);
-    OIIO_CHECK_ASSERT(logOp5.getGreenParams() == paramsG);
-    OIIO_CHECK_ASSERT(logOp5.getBlueParams() == paramsB);
+    OCIO_CHECK_ASSERT(!logOp5.allComponentsEqual());
+    OCIO_CHECK_ASSERT(logOp5.getRedParams() == paramsR);
+    OCIO_CHECK_ASSERT(logOp5.getGreenParams() == paramsG);
+    OCIO_CHECK_ASSERT(logOp5.getBlueParams() == paramsB);
 
     // Initialize with base.
     const double baseVal = 2.0;
     OCIO::LogOpData logOp6(baseVal, OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_ASSERT(logOp6.allComponentsEqual());
+    OCIO_CHECK_ASSERT(logOp6.allComponentsEqual());
     auto & param = logOp6.getRedParams();
-    OIIO_CHECK_EQUAL(logOp6.getBase(), baseVal);
-    OIIO_CHECK_EQUAL(param[OCIO::LOG_SIDE_SLOPE], 1.0f);
-    OIIO_CHECK_EQUAL(param[OCIO::LIN_SIDE_SLOPE], 1.0f);
-    OIIO_CHECK_EQUAL(param[OCIO::LIN_SIDE_OFFSET], 0.0f);
-    OIIO_CHECK_EQUAL(param[OCIO::LOG_SIDE_OFFSET], 0.0f);
+    OCIO_CHECK_EQUAL(logOp6.getBase(), baseVal);
+    OCIO_CHECK_EQUAL(param[OCIO::LOG_SIDE_SLOPE], 1.0f);
+    OCIO_CHECK_EQUAL(param[OCIO::LIN_SIDE_SLOPE], 1.0f);
+    OCIO_CHECK_EQUAL(param[OCIO::LIN_SIDE_OFFSET], 0.0f);
+    OCIO_CHECK_EQUAL(param[OCIO::LOG_SIDE_OFFSET], 0.0f);
 
     // Initialize with OCIO parameters.
     const double logSlope[] = { 1.5, 1.6, 1.7 };
@@ -584,26 +584,26 @@ OIIO_ADD_TEST(LogOpData, accessor_test)
     const double logOffset[] = { 10.0, 20.0, 30.0 };
 
     OCIO::LogOpData logOp7(base, logSlope, logOffset, linSlope, linOffset, OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_ASSERT(!logOp7.allComponentsEqual());
+    OCIO_CHECK_ASSERT(!logOp7.allComponentsEqual());
     auto & paramR = logOp7.getRedParams();
-    OIIO_CHECK_EQUAL(logOp7.getBase(), base);
-    OIIO_CHECK_EQUAL(paramR[OCIO::LOG_SIDE_SLOPE], logSlope[0]);
-    OIIO_CHECK_EQUAL(paramR[OCIO::LIN_SIDE_SLOPE], linSlope[0]);
-    OIIO_CHECK_EQUAL(paramR[OCIO::LIN_SIDE_OFFSET], linOffset[0]);
-    OIIO_CHECK_EQUAL(paramR[OCIO::LOG_SIDE_OFFSET], logOffset[0]);
+    OCIO_CHECK_EQUAL(logOp7.getBase(), base);
+    OCIO_CHECK_EQUAL(paramR[OCIO::LOG_SIDE_SLOPE], logSlope[0]);
+    OCIO_CHECK_EQUAL(paramR[OCIO::LIN_SIDE_SLOPE], linSlope[0]);
+    OCIO_CHECK_EQUAL(paramR[OCIO::LIN_SIDE_OFFSET], linOffset[0]);
+    OCIO_CHECK_EQUAL(paramR[OCIO::LOG_SIDE_OFFSET], logOffset[0]);
     auto & paramG = logOp7.getGreenParams();
-    OIIO_CHECK_EQUAL(paramG[OCIO::LOG_SIDE_SLOPE], logSlope[1]);
-    OIIO_CHECK_EQUAL(paramG[OCIO::LIN_SIDE_SLOPE], linSlope[1]);
-    OIIO_CHECK_EQUAL(paramG[OCIO::LIN_SIDE_OFFSET], linOffset[1]);
-    OIIO_CHECK_EQUAL(paramG[OCIO::LOG_SIDE_OFFSET], logOffset[1]);
+    OCIO_CHECK_EQUAL(paramG[OCIO::LOG_SIDE_SLOPE], logSlope[1]);
+    OCIO_CHECK_EQUAL(paramG[OCIO::LIN_SIDE_SLOPE], linSlope[1]);
+    OCIO_CHECK_EQUAL(paramG[OCIO::LIN_SIDE_OFFSET], linOffset[1]);
+    OCIO_CHECK_EQUAL(paramG[OCIO::LOG_SIDE_OFFSET], logOffset[1]);
     auto & paramB = logOp7.getBlueParams();
-    OIIO_CHECK_EQUAL(paramB[OCIO::LOG_SIDE_SLOPE], logSlope[2]);
-    OIIO_CHECK_EQUAL(paramB[OCIO::LIN_SIDE_SLOPE], linSlope[2]);
-    OIIO_CHECK_EQUAL(paramB[OCIO::LIN_SIDE_OFFSET], linOffset[2]);
-    OIIO_CHECK_EQUAL(paramB[OCIO::LOG_SIDE_OFFSET], logOffset[2]);
+    OCIO_CHECK_EQUAL(paramB[OCIO::LOG_SIDE_SLOPE], logSlope[2]);
+    OCIO_CHECK_EQUAL(paramB[OCIO::LIN_SIDE_SLOPE], linSlope[2]);
+    OCIO_CHECK_EQUAL(paramB[OCIO::LIN_SIDE_OFFSET], linOffset[2]);
+    OCIO_CHECK_EQUAL(paramB[OCIO::LOG_SIDE_OFFSET], logOffset[2]);
 }
 
-OIIO_ADD_TEST(LogOpData, validation_fails_test)
+OCIO_ADD_TEST(LogOpData, validation_fails_test)
 {
     double base = 1.0;
     double logSlope[] = { 1.0, 1.0, 1.0 };
@@ -614,10 +614,10 @@ OIIO_ADD_TEST(LogOpData, validation_fails_test)
     
     // Fail invalid base.
     OCIO::LogOpData logOp1(base, logSlope, logOffset, linSlope, linOffset, direction);
-    OIIO_CHECK_THROW_WHAT(logOp1.validate(), OCIO::Exception, "base cannot be 1");
+    OCIO_CHECK_THROW_WHAT(logOp1.validate(), OCIO::Exception, "base cannot be 1");
     direction = OCIO::TRANSFORM_DIR_INVERSE;
     OCIO::LogOpData invlogOp1(base, logSlope, logOffset, linSlope, linOffset, direction);
-    OIIO_CHECK_THROW_WHAT(invlogOp1.validate(), OCIO::Exception, "base cannot be 1");
+    OCIO_CHECK_THROW_WHAT(invlogOp1.validate(), OCIO::Exception, "base cannot be 1");
 
     base = 10.0;
 
@@ -626,10 +626,10 @@ OIIO_ADD_TEST(LogOpData, validation_fails_test)
     linSlope[0] = linSlope[1] = linSlope[2] = 0.0;
 
     OCIO::LogOpData logOp2(base, logSlope, logOffset, linSlope, linOffset, direction);
-    OIIO_CHECK_THROW_WHAT(logOp2.validate(), OCIO::Exception, "linear slope cannot be 0");
+    OCIO_CHECK_THROW_WHAT(logOp2.validate(), OCIO::Exception, "linear slope cannot be 0");
     direction = OCIO::TRANSFORM_DIR_INVERSE;
     OCIO::LogOpData invlogOp2(base, logSlope, logOffset, linSlope, linOffset, direction);
-    OIIO_CHECK_THROW_WHAT(invlogOp2.validate(), OCIO::Exception, "linear slope cannot be 0");
+    OCIO_CHECK_THROW_WHAT(invlogOp2.validate(), OCIO::Exception, "linear slope cannot be 0");
 
     linSlope[0] = linSlope[1] = linSlope[2] = 1.0;
 
@@ -638,13 +638,13 @@ OIIO_ADD_TEST(LogOpData, validation_fails_test)
     logSlope[0] = logSlope[1] = logSlope[2] = 0.0;
     
     OCIO::LogOpData logOp3(base, logSlope, logOffset, linSlope, linOffset, direction);
-    OIIO_CHECK_THROW_WHAT(logOp3.validate(), OCIO::Exception, "log slope cannot be 0");
+    OCIO_CHECK_THROW_WHAT(logOp3.validate(), OCIO::Exception, "log slope cannot be 0");
     direction = OCIO::TRANSFORM_DIR_INVERSE;
     OCIO::LogOpData invlogOp3(base, logSlope, logOffset, linSlope, linOffset, direction);
-    OIIO_CHECK_THROW_WHAT(invlogOp3.validate(), OCIO::Exception, "log slope cannot be 0");
+    OCIO_CHECK_THROW_WHAT(invlogOp3.validate(), OCIO::Exception, "log slope cannot be 0");
 }
 
-OIIO_ADD_TEST(LogOpData, log_inverse)
+OCIO_ADD_TEST(LogOpData, log_inverse)
 {
     OCIO::LogOpData::Params paramR{ 1.5, 10.0, 1.1, 1.0 };
     OCIO::LogOpData::Params paramG{ 1.6, 20.0, 1.2, 2.0 };
@@ -655,26 +655,26 @@ OIIO_ADD_TEST(LogOpData, log_inverse)
                            base, paramR, paramG, paramB);
     OCIO::ConstLogOpDataRcPtr invLogOp0 = logOp0.inverse();
 
-    OIIO_CHECK_ASSERT(logOp0.getRedParams() == invLogOp0->getRedParams());
-    OIIO_CHECK_ASSERT(logOp0.getGreenParams() == invLogOp0->getGreenParams());
-    OIIO_CHECK_ASSERT(logOp0.getBlueParams() == invLogOp0->getBlueParams());
+    OCIO_CHECK_ASSERT(logOp0.getRedParams() == invLogOp0->getRedParams());
+    OCIO_CHECK_ASSERT(logOp0.getGreenParams() == invLogOp0->getGreenParams());
+    OCIO_CHECK_ASSERT(logOp0.getBlueParams() == invLogOp0->getBlueParams());
 
-    OIIO_CHECK_EQUAL(logOp0.getInputBitDepth(), invLogOp0->getOutputBitDepth());
-    OIIO_CHECK_EQUAL(logOp0.getOutputBitDepth(), invLogOp0->getInputBitDepth());
+    OCIO_CHECK_EQUAL(logOp0.getInputBitDepth(), invLogOp0->getOutputBitDepth());
+    OCIO_CHECK_EQUAL(logOp0.getOutputBitDepth(), invLogOp0->getInputBitDepth());
 
     // When components are not equals, ops are not considered inverse.
-    OIIO_CHECK_ASSERT(!logOp0.isInverse(invLogOp0));
+    OCIO_CHECK_ASSERT(!logOp0.isInverse(invLogOp0));
 
     // Using equal components.
     OCIO::LogOpData logOp1(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_UINT10, OCIO::TRANSFORM_DIR_FORWARD,
                            base, paramR, paramR, paramR);
     OCIO::ConstLogOpDataRcPtr invLogOp1 = logOp1.inverse();
 
-    OIIO_CHECK_ASSERT(logOp1.isInverse(invLogOp1));
+    OCIO_CHECK_ASSERT(logOp1.isInverse(invLogOp1));
 
 }
 
-OIIO_ADD_TEST(LogOpData, identity_replacement)
+OCIO_ADD_TEST(LogOpData, identity_replacement)
 {
     OCIO::LogOpData::Params paramsR{ 1.5, 10.0, 2.0, 1.0 };
     const double base = 2.0;
@@ -685,7 +685,7 @@ OIIO_ADD_TEST(LogOpData, identity_replacement)
         OCIO::LogOpData logOp(inBitDepth, outBitDepth,
                               OCIO::TRANSFORM_DIR_INVERSE,
                               base, paramsR, paramsR, paramsR);
-        OIIO_CHECK_EQUAL(logOp.getIdentityReplacement()->getType(),
+        OCIO_CHECK_EQUAL(logOp.getIdentityReplacement()->getType(),
                          OCIO::OpData::MatrixType);
     }
     {
@@ -693,22 +693,22 @@ OIIO_ADD_TEST(LogOpData, identity_replacement)
                               OCIO::TRANSFORM_DIR_FORWARD,
                               base, paramsR, paramsR, paramsR);
         auto op = logOp.getIdentityReplacement();
-        OIIO_CHECK_EQUAL(op->getType(),
+        OCIO_CHECK_EQUAL(op->getType(),
                          OCIO::OpData::RangeType);
         auto r = std::dynamic_pointer_cast<OCIO::RangeOpData>(op);
         // -32767.5 = -(1.0/2.0) * 65535
-        OIIO_CHECK_EQUAL((int)(r->getMinInValue()), (int)-32767.5);
-        OIIO_CHECK_ASSERT(r->maxIsEmpty());
+        OCIO_CHECK_EQUAL((int)(r->getMinInValue()), (int)-32767.5);
+        OCIO_CHECK_ASSERT(r->maxIsEmpty());
     }
 
     {
         OCIO::LogOpData logOp(2.0f, OCIO::TRANSFORM_DIR_FORWARD);
-        OIIO_CHECK_EQUAL(logOp.getIdentityReplacement()->getType(),
+        OCIO_CHECK_EQUAL(logOp.getIdentityReplacement()->getType(),
                          OCIO::OpData::RangeType);
     }
     {
         OCIO::LogOpData logOp(2.0f, OCIO::TRANSFORM_DIR_INVERSE);
-        OIIO_CHECK_EQUAL(logOp.getIdentityReplacement()->getType(),
+        OCIO_CHECK_EQUAL(logOp.getIdentityReplacement()->getType(),
                          OCIO::OpData::MatrixType);
     }
 }

--- a/src/OpenColorIO/ops/Log/LogOps.cpp
+++ b/src/OpenColorIO/ops/Log/LogOps.cpp
@@ -196,9 +196,9 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(LogOps, lin_to_log)
+OCIO_ADD_TEST(LogOps, lin_to_log)
 {
     const double base = 10.0;
     const double logSlope[3] = { 0.18, 0.18, 0.18 };
@@ -219,25 +219,25 @@ OIIO_ADD_TEST(LogOps, lin_to_log)
                               1.0f };
     
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
+    OCIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
                                     linSlope, linOffset,
                                     OCIO::TRANSFORM_DIR_FORWARD));
 
     // One operator has been created.
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_REQUIRE_ASSERT((bool)ops[0]);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_ASSERT((bool)ops[0]);
 
     // No chache ID before operator has been finalized.
     std::string opCache = ops[0]->getCacheID();
-    OIIO_CHECK_EQUAL(opCache.size(), 0);
+    OCIO_CHECK_EQUAL(opCache.size(), 0);
 
-    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
+    OCIO_CHECK_NO_THROW(FinalizeOpVec(ops));
 
     // Validate properties.
     opCache = ops[0]->getCacheID();
-    OIIO_CHECK_NE(opCache.size(), 0);
-    OIIO_CHECK_EQUAL(ops[0]->isNoOp(), false);
-    OIIO_CHECK_EQUAL(ops[0]->hasChannelCrosstalk(), false);
+    OCIO_CHECK_NE(opCache.size(), 0);
+    OCIO_CHECK_EQUAL(ops[0]->isNoOp(), false);
+    OCIO_CHECK_EQUAL(ops[0]->hasChannelCrosstalk(), false);
     
     // Apply the result.
     for(OCIO::OpRcPtrVec::size_type i = 0, size = ops.size(); i < size; ++i)
@@ -247,11 +247,11 @@ OIIO_ADD_TEST(LogOps, lin_to_log)
     
     for(int i=0; i<8; ++i)
     {
-        OIIO_CHECK_CLOSE( data[i], result[i], 1.0e-3 );
+        OCIO_CHECK_CLOSE( data[i], result[i], 1.0e-3 );
     }
 }
 
-OIIO_ADD_TEST(LogOps, log_to_lin)
+OCIO_ADD_TEST(LogOps, log_to_lin)
 {
     const double base = 10.0;
     const double logSlope[3] = { 0.18, 0.18, 0.18 };
@@ -272,11 +272,11 @@ OIIO_ADD_TEST(LogOps, log_to_lin)
                               10.0f, 100.0f, 1000.0f, 1.0f, };
     
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
+    OCIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
                                     linSlope, linOffset,
                                     OCIO::TRANSFORM_DIR_INVERSE));
     
-    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
+    OCIO_CHECK_NO_THROW(FinalizeOpVec(ops));
     
     // Apply the result.
     for(OCIO::OpRcPtrVec::size_type i = 0, size = ops.size(); i < size; ++i)
@@ -286,11 +286,11 @@ OIIO_ADD_TEST(LogOps, log_to_lin)
     
     for(int i=0; i<8; ++i)
     {
-        OIIO_CHECK_CLOSE( data[i], result[i], 2.0e-3f );
+        OCIO_CHECK_CLOSE( data[i], result[i], 2.0e-3f );
     }
 }
 
-OIIO_ADD_TEST(LogOps, inverse)
+OCIO_ADD_TEST(LogOps, inverse)
 {
     double base = 10.0;
     const double logSlope[3] = { 0.5, 0.5, 0.5 };
@@ -300,24 +300,24 @@ OIIO_ADD_TEST(LogOps, inverse)
     const double logSlope2[3] = { 0.5, 1.0, 1.5 };
 
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset, linSlope, linOffset,
+    OCIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset, linSlope, linOffset,
                                     OCIO::TRANSFORM_DIR_FORWARD));
     
-    OIIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset, linSlope, linOffset,
+    OCIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset, linSlope, linOffset,
                                     OCIO::TRANSFORM_DIR_INVERSE));
     
     base += 1.0;
-    OIIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset, linSlope, linOffset,
+    OCIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset, linSlope, linOffset,
                                     OCIO::TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset, linSlope, linOffset,
+    OCIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset, linSlope, linOffset,
                                     OCIO::TRANSFORM_DIR_FORWARD));
 
-    OIIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope2, logOffset, linSlope, linOffset,
+    OCIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope2, logOffset, linSlope, linOffset,
                                     OCIO::TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope2, logOffset, linSlope, linOffset,
+    OCIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope2, logOffset, linSlope, linOffset,
                                     OCIO::TRANSFORM_DIR_FORWARD));
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 6);
+    OCIO_REQUIRE_EQUAL(ops.size(), 6);
     OCIO::ConstOpRcPtr op0 = ops[0];
     OCIO::ConstOpRcPtr op1 = ops[1];
     OCIO::ConstOpRcPtr op2 = ops[2];
@@ -325,28 +325,28 @@ OIIO_ADD_TEST(LogOps, inverse)
     OCIO::ConstOpRcPtr op4 = ops[4];
     OCIO::ConstOpRcPtr op5 = ops[5];
 
-    OIIO_CHECK_ASSERT(ops[0]->isSameType(op1));
-    OIIO_CHECK_ASSERT(ops[0]->isSameType(op2));
+    OCIO_CHECK_ASSERT(ops[0]->isSameType(op1));
+    OCIO_CHECK_ASSERT(ops[0]->isSameType(op2));
     OCIO::ConstOpRcPtr op3Cloned = ops[3]->clone();
-    OIIO_CHECK_ASSERT(ops[0]->isSameType(op3Cloned));
+    OCIO_CHECK_ASSERT(ops[0]->isSameType(op3Cloned));
     
-    OIIO_CHECK_EQUAL(ops[0]->isInverse(op0), false);
-    OIIO_CHECK_EQUAL(ops[0]->isInverse(op1), true);
-    OIIO_CHECK_EQUAL(ops[0]->isInverse(op2), false);
-    OIIO_CHECK_EQUAL(ops[0]->isInverse(op3), false);
+    OCIO_CHECK_EQUAL(ops[0]->isInverse(op0), false);
+    OCIO_CHECK_EQUAL(ops[0]->isInverse(op1), true);
+    OCIO_CHECK_EQUAL(ops[0]->isInverse(op2), false);
+    OCIO_CHECK_EQUAL(ops[0]->isInverse(op3), false);
     
-    OIIO_CHECK_EQUAL(ops[1]->isInverse(op0), true);
-    OIIO_CHECK_EQUAL(ops[1]->isInverse(op2), false);
-    OIIO_CHECK_EQUAL(ops[1]->isInverse(op3), false);
+    OCIO_CHECK_EQUAL(ops[1]->isInverse(op0), true);
+    OCIO_CHECK_EQUAL(ops[1]->isInverse(op2), false);
+    OCIO_CHECK_EQUAL(ops[1]->isInverse(op3), false);
     
-    OIIO_CHECK_EQUAL(ops[2]->isInverse(op2), false);
-    OIIO_CHECK_EQUAL(ops[2]->isInverse(op3), true);
+    OCIO_CHECK_EQUAL(ops[2]->isInverse(op2), false);
+    OCIO_CHECK_EQUAL(ops[2]->isInverse(op3), true);
     
-    OIIO_CHECK_EQUAL(ops[3]->isInverse(op3), false);
+    OCIO_CHECK_EQUAL(ops[3]->isInverse(op3), false);
 
     // When r, g & b are not equal, ops are not considered inverse 
     // even though they are.
-    OIIO_CHECK_EQUAL(ops[4]->isInverse(op5), false);
+    OCIO_CHECK_EQUAL(ops[4]->isInverse(op5), false);
 
     const float result[12] = { 0.01f, 0.1f, 1.0f, 1.0f,
                                1.0f, 10.0f, 100.0f, 1.0f,
@@ -361,15 +361,15 @@ OIIO_ADD_TEST(LogOps, inverse)
     ops[0]->finalize();
     ops[0]->apply(data, 3);
     // Note: Skip testing alpha channels.
-    OIIO_CHECK_NE( data[0], result[0] );
-    OIIO_CHECK_NE( data[1], result[1] );
-    OIIO_CHECK_NE( data[2], result[2] );
-    OIIO_CHECK_NE( data[4], result[4] );
-    OIIO_CHECK_NE( data[5], result[5] );
-    OIIO_CHECK_NE( data[6], result[6] );
-    OIIO_CHECK_NE( data[8], result[8] );
-    OIIO_CHECK_NE( data[9], result[9] );
-    OIIO_CHECK_NE( data[10], result[10] );
+    OCIO_CHECK_NE( data[0], result[0] );
+    OCIO_CHECK_NE( data[1], result[1] );
+    OCIO_CHECK_NE( data[2], result[2] );
+    OCIO_CHECK_NE( data[4], result[4] );
+    OCIO_CHECK_NE( data[5], result[5] );
+    OCIO_CHECK_NE( data[6], result[6] );
+    OCIO_CHECK_NE( data[8], result[8] );
+    OCIO_CHECK_NE( data[9], result[9] );
+    OCIO_CHECK_NE( data[10], result[10] );
 
     ops[1]->finalize();
     ops[1]->apply(data, 3);
@@ -382,11 +382,11 @@ OIIO_ADD_TEST(LogOps, inverse)
 
     for(int i=0; i<12; ++i)
     {
-        OIIO_CHECK_CLOSE( data[i], result[i], error);
+        OCIO_CHECK_CLOSE( data[i], result[i], error);
     }
 }
 
-OIIO_ADD_TEST(LogOps, cache_id)
+OCIO_ADD_TEST(LogOps, cache_id)
 {
     const double base = 10.0;
     const double logSlope[3] = { 0.18, 0.18, 0.18 };
@@ -395,34 +395,34 @@ OIIO_ADD_TEST(LogOps, cache_id)
     double logOffset[3] = { 1.0, 1.0, 1.0 };
 
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
+    OCIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
                                     linSlope, linOffset,
                                     OCIO::TRANSFORM_DIR_FORWARD));
     logOffset[0] += 1.0f;
-    OIIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
+    OCIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
                                     linSlope, linOffset,
                                     OCIO::TRANSFORM_DIR_FORWARD));
     logOffset[0] -= 1.0f;
-    OIIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
+    OCIO_CHECK_NO_THROW(CreateLogOp(ops, base, logSlope, logOffset,
                                     linSlope, linOffset,
                                     OCIO::TRANSFORM_DIR_FORWARD));
 
     // 3 operators have been created
-    OIIO_CHECK_EQUAL(ops.size(), 3);
-    OIIO_REQUIRE_ASSERT((bool)ops[0]);
-    OIIO_REQUIRE_ASSERT((bool)ops[1]);
-    OIIO_REQUIRE_ASSERT((bool)ops[2]);
+    OCIO_CHECK_EQUAL(ops.size(), 3);
+    OCIO_REQUIRE_ASSERT((bool)ops[0]);
+    OCIO_REQUIRE_ASSERT((bool)ops[1]);
+    OCIO_REQUIRE_ASSERT((bool)ops[2]);
 
-    OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
+    OCIO_CHECK_NO_THROW(FinalizeOpVec(ops));
 
     const std::string opCacheID0 = ops[0]->getCacheID();
     const std::string opCacheID1 = ops[1]->getCacheID();
     const std::string opCacheID2 = ops[2]->getCacheID();
-    OIIO_CHECK_EQUAL(opCacheID0, opCacheID2);
-    OIIO_CHECK_NE(opCacheID0, opCacheID1);
+    OCIO_CHECK_EQUAL(opCacheID0, opCacheID2);
+    OCIO_CHECK_NE(opCacheID0, opCacheID1);
 }
 
-OIIO_ADD_TEST(LogOps, throw_direction)
+OCIO_ADD_TEST(LogOps, throw_direction)
 {
     const double base = 10.0;
     const double logSlope[3] = { 0.18, 0.18, 0.18 };
@@ -431,7 +431,7 @@ OIIO_ADD_TEST(LogOps, throw_direction)
     const double logOffset[3] = { 1.0, 1.0, 1.0 };
 
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         CreateLogOp(ops, base, logSlope, logOffset,
                     linSlope, linOffset,
                     OCIO::TRANSFORM_DIR_UNKNOWN),

--- a/src/OpenColorIO/ops/Log/LogUtils.cpp
+++ b/src/OpenColorIO/ops/Log/LogUtils.cpp
@@ -193,9 +193,9 @@ OCIO_NAMESPACE_EXIT
 
 namespace OCIO = OCIO_NAMESPACE;
 
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(LogUtil, ctf_to_ocio_fail)
+OCIO_ADD_TEST(LogUtil, ctf_to_ocio_fail)
 {
     OCIO::LogUtil::CTFParams ctfParams;
     ctfParams.m_style = OCIO::LogUtil::LOG_TO_LIN;
@@ -216,7 +216,7 @@ OIIO_ADD_TEST(LogUtil, ctf_to_ocio_fail)
     greenP = redP;
     blueP = redP;
     
-    OIIO_CHECK_THROW_WHAT( 
+    OCIO_CHECK_THROW_WHAT( 
         OCIO::LogUtil::ConvertLogParameters(ctfParams, base, paramsR, paramsG, paramsB, dir),
         OCIO::Exception, "gamma should be greater than 0.01");
 
@@ -226,7 +226,7 @@ OIIO_ADD_TEST(LogUtil, ctf_to_ocio_fail)
     redP[OCIO::LogUtil::CTFParams::highlight] = 0.8;
     redP[OCIO::LogUtil::CTFParams::shadow]    = 0.5;
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         OCIO::LogUtil::ConvertLogParameters(ctfParams, base, paramsR, paramsG, paramsB, dir),
         OCIO::Exception, "refWhite should be greater than refBlack");
 
@@ -236,13 +236,13 @@ OIIO_ADD_TEST(LogUtil, ctf_to_ocio_fail)
     redP[OCIO::LogUtil::CTFParams::highlight] = 0.5; // invalid
     redP[OCIO::LogUtil::CTFParams::shadow]    = 0.5; // invalid
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         OCIO::LogUtil::ConvertLogParameters(ctfParams, base, paramsR, paramsG, paramsB, dir),
         OCIO::Exception, "highlight should be greater than shadow");
 
 }
 
-OIIO_ADD_TEST(LogUtil, ctf_to_ocio_ok)
+OCIO_ADD_TEST(LogUtil, ctf_to_ocio_ok)
 {
     OCIO::LogUtil::CTFParams ctfParams;
     ctfParams.m_style = OCIO::LogUtil::LOG10;
@@ -252,61 +252,61 @@ OIIO_ADD_TEST(LogUtil, ctf_to_ocio_ok)
     OCIO::TransformDirection dir;
     OCIO::LogUtil::ConvertLogParameters(ctfParams, base, paramsR, paramsG, paramsB, dir);
 
-    OIIO_CHECK_EQUAL(base, 10.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_SLOPE], 1.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_SLOPE], 1.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_OFFSET], 0.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_OFFSET], 0.);
-    OIIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(base, 10.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_SLOPE], 1.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_SLOPE], 1.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_OFFSET], 0.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_OFFSET], 0.);
+    OCIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_FORWARD);
 
     OCIO::LogOpData logOp(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, dir,
                           base, paramsR, paramsG, paramsB);
 
-    OIIO_CHECK_ASSERT(!logOp.isIdentity());
-    OIIO_CHECK_ASSERT(!logOp.hasChannelCrosstalk());
-    OIIO_CHECK_NO_THROW(logOp.validate());
+    OCIO_CHECK_ASSERT(!logOp.isIdentity());
+    OCIO_CHECK_ASSERT(!logOp.hasChannelCrosstalk());
+    OCIO_CHECK_NO_THROW(logOp.validate());
 
     ctfParams.m_style = OCIO::LogUtil::LOG2;
     OCIO::LogUtil::ConvertLogParameters(ctfParams, base, paramsR, paramsG, paramsB, dir);
 
-    OIIO_CHECK_EQUAL(base, 2.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_SLOPE], 1.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_SLOPE], 1.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_OFFSET], 0.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_OFFSET], 0.);
-    OIIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(base, 2.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_SLOPE], 1.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_SLOPE], 1.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_OFFSET], 0.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_OFFSET], 0.);
+    OCIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_FORWARD);
 
     OCIO::LogOpData logOp2(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, dir,
                            base, paramsR, paramsG, paramsB);
-    OIIO_CHECK_NO_THROW(logOp2.validate());
+    OCIO_CHECK_NO_THROW(logOp2.validate());
 
     ctfParams.m_style = OCIO::LogUtil::ANTI_LOG10;
     OCIO::LogUtil::ConvertLogParameters(ctfParams, base, paramsR, paramsG, paramsB, dir);
 
-    OIIO_CHECK_EQUAL(base, 10.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_SLOPE], 1.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_SLOPE], 1.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_OFFSET], 0.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_OFFSET], 0.);
-    OIIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(base, 10.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_SLOPE], 1.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_SLOPE], 1.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_OFFSET], 0.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_OFFSET], 0.);
+    OCIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_INVERSE);
 
     OCIO::LogOpData logOp3(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, dir,
                            base, paramsR, paramsG, paramsB);
-    OIIO_CHECK_NO_THROW(logOp3.validate());
+    OCIO_CHECK_NO_THROW(logOp3.validate());
 
     ctfParams.m_style = OCIO::LogUtil::ANTI_LOG2;
     OCIO::LogUtil::ConvertLogParameters(ctfParams, base, paramsR, paramsG, paramsB, dir);
 
-    OIIO_CHECK_EQUAL(base, 2.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_SLOPE], 1.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_SLOPE], 1.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_OFFSET], 0.);
-    OIIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_OFFSET], 0.);
-    OIIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(base, 2.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_SLOPE], 1.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_SLOPE], 1.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LIN_SIDE_OFFSET], 0.);
+    OCIO_CHECK_EQUAL(paramsR[OCIO::LOG_SIDE_OFFSET], 0.);
+    OCIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_INVERSE);
 
     OCIO::LogOpData logOp4(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, dir,
                            base, paramsR, paramsG, paramsB);
-    OIIO_CHECK_NO_THROW(logOp4.validate());
+    OCIO_CHECK_NO_THROW(logOp4.validate());
 
     auto & redP = ctfParams.get(OCIO::LogUtil::CTFParams::red);
     redP[OCIO::LogUtil::CTFParams::gamma]     = 4.6;
@@ -329,30 +329,30 @@ OIIO_ADD_TEST(LogUtil, ctf_to_ocio_ok)
     OCIO::LogUtil::ConvertLogParameters(ctfParams, base, paramsR, paramsG, paramsB, dir);
 
     const double tol = 1e-6;
-    OIIO_CHECK_EQUAL(base, 10.);
-    OIIO_CHECK_CLOSE(paramsR[OCIO::LOG_SIDE_SLOPE], 2.2482893, tol);
-    OIIO_CHECK_CLOSE(paramsR[OCIO::LIN_SIDE_SLOPE], 1.7250706, tol);
-    OIIO_CHECK_CLOSE(paramsR[OCIO::LIN_SIDE_OFFSET], -0.2075494, tol);
-    OIIO_CHECK_CLOSE(paramsR[OCIO::LOG_SIDE_OFFSET], 0.7409580, tol);
+    OCIO_CHECK_EQUAL(base, 10.);
+    OCIO_CHECK_CLOSE(paramsR[OCIO::LOG_SIDE_SLOPE], 2.2482893, tol);
+    OCIO_CHECK_CLOSE(paramsR[OCIO::LIN_SIDE_SLOPE], 1.7250706, tol);
+    OCIO_CHECK_CLOSE(paramsR[OCIO::LIN_SIDE_OFFSET], -0.2075494, tol);
+    OCIO_CHECK_CLOSE(paramsR[OCIO::LOG_SIDE_OFFSET], 0.7409580, tol);
 
-    OIIO_CHECK_CLOSE(paramsG[OCIO::LOG_SIDE_SLOPE], 1.2707722, tol);
-    OIIO_CHECK_CLOSE(paramsG[OCIO::LIN_SIDE_SLOPE], 0.5240051, tol);
-    OIIO_CHECK_CLOSE(paramsG[OCIO::LIN_SIDE_OFFSET], 0.5807959, tol);
-    OIIO_CHECK_CLOSE(paramsG[OCIO::LOG_SIDE_OFFSET], 0.2932551, tol);
+    OCIO_CHECK_CLOSE(paramsG[OCIO::LOG_SIDE_SLOPE], 1.2707722, tol);
+    OCIO_CHECK_CLOSE(paramsG[OCIO::LIN_SIDE_SLOPE], 0.5240051, tol);
+    OCIO_CHECK_CLOSE(paramsG[OCIO::LIN_SIDE_OFFSET], 0.5807959, tol);
+    OCIO_CHECK_CLOSE(paramsG[OCIO::LOG_SIDE_OFFSET], 0.2932551, tol);
 
-    OIIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_FORWARD);
 
     OCIO::LogOpData logOp5(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, dir,
                            base, paramsR, paramsG, paramsB);
-    OIIO_CHECK_NO_THROW(logOp5.validate());
+    OCIO_CHECK_NO_THROW(logOp5.validate());
 
     ctfParams.m_style = OCIO::LogUtil::LOG_TO_LIN;
     OCIO::LogUtil::ConvertLogParameters(ctfParams, base, paramsR, paramsG, paramsB, dir);
-    OIIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(dir, OCIO::TRANSFORM_DIR_INVERSE);
 
     OCIO::LogOpData logOp6(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, dir,
                            base, paramsR, paramsG, paramsB);
-    OIIO_CHECK_NO_THROW(logOp6.validate());
+    OCIO_CHECK_NO_THROW(logOp6.validate());
 }
 
 #endif

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOp.cpp
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOp.cpp
@@ -780,10 +780,10 @@ OCIO_NAMESPACE_EXIT
 #include <cstring>
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
-OIIO_ADD_TEST(Lut1DOpStruct, no_op)
+OCIO_ADD_TEST(Lut1DOpStruct, no_op)
 {
     // Make an identity LUT.
     OCIO::Lut1DRcPtr lut = OCIO::Lut1D::Create();
@@ -800,12 +800,12 @@ OIIO_ADD_TEST(Lut1DOpStruct, no_op)
     
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::Lut1D::ERROR_RELATIVE;
-    OIIO_CHECK_ASSERT(lut->isNoOp());
+    OCIO_CHECK_ASSERT(lut->isNoOp());
     
     lut->unfinalize();
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::Lut1D::ERROR_ABSOLUTE;
-    OIIO_CHECK_ASSERT(lut->isNoOp());
+    OCIO_CHECK_ASSERT(lut->isNoOp());
 
     // Edit the LUT.
     // These should NOT be identity.
@@ -813,12 +813,12 @@ OIIO_ADD_TEST(Lut1DOpStruct, no_op)
     lut->luts[0][125] += 1e-3f;
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::Lut1D::ERROR_RELATIVE;
-    OIIO_CHECK_ASSERT(!lut->isNoOp());
+    OCIO_CHECK_ASSERT(!lut->isNoOp());
 
     lut->unfinalize();
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::Lut1D::ERROR_ABSOLUTE;
-    OIIO_CHECK_ASSERT(!lut->isNoOp());
+    OCIO_CHECK_ASSERT(!lut->isNoOp());
 }
 
 namespace
@@ -846,24 +846,24 @@ OCIO::Lut1DRcPtr CreateSquareLut()
 }
 }
 
-OIIO_ADD_TEST(Lut1DOpStruct, FiniteValue)
+OCIO_ADD_TEST(Lut1DOpStruct, FiniteValue)
 {
     OCIO::Lut1DRcPtr lut = CreateSquareLut();
     
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::Lut1D::ERROR_RELATIVE;
     bool isNoOp = true;
-    OIIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
-    OIIO_CHECK_ASSERT(!isNoOp);
+    OCIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
+    OCIO_CHECK_ASSERT(!isNoOp);
     
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut, OCIO::INTERP_LINEAR,
+    OCIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut, OCIO::INTERP_LINEAR,
                                       OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut, OCIO::INTERP_LINEAR,
+    OCIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut, OCIO::INTERP_LINEAR,
                                       OCIO::TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
-    OIIO_CHECK_NO_THROW(ops[1]->finalize());
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_CHECK_NO_THROW(ops[1]->finalize());
 
     float inputBuffer_linearforward[4] = { 0.5f, 0.6f, 0.7f, 0.5f };
     float inputBuffer_linearforward2[4] = { 0.5f, 0.6f, 0.7f, 0.5f };
@@ -872,8 +872,8 @@ OIIO_ADD_TEST(Lut1DOpStruct, FiniteValue)
     ops[0]->apply(inputBuffer_linearforward2, 1);
     for(int i=0; i <4; ++i)
     {
-        OIIO_CHECK_CLOSE(inputBuffer_linearforward[i], outputBuffer_linearforward[i], 1e-5f);
-        OIIO_CHECK_CLOSE(inputBuffer_linearforward2[i], outputBuffer_linearforward[i], 1e-5f);
+        OCIO_CHECK_CLOSE(inputBuffer_linearforward[i], outputBuffer_linearforward[i], 1e-5f);
+        OCIO_CHECK_CLOSE(inputBuffer_linearforward2[i], outputBuffer_linearforward[i], 1e-5f);
     }
     
     float inputBuffer_nearestforward[4] = { 0.5f, 0.6f, 0.7f, 0.5f };
@@ -881,7 +881,7 @@ OIIO_ADD_TEST(Lut1DOpStruct, FiniteValue)
     OCIO::Lut1D_Nearest(inputBuffer_nearestforward, 1, *lut);
     for(int i=0; i <4; ++i)
     {
-        OIIO_CHECK_CLOSE(inputBuffer_nearestforward[i], outputBuffer_nearestforward[i], 1e-5f);
+        OCIO_CHECK_CLOSE(inputBuffer_nearestforward[i], outputBuffer_nearestforward[i], 1e-5f);
     }
     
     const float inputBuffer_linearinverse[4] = { 0.5f, 0.6f, 0.7f, 0.5f };
@@ -891,8 +891,8 @@ OIIO_ADD_TEST(Lut1DOpStruct, FiniteValue)
     ops[1]->apply(outputBuffer_linearinverse2, 1);
     for(int i=0; i <4; ++i)
     {
-        OIIO_CHECK_CLOSE(inputBuffer_linearinverse[i], outputBuffer_linearinverse[i], 1e-5f);
-        OIIO_CHECK_CLOSE(inputBuffer_linearinverse[i], outputBuffer_linearinverse2[i], 1e-5f);
+        OCIO_CHECK_CLOSE(inputBuffer_linearinverse[i], outputBuffer_linearinverse[i], 1e-5f);
+        OCIO_CHECK_CLOSE(inputBuffer_linearinverse[i], outputBuffer_linearinverse2[i], 1e-5f);
     }
     
     const float inputBuffer_nearestinverse[4] = { 0.498039f, 0.6f, 0.698039f, 0.5f };
@@ -900,11 +900,11 @@ OIIO_ADD_TEST(Lut1DOpStruct, FiniteValue)
     OCIO::Lut1D_NearestInverse(outputBuffer_nearestinverse, 1, *lut);
     for(int i=0; i <4; ++i)
     {
-        OIIO_CHECK_CLOSE(inputBuffer_nearestinverse[i], outputBuffer_nearestinverse[i], 1e-5f);
+        OCIO_CHECK_CLOSE(inputBuffer_nearestinverse[i], outputBuffer_nearestinverse[i], 1e-5f);
     }
 }
 
-OIIO_ADD_TEST(Lut1DOp, arbitrary_value)
+OCIO_ADD_TEST(Lut1DOp, arbitrary_value)
 {
     OCIO::Lut1DRcPtr lut = CreateSquareLut();
     lut->from_min[0] = -0.25f;
@@ -935,12 +935,12 @@ OIIO_ADD_TEST(Lut1DOp, arbitrary_value)
 
     for(int i=0; i<16; ++i)
     {
-        OIIO_CHECK_CLOSE(outputBuffer_linearforward[i], outputBuffer_inv_linearforward[i], 1e-5f);
+        OCIO_CHECK_CLOSE(outputBuffer_linearforward[i], outputBuffer_inv_linearforward[i], 1e-5f);
     }
 }
 
 
-OIIO_ADD_TEST(Lut1DOp, extrapolation_errors)
+OCIO_ADD_TEST(Lut1DOp, extrapolation_errors)
 {
     OCIO::Lut1DRcPtr lut = OCIO::Lut1D::Create();
 
@@ -955,8 +955,8 @@ OIIO_ADD_TEST(Lut1DOp, extrapolation_errors)
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::Lut1D::ERROR_RELATIVE;
     bool isNoOp = true;
-    OIIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
-    OIIO_CHECK_ASSERT(!isNoOp);
+    OCIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
+    OCIO_CHECK_ASSERT(!isNoOp);
 
     const int PIXELS = 5;
     float inputBuffer_linearforward[PIXELS*4] = {
@@ -974,12 +974,12 @@ OIIO_ADD_TEST(Lut1DOp, extrapolation_errors)
     OCIO::Lut1D_Linear(inputBuffer_linearforward, PIXELS, *lut);
     for(size_t i=0; i <sizeof(inputBuffer_linearforward)/sizeof(inputBuffer_linearforward[0]); ++i)
     {
-        OIIO_CHECK_CLOSE(inputBuffer_linearforward[i], outputBuffer_linearforward[i], 1e-5f);
+        OCIO_CHECK_CLOSE(inputBuffer_linearforward[i], outputBuffer_linearforward[i], 1e-5f);
     }
 }
 
 
-OIIO_ADD_TEST(Lut1DOp, inverse)
+OCIO_ADD_TEST(Lut1DOp, inverse)
 {
     // Make a LUT that squares the input.
     OCIO::Lut1DRcPtr lut_a = CreateSquareLut();
@@ -1016,81 +1016,81 @@ OIIO_ADD_TEST(Lut1DOp, inverse)
 
     OCIO::OpRcPtrVec ops;
     // Adding Lut1DOp.
-    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut_a,
+    OCIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut_a,
                                       OCIO::INTERP_LINEAR,
                                       OCIO::TRANSFORM_DIR_FORWARD));
     // Adding inverse Lut1DOp.
-    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut_a,
+    OCIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut_a,
                                       OCIO::INTERP_LINEAR,
                                       OCIO::TRANSFORM_DIR_INVERSE));
     // Adding MatrixOffsetOp (i.e. min & max) and Lut1DOp.
-    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut_b,
+    OCIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut_b,
                                       OCIO::INTERP_LINEAR,
                                       OCIO::TRANSFORM_DIR_FORWARD));
     // Adding inverse Lut1DOp and MatrixOffsetOp (i.e. min & max).
-    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut_b,
+    OCIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut_b,
                                       OCIO::INTERP_LINEAR,
                                       OCIO::TRANSFORM_DIR_INVERSE));
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 6);
+    OCIO_REQUIRE_EQUAL(ops.size(), 6);
 
-    OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<Lut1DOp>");
-    OIIO_CHECK_EQUAL(ops[1]->getInfo(), "<Lut1DOp>");
-    OIIO_CHECK_EQUAL(ops[2]->getInfo(), "<MatrixOffsetOp>");
-    OIIO_CHECK_EQUAL(ops[3]->getInfo(), "<Lut1DOp>");
-    OIIO_CHECK_EQUAL(ops[4]->getInfo(), "<Lut1DOp>");
-    OIIO_CHECK_EQUAL(ops[5]->getInfo(), "<MatrixOffsetOp>");
+    OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<Lut1DOp>");
+    OCIO_CHECK_EQUAL(ops[1]->getInfo(), "<Lut1DOp>");
+    OCIO_CHECK_EQUAL(ops[2]->getInfo(), "<MatrixOffsetOp>");
+    OCIO_CHECK_EQUAL(ops[3]->getInfo(), "<Lut1DOp>");
+    OCIO_CHECK_EQUAL(ops[4]->getInfo(), "<Lut1DOp>");
+    OCIO_CHECK_EQUAL(ops[5]->getInfo(), "<MatrixOffsetOp>");
 
     OCIO::ConstOpRcPtr op1 = ops[1];
     OCIO::ConstOpRcPtr op3 = ops[3];
     OCIO::ConstOpRcPtr op4 = ops[4];
 
-    OIIO_CHECK_ASSERT(ops[0]->isInverse(op1));
-    OIIO_CHECK_ASSERT(ops[3]->isInverse(op4));
+    OCIO_CHECK_ASSERT(ops[0]->isInverse(op1));
+    OCIO_CHECK_ASSERT(ops[3]->isInverse(op4));
 
     OCIO::ConstOpRcPtr clonedOp = ops[3]->clone();
-    OIIO_CHECK_ASSERT(ops[3]->isSameType(clonedOp));
+    OCIO_CHECK_ASSERT(ops[3]->isSameType(clonedOp));
 
-    OIIO_CHECK_EQUAL(ops[0]->isInverse(op1), true);
-    OIIO_CHECK_EQUAL(ops[3]->isInverse(op4), true);
+    OCIO_CHECK_EQUAL(ops[0]->isInverse(op1), true);
+    OCIO_CHECK_EQUAL(ops[3]->isInverse(op4), true);
 
-    OIIO_CHECK_EQUAL(ops[0]->isInverse(op3), false);
-    OIIO_CHECK_EQUAL(ops[1]->isInverse(op4), false);
+    OCIO_CHECK_EQUAL(ops[0]->isInverse(op3), false);
+    OCIO_CHECK_EQUAL(ops[1]->isInverse(op4), false);
 
     // Add same as first.
-    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut_c,
+    OCIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut_c,
         OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 7);
+    OCIO_REQUIRE_EQUAL(ops.size(), 7);
 
-    OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<Lut1DOp>");
-    OIIO_CHECK_EQUAL(ops[1]->getInfo(), "<Lut1DOp>");
-    OIIO_CHECK_EQUAL(ops[2]->getInfo(), "<MatrixOffsetOp>");
-    OIIO_CHECK_EQUAL(ops[3]->getInfo(), "<Lut1DOp>");
-    OIIO_CHECK_EQUAL(ops[4]->getInfo(), "<Lut1DOp>");
-    OIIO_CHECK_EQUAL(ops[5]->getInfo(), "<MatrixOffsetOp>");
-    OIIO_CHECK_EQUAL(ops[6]->getInfo(), "<Lut1DOp>");
+    OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<Lut1DOp>");
+    OCIO_CHECK_EQUAL(ops[1]->getInfo(), "<Lut1DOp>");
+    OCIO_CHECK_EQUAL(ops[2]->getInfo(), "<MatrixOffsetOp>");
+    OCIO_CHECK_EQUAL(ops[3]->getInfo(), "<Lut1DOp>");
+    OCIO_CHECK_EQUAL(ops[4]->getInfo(), "<Lut1DOp>");
+    OCIO_CHECK_EQUAL(ops[5]->getInfo(), "<MatrixOffsetOp>");
+    OCIO_CHECK_EQUAL(ops[6]->getInfo(), "<Lut1DOp>");
 
-    OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops, false));
-    OIIO_REQUIRE_EQUAL(ops.size(), 7);
+    OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops, false));
+    OCIO_REQUIRE_EQUAL(ops.size(), 7);
 
-    OIIO_CHECK_EQUAL(ops[0]->getCacheID(), ops[3]->getCacheID());
-    OIIO_CHECK_EQUAL(ops[1]->getCacheID(), ops[4]->getCacheID());
+    OCIO_CHECK_EQUAL(ops[0]->getCacheID(), ops[3]->getCacheID());
+    OCIO_CHECK_EQUAL(ops[1]->getCacheID(), ops[4]->getCacheID());
 
-    OIIO_CHECK_NE(ops[0]->getCacheID(), ops[1]->getCacheID());
-    OIIO_CHECK_NE(ops[0]->getCacheID(), ops[6]->getCacheID());
-    OIIO_CHECK_NE(ops[1]->getCacheID(), ops[3]->getCacheID());
-    OIIO_CHECK_NE(ops[1]->getCacheID(), ops[6]->getCacheID());
+    OCIO_CHECK_NE(ops[0]->getCacheID(), ops[1]->getCacheID());
+    OCIO_CHECK_NE(ops[0]->getCacheID(), ops[6]->getCacheID());
+    OCIO_CHECK_NE(ops[1]->getCacheID(), ops[3]->getCacheID());
+    OCIO_CHECK_NE(ops[1]->getCacheID(), ops[6]->getCacheID());
 
     // Optimize will remove LUT forward and inverse (0+1 and 3+4),
     // and remove matrix forward and inverse 2+5.
-    OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops, true));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<Lut1DOp>");
+    OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops, true));
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<Lut1DOp>");
 }
 
 
 #ifdef USE_SSE
-OIIO_ADD_TEST(Lut1DOp, sse)
+OCIO_ADD_TEST(Lut1DOp, sse)
 {
     // Make a LUT that squares the input.
     OCIO::Lut1DRcPtr lut = CreateSquareLut();
@@ -1098,8 +1098,8 @@ OIIO_ADD_TEST(Lut1DOp, sse)
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::Lut1D::ERROR_RELATIVE;
     bool isNoOp = true;
-    OIIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
-    OIIO_CHECK_ASSERT(!isNoOp);
+    OCIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
+    OCIO_CHECK_ASSERT(!isNoOp);
 
     const int NUM_TEST_PIXELS = 1024;
     std::vector<float> testValues(NUM_TEST_PIXELS*4);
@@ -1123,8 +1123,8 @@ OIIO_ADD_TEST(Lut1DOp, sse)
     
     for(int i=0; i<NUM_TEST_PIXELS*4; ++i)
     {
-        OIIO_CHECK_CLOSE(outputBuffer_cpu[i], outputBuffer_sse[i], 1e-7f);
-        //OIIO_CHECK_EQUAL(outputBuffer_cpu[i], outputBuffer_sse[i]);
+        OCIO_CHECK_CLOSE(outputBuffer_cpu[i], outputBuffer_sse[i], 1e-7f);
+        //OCIO_CHECK_EQUAL(outputBuffer_cpu[i], outputBuffer_sse[i]);
     }
     
     
@@ -1153,8 +1153,8 @@ OIIO_ADD_TEST(Lut1DOp, sse)
     
     for(int i=0; i<NUM_TEST_PIXELS*4; ++i)
     {
-        //OIIO_CHECK_CLOSE(outputBuffer_cpu[i], outputBuffer_sse[i], 1e-7f);
-        OIIO_CHECK_EQUAL(outputBuffer_cpu[i], outputBuffer_sse[i]);
+        //OCIO_CHECK_CLOSE(outputBuffer_cpu[i], outputBuffer_sse[i], 1e-7f);
+        OCIO_CHECK_EQUAL(outputBuffer_cpu[i], outputBuffer_sse[i]);
     }
     
     */
@@ -1162,14 +1162,14 @@ OIIO_ADD_TEST(Lut1DOp, sse)
 #endif
 
 
-OIIO_ADD_TEST(Lut1DOp, nan_inf)
+OCIO_ADD_TEST(Lut1DOp, nan_inf)
 {
     // Make a LUT that squares the input.
     OCIO::Lut1DRcPtr lut = CreateSquareLut();
     
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::Lut1D::ERROR_RELATIVE;
-    OIIO_CHECK_ASSERT(!lut->isNoOp());
+    OCIO_CHECK_ASSERT(!lut->isNoOp());
     
     const float reference[4] = {  std::numeric_limits<float>::signaling_NaN(),
                                   std::numeric_limits<float>::quiet_NaN(),
@@ -1191,11 +1191,11 @@ OIIO_ADD_TEST(Lut1DOp, nan_inf)
         if(isnan(color[i]))
         {
             std::cerr << color[i] << " " << output[i] << std::endl;
-            OIIO_CHECK_EQUAL(isnan(color[i]), isnan(output[i]));
+            OCIO_CHECK_EQUAL(isnan(color[i]), isnan(output[i]));
         }
         else
         {
-            OIIO_CHECK_EQUAL(color[i], output[i]);
+            OCIO_CHECK_EQUAL(color[i], output[i]);
         }
     }
     */
@@ -1206,11 +1206,11 @@ OIIO_ADD_TEST(Lut1DOp, nan_inf)
     {
         if(isnan(color[i]))
         {
-            OIIO_CHECK_EQUAL(isnan(color[i]), isnan(output[i]));
+            OCIO_CHECK_EQUAL(isnan(color[i]), isnan(output[i]));
         }
         else
         {
-            OIIO_CHECK_EQUAL(color[i], output[i]);
+            OCIO_CHECK_EQUAL(color[i], output[i]);
         }
     }
     */
@@ -1221,11 +1221,11 @@ OIIO_ADD_TEST(Lut1DOp, nan_inf)
     {
         if(isnan(color[i]))
         {
-            OIIO_CHECK_EQUAL(isnan(color[i]), isnan(output[i]));
+            OCIO_CHECK_EQUAL(isnan(color[i]), isnan(output[i]));
         }
         else
         {
-            OIIO_CHECK_EQUAL(color[i], output[i]);
+            OCIO_CHECK_EQUAL(color[i], output[i]);
         }
     }
     */
@@ -1236,17 +1236,17 @@ OIIO_ADD_TEST(Lut1DOp, nan_inf)
     {
         if(isnan(color[i]))
         {
-            OIIO_CHECK_EQUAL(isnan(color[i]), isnan(output[i]));
+            OCIO_CHECK_EQUAL(isnan(color[i]), isnan(output[i]));
         }
         else
         {
-            OIIO_CHECK_EQUAL(color[i], output[i]);
+            OCIO_CHECK_EQUAL(color[i], output[i]);
         }
     }
     */
 }
 
-OIIO_ADD_TEST(Lut1DOp, throw_no_op)
+OCIO_ADD_TEST(Lut1DOp, throw_no_op)
 {
     // Make an identity LUT.
     OCIO::Lut1DRcPtr lut = OCIO::Lut1D::Create();
@@ -1263,32 +1263,32 @@ OIIO_ADD_TEST(Lut1DOp, throw_no_op)
 
     lut->maxerror = 1e-5f;
     lut->errortype = (OCIO::Lut1D::ErrorType)0;
-    OIIO_CHECK_THROW_WHAT(lut->isNoOp(),
+    OCIO_CHECK_THROW_WHAT(lut->isNoOp(),
                           OCIO::Exception, "Unknown error type");
 
     lut->errortype = OCIO::Lut1D::ERROR_RELATIVE;
-    OIIO_CHECK_NO_THROW(lut->isNoOp());
+    OCIO_CHECK_NO_THROW(lut->isNoOp());
     lut->unfinalize();
 
     lut->luts[0].clear();
-    OIIO_CHECK_THROW_WHAT(lut->isNoOp(),
+    OCIO_CHECK_THROW_WHAT(lut->isNoOp(),
                           OCIO::Exception, "invalid Lut1D");
 
     lut->luts[0] = lut->luts[1];
     lut->luts[1].clear();
-    OIIO_CHECK_THROW_WHAT(lut->isNoOp(),
+    OCIO_CHECK_THROW_WHAT(lut->isNoOp(),
                           OCIO::Exception, "invalid Lut1D");
 
     lut->luts[1] = lut->luts[2];
     lut->luts[2].clear();
-    OIIO_CHECK_THROW_WHAT(lut->isNoOp(),
+    OCIO_CHECK_THROW_WHAT(lut->isNoOp(),
                           OCIO::Exception, "invalid Lut1D");
 
     lut->luts[2] = lut->luts[0];
-    OIIO_CHECK_NO_THROW(lut->isNoOp());
+    OCIO_CHECK_NO_THROW(lut->isNoOp());
 }
 
-OIIO_ADD_TEST(Lut1DOp, throw_op)
+OCIO_ADD_TEST(Lut1DOp, throw_op)
 {
     OCIO::Lut1DRcPtr lut = OCIO::Lut1D::Create();
     for (int c = 0; c<3; ++c)
@@ -1299,18 +1299,18 @@ OIIO_ADD_TEST(Lut1DOp, throw_op)
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::Lut1D::ERROR_RELATIVE;
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_THROW_WHAT(CreateLut1DOp(ops, lut,
+    OCIO_CHECK_THROW_WHAT(CreateLut1DOp(ops, lut,
                                         OCIO::INTERP_NEAREST,
                                         OCIO::TRANSFORM_DIR_UNKNOWN),
                           OCIO::Exception, "unspecified transform direction");
     
-    OIIO_CHECK_THROW_WHAT(CreateLut1DOp(ops, lut,
+    OCIO_CHECK_THROW_WHAT(CreateLut1DOp(ops, lut,
                                         OCIO::INTERP_UNKNOWN,
                                         OCIO::TRANSFORM_DIR_FORWARD),
                           OCIO::Exception, "unspecified interpolation");
 
     // INTERP_TETRAHEDRAL not allowed for 1D LUT.
-    OIIO_CHECK_THROW_WHAT(CreateLut1DOp(ops, lut,
+    OCIO_CHECK_THROW_WHAT(CreateLut1DOp(ops, lut,
                                         OCIO::INTERP_TETRAHEDRAL,
                                         OCIO::TRANSFORM_DIR_FORWARD),
                           OCIO::Exception,
@@ -1318,13 +1318,13 @@ OIIO_ADD_TEST(Lut1DOp, throw_op)
     ops.clear();
 
     lut->luts[0].clear();
-    OIIO_CHECK_THROW_WHAT(CreateLut1DOp(ops, lut,
+    OCIO_CHECK_THROW_WHAT(CreateLut1DOp(ops, lut,
                                         OCIO::INTERP_BEST,
                                         OCIO::TRANSFORM_DIR_FORWARD),
                           OCIO::Exception, "no LUT data provided");
 }
 
-OIIO_ADD_TEST(Lut1DOp, gpu)
+OCIO_ADD_TEST(Lut1DOp, gpu)
 {
     OCIO::Lut1DRcPtr lut = OCIO::Lut1D::Create();
     for (int c = 0; c < 3; ++c)
@@ -1335,27 +1335,27 @@ OIIO_ADD_TEST(Lut1DOp, gpu)
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::Lut1D::ERROR_RELATIVE;
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut,
+    OCIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut,
                                       OCIO::INTERP_NEAREST,
                                       OCIO::TRANSFORM_DIR_FORWARD));
     
-    OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_EQUAL(ops[0]->supportedByLegacyShader(), false);
+    OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops));
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops[0]->supportedByLegacyShader(), false);
 }
 
-OIIO_ADD_TEST(Lut1DOp, identity_lut_1d)
+OCIO_ADD_TEST(Lut1DOp, identity_lut_1d)
 {
     int size = 3;
     int channels = 2;
     std::vector<float> data(size*channels);
     OCIO::GenerateIdentityLut1D(&data[0], size, channels);
-    OIIO_CHECK_EQUAL(data[0], 0.0f);
-    OIIO_CHECK_EQUAL(data[1], 0.0f);
-    OIIO_CHECK_EQUAL(data[2], 0.5f);
-    OIIO_CHECK_EQUAL(data[3], 0.5f);
-    OIIO_CHECK_EQUAL(data[4], 1.0f);
-    OIIO_CHECK_EQUAL(data[5], 1.0f);
+    OCIO_CHECK_EQUAL(data[0], 0.0f);
+    OCIO_CHECK_EQUAL(data[1], 0.0f);
+    OCIO_CHECK_EQUAL(data[2], 0.5f);
+    OCIO_CHECK_EQUAL(data[3], 0.5f);
+    OCIO_CHECK_EQUAL(data[4], 1.0f);
+    OCIO_CHECK_EQUAL(data[5], 1.0f);
 
     size = 4;
     channels = 3;
@@ -1363,14 +1363,14 @@ OIIO_ADD_TEST(Lut1DOp, identity_lut_1d)
     OCIO::GenerateIdentityLut1D(&data[0], size, channels);
     for (int c = 0; c < channels; ++c)
     {
-        OIIO_CHECK_EQUAL(data[0+c], 0.0f);
-        OIIO_CHECK_EQUAL(data[channels+c], 0.33333333f);
-        OIIO_CHECK_EQUAL(data[2*channels+c], 0.66666667f);
-        OIIO_CHECK_EQUAL(data[3*channels+c], 1.0f);
+        OCIO_CHECK_EQUAL(data[0+c], 0.0f);
+        OCIO_CHECK_EQUAL(data[channels+c], 0.33333333f);
+        OCIO_CHECK_EQUAL(data[2*channels+c], 0.66666667f);
+        OCIO_CHECK_EQUAL(data[3*channels+c], 1.0f);
     }
 }
 
-OIIO_ADD_TEST(Lut1D, basic)
+OCIO_ADD_TEST(Lut1D, basic)
 {
     const OCIO::BitDepth bitDepth = OCIO::BIT_DEPTH_F32;
 
@@ -1383,9 +1383,9 @@ OIIO_ADD_TEST(Lut1D, basic)
 
     OCIO::Lut1DOp lut(lutData);
 
-    OIIO_CHECK_NO_THROW(lut.finalize());
-    OIIO_CHECK_ASSERT(lutData->isIdentity());
-    OIIO_CHECK_ASSERT(!lut.isNoOp());
+    OCIO_CHECK_NO_THROW(lut.finalize());
+    OCIO_CHECK_ASSERT(lutData->isIdentity());
+    OCIO_CHECK_ASSERT(!lut.isNoOp());
 
     const float step = OCIO::GetBitDepthMaxValue(lutData->getInputBitDepth())
                        / ((float)lutData->getArray().getLength() - 1.0f);
@@ -1395,17 +1395,17 @@ OIIO_ADD_TEST(Lut1D, basic)
 
     const float error = 1e-6f;
     {
-        OIIO_CHECK_NO_THROW(lut.apply(myImage, myImage, 2));
+        OCIO_CHECK_NO_THROW(lut.apply(myImage, myImage, 2));
 
-        OIIO_CHECK_CLOSE(myImage[0], 0.0f, error);
-        OIIO_CHECK_CLOSE(myImage[1], 0.0f, error);
-        OIIO_CHECK_CLOSE(myImage[2], 0.0f, error);
-        OIIO_CHECK_CLOSE(myImage[3], 1.0f, error);
+        OCIO_CHECK_CLOSE(myImage[0], 0.0f, error);
+        OCIO_CHECK_CLOSE(myImage[1], 0.0f, error);
+        OCIO_CHECK_CLOSE(myImage[2], 0.0f, error);
+        OCIO_CHECK_CLOSE(myImage[3], 1.0f, error);
 
-        OIIO_CHECK_CLOSE(myImage[4], 0.0f, error);
-        OIIO_CHECK_CLOSE(myImage[5], 0.0f, error);
-        OIIO_CHECK_CLOSE(myImage[6], step, error);
-        OIIO_CHECK_CLOSE(myImage[7], 1.0f, error);
+        OCIO_CHECK_CLOSE(myImage[4], 0.0f, error);
+        OCIO_CHECK_CLOSE(myImage[5], 0.0f, error);
+        OCIO_CHECK_CLOSE(myImage[6], step, error);
+        OCIO_CHECK_CLOSE(myImage[7], 1.0f, error);
     }
 
     // No more an 'identity LUT 1D'.
@@ -1413,27 +1413,27 @@ OIIO_ADD_TEST(Lut1D, basic)
 
     lutData->getArray()[5] = arbitraryVal;
 
-    OIIO_CHECK_NO_THROW(lut.finalize());
-    OIIO_CHECK_ASSERT(!lutData->isIdentity());
-    OIIO_CHECK_ASSERT(!lut.isNoOp());
+    OCIO_CHECK_NO_THROW(lut.finalize());
+    OCIO_CHECK_ASSERT(!lutData->isIdentity());
+    OCIO_CHECK_ASSERT(!lut.isNoOp());
 
     {
-        OIIO_CHECK_NO_THROW(lut.apply(myImage, myImage, 2));
+        OCIO_CHECK_NO_THROW(lut.apply(myImage, myImage, 2));
 
-        OIIO_CHECK_CLOSE(myImage[0], 0.0f, error);
-        OIIO_CHECK_CLOSE(myImage[1], 0.0f, error);
-        OIIO_CHECK_CLOSE(myImage[2], 0.0f, error);
-        OIIO_CHECK_CLOSE(myImage[3], 1.0f, error);
+        OCIO_CHECK_CLOSE(myImage[0], 0.0f, error);
+        OCIO_CHECK_CLOSE(myImage[1], 0.0f, error);
+        OCIO_CHECK_CLOSE(myImage[2], 0.0f, error);
+        OCIO_CHECK_CLOSE(myImage[3], 1.0f, error);
 
-        OIIO_CHECK_CLOSE(myImage[4], 0.0f, error);
-        OIIO_CHECK_CLOSE(myImage[5], 0.0f, error);
-        OIIO_CHECK_CLOSE(myImage[6], arbitraryVal, error);
-        OIIO_CHECK_CLOSE(myImage[7], 1.0f, error);
+        OCIO_CHECK_CLOSE(myImage[4], 0.0f, error);
+        OCIO_CHECK_CLOSE(myImage[5], 0.0f, error);
+        OCIO_CHECK_CLOSE(myImage[6], arbitraryVal, error);
+        OCIO_CHECK_CLOSE(myImage[7], 1.0f, error);
     }
 
 }
 
-OIIO_ADD_TEST(Lut1D, half)
+OCIO_ADD_TEST(Lut1D, half)
 {
     OCIO::Lut1DOpDataRcPtr
         lutData(
@@ -1450,7 +1450,7 @@ OIIO_ADD_TEST(Lut1D, half)
     // No more an 'identity LUT 1D'
     const float arbitraryVal = 0.123456f;
     lutData->getArray()[5] = arbitraryVal;
-    OIIO_CHECK_ASSERT(!lutData->isIdentity());
+    OCIO_CHECK_ASSERT(!lutData->isIdentity());
 
     const half myImage[8] = { 0.1f, 0.3f, 0.4f, 1.0f,
                               0.0f, 0.9f, step, 0.0f };
@@ -1460,23 +1460,23 @@ OIIO_ADD_TEST(Lut1D, half)
 
     // TODO: The SC test is intended to test half evaluation using myImage
     // as input.  Adjust after half support is added to apply.
-    OIIO_CHECK_NO_THROW(lut.finalize());
-    OIIO_CHECK_NO_THROW(lut.apply(resImage, resImage, 2));
+    OCIO_CHECK_NO_THROW(lut.finalize());
+    OCIO_CHECK_NO_THROW(lut.apply(resImage, resImage, 2));
 
     const float error = 1e-4f;
 
-    OIIO_CHECK_CLOSE(resImage[0], (float)myImage[0], error);
-    OIIO_CHECK_CLOSE(resImage[1], (float)myImage[1], error);
-    OIIO_CHECK_CLOSE(resImage[2], (float)myImage[2], error);
-    OIIO_CHECK_CLOSE(resImage[3], (float)myImage[3], error);
+    OCIO_CHECK_CLOSE(resImage[0], (float)myImage[0], error);
+    OCIO_CHECK_CLOSE(resImage[1], (float)myImage[1], error);
+    OCIO_CHECK_CLOSE(resImage[2], (float)myImage[2], error);
+    OCIO_CHECK_CLOSE(resImage[3], (float)myImage[3], error);
 
-    OIIO_CHECK_CLOSE(resImage[4], (float)myImage[4], error);
-    OIIO_CHECK_CLOSE(resImage[5], (float)myImage[5], error);
-    OIIO_CHECK_CLOSE(resImage[6], arbitraryVal, error);
-    OIIO_CHECK_CLOSE(resImage[7], (float)myImage[7], error);
+    OCIO_CHECK_CLOSE(resImage[4], (float)myImage[4], error);
+    OCIO_CHECK_CLOSE(resImage[5], (float)myImage[5], error);
+    OCIO_CHECK_CLOSE(resImage[6], arbitraryVal, error);
+    OCIO_CHECK_CLOSE(resImage[7], (float)myImage[7], error);
 }
 
-OIIO_ADD_TEST(Lut1D, nan)
+OCIO_ADD_TEST(Lut1D, nan)
 {
     const OCIO::BitDepth bitDepth = OCIO::BIT_DEPTH_F32;
 
@@ -1490,9 +1490,9 @@ OIIO_ADD_TEST(Lut1D, nan)
 
     OCIO::Lut1DOp lut(lutData);
 
-    OIIO_CHECK_NO_THROW(lut.finalize());
-    OIIO_CHECK_ASSERT(lut.isIdentity());
-    OIIO_CHECK_ASSERT(!lut.isNoOp());
+    OCIO_CHECK_NO_THROW(lut.finalize());
+    OCIO_CHECK_ASSERT(lut.isIdentity());
+    OCIO_CHECK_ASSERT(!lut.isNoOp());
 
     const float step = OCIO::GetBitDepthMaxValue(lutData->getInputBitDepth())
                        / ((float)lutData->getArray().getLength() - 1.0f);
@@ -1502,20 +1502,20 @@ OIIO_ADD_TEST(Lut1D, nan)
                                            0.0f, 0.0f, step, 1.0f };
 
     const float error = 1e-6f;
-    OIIO_CHECK_NO_THROW(lut.apply(myImage, myImage, 2));
+    OCIO_CHECK_NO_THROW(lut.apply(myImage, myImage, 2));
 
-    OIIO_CHECK_CLOSE(myImage[0], 0.0f, error);
-    OIIO_CHECK_CLOSE(myImage[1], 0.0f, error);
-    OIIO_CHECK_CLOSE(myImage[2], 0.0f, error);
-    OIIO_CHECK_CLOSE(myImage[3], 1.0f, error);
+    OCIO_CHECK_CLOSE(myImage[0], 0.0f, error);
+    OCIO_CHECK_CLOSE(myImage[1], 0.0f, error);
+    OCIO_CHECK_CLOSE(myImage[2], 0.0f, error);
+    OCIO_CHECK_CLOSE(myImage[3], 1.0f, error);
 
-    OIIO_CHECK_CLOSE(myImage[4], 0.0f, error);
-    OIIO_CHECK_CLOSE(myImage[5], 0.0f, error);
-    OIIO_CHECK_CLOSE(myImage[6], step, error);
-    OIIO_CHECK_CLOSE(myImage[7], 1.0f, error);
+    OCIO_CHECK_CLOSE(myImage[4], 0.0f, error);
+    OCIO_CHECK_CLOSE(myImage[5], 0.0f, error);
+    OCIO_CHECK_CLOSE(myImage[6], step, error);
+    OCIO_CHECK_CLOSE(myImage[7], 1.0f, error);
 }
 
-OIIO_ADD_TEST(Lut1D, finite_value)
+OCIO_ADD_TEST(Lut1D, finite_value)
 {
     // Make a LUT that squares the input.
     OCIO::Lut1DRcPtr lut = CreateSquareLut();
@@ -1523,8 +1523,8 @@ OIIO_ADD_TEST(Lut1D, finite_value)
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::Lut1D::ERROR_RELATIVE;
     bool isNoOp = true;
-    OIIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
-    OIIO_CHECK_ASSERT(!isNoOp);
+    OCIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
+    OCIO_CHECK_ASSERT(!isNoOp);
 
     // Check lut1D with OCIO::Lut1D_Linear.
     {
@@ -1534,23 +1534,23 @@ OIIO_ADD_TEST(Lut1D, finite_value)
         OCIO::Lut1D_Linear(lut1dlegacy_inputBuffer_linearforward, 1, *lut);
 
         OCIO::OpRcPtrVec ops;
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_NO_THROW(
             CreateLut1DOp(ops, lut, OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_FORWARD));
-        OIIO_REQUIRE_EQUAL(ops.size(), 1);
+        OCIO_REQUIRE_EQUAL(ops.size(), 1);
 
         float lut1d_inputBuffer_linearforward[4] = { 0.5f, 0.6f, 0.7f, 0.5f };
 
-        OIIO_CHECK_NO_THROW(ops[0]->finalize());
-        OIIO_CHECK_NO_THROW(ops[0]->apply(lut1d_inputBuffer_linearforward, 1));
+        OCIO_CHECK_NO_THROW(ops[0]->finalize());
+        OCIO_CHECK_NO_THROW(ops[0]->apply(lut1d_inputBuffer_linearforward, 1));
         for (int i = 0; i <4; ++i)
         {
-            OIIO_CHECK_CLOSE(lut1d_inputBuffer_linearforward[i],
+            OCIO_CHECK_CLOSE(lut1d_inputBuffer_linearforward[i],
                              outputBuffer_linearforward[i], 1e-5f);
 
-            OIIO_CHECK_CLOSE(lut1dlegacy_inputBuffer_linearforward[i],
+            OCIO_CHECK_CLOSE(lut1dlegacy_inputBuffer_linearforward[i],
                              outputBuffer_linearforward[i], 1e-5f);
 
-            OIIO_CHECK_CLOSE(lut1dlegacy_inputBuffer_linearforward[i],
+            OCIO_CHECK_CLOSE(lut1dlegacy_inputBuffer_linearforward[i],
                              lut1d_inputBuffer_linearforward[i], 1e-5f);
         }
     }
@@ -1563,29 +1563,29 @@ OIIO_ADD_TEST(Lut1D, finite_value)
         OCIO::Lut1D_LinearInverse(lut1dlegacy_outputBuffer_linearinverse, 1, *lut);
 
         OCIO::OpRcPtrVec ops;
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_NO_THROW(
             CreateLut1DOp(ops, lut, OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_INVERSE));
-        OIIO_REQUIRE_EQUAL(ops.size(), 1);
+        OCIO_REQUIRE_EQUAL(ops.size(), 1);
 
         float lut1d_outputBuffer_linearinverse[4] = { 0.25f, 0.36f, 0.49f, 0.5f };
 
-        OIIO_CHECK_NO_THROW(ops[0]->finalize());
-        OIIO_CHECK_NO_THROW(ops[0]->apply(lut1d_outputBuffer_linearinverse, 1));
+        OCIO_CHECK_NO_THROW(ops[0]->finalize());
+        OCIO_CHECK_NO_THROW(ops[0]->apply(lut1d_outputBuffer_linearinverse, 1));
         for (int i = 0; i <4; ++i)
         {
-            OIIO_CHECK_CLOSE(lut1dlegacy_outputBuffer_linearinverse[i],
+            OCIO_CHECK_CLOSE(lut1dlegacy_outputBuffer_linearinverse[i],
                              inputBuffer_linearinverse[i], 1e-5f);
 
-            OIIO_CHECK_CLOSE(lut1d_outputBuffer_linearinverse[i],
+            OCIO_CHECK_CLOSE(lut1d_outputBuffer_linearinverse[i],
                              inputBuffer_linearinverse[i], 1e-5f);
 
-            OIIO_CHECK_CLOSE(lut1dlegacy_outputBuffer_linearinverse[i],
+            OCIO_CHECK_CLOSE(lut1dlegacy_outputBuffer_linearinverse[i],
                 lut1d_outputBuffer_linearinverse[i], 1e-5f);
         }
     }
 }
 
-OIIO_ADD_TEST(Lut1D, finite_value_hue_adjust)
+OCIO_ADD_TEST(Lut1D, finite_value_hue_adjust)
 {
     // Make a LUT that squares the input.
     OCIO::Lut1DRcPtr lut = CreateSquareLut();
@@ -1593,13 +1593,13 @@ OIIO_ADD_TEST(Lut1D, finite_value_hue_adjust)
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::Lut1D::ERROR_RELATIVE;
     bool isNoOp = true;
-    OIIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
-    OIIO_CHECK_ASSERT(!isNoOp);
+    OCIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
+    OCIO_CHECK_ASSERT(!isNoOp);
 
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateLut1DOp(ops, lut, OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
     OCIO::OpRcPtr cloned = ops[0]->clone();
     OCIO::Lut1DOpRcPtr typedRcPtr = OCIO::DynamicPtrCast<OCIO::Lut1DOp>(cloned);
     typedRcPtr->lut1DData()->setHueAdjust(OCIO::Lut1DOpData::HUE_DW3);
@@ -1610,37 +1610,37 @@ OIIO_ADD_TEST(Lut1D, finite_value_hue_adjust)
                                                   0.5f };
     float lut1d_inputBuffer_linearforward[4] = { 0.5f, 0.6f, 0.7f, 0.5f };
 
-    OIIO_CHECK_NO_THROW(typedRcPtr->finalize());
-    OIIO_CHECK_NO_THROW(typedRcPtr->apply(lut1d_inputBuffer_linearforward, 1));
+    OCIO_CHECK_NO_THROW(typedRcPtr->finalize());
+    OCIO_CHECK_NO_THROW(typedRcPtr->apply(lut1d_inputBuffer_linearforward, 1));
     for (int i = 0; i <4; ++i)
     {
-        OIIO_CHECK_CLOSE(lut1d_inputBuffer_linearforward[i],
+        OCIO_CHECK_CLOSE(lut1d_inputBuffer_linearforward[i],
                          outputBuffer_linearforward[i], 1e-5f);
     }
 
     OCIO::Lut1DOpDataRcPtr invData = typedRcPtr->lut1DData()->inverse();
     OCIO::Lut1DOpDataRcPtr invDataExact = invData->clone();
     invDataExact->setInversionQuality(OCIO::LUT_INVERSION_BEST);
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateLut1DOp(ops, invData, OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateLut1DOp(ops, invDataExact, OCIO::TRANSFORM_DIR_FORWARD));
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 3);
+    OCIO_REQUIRE_EQUAL(ops.size(), 3);
 
     const float inputBuffer_linearinverse[4] = { 0.5f, 0.6f, 0.7f, 0.5f };
     float lut1d_outputBuffer_linearinverse[4] = { 0.25f, 0.37f, 0.49f, 0.5f };
     float lut1d_outputBuffer_linearinverseEx[4] = { 0.25f, 0.37f, 0.49f, 0.5f };
 
-    OIIO_CHECK_NO_THROW(ops[1]->finalize());
-    OIIO_CHECK_NO_THROW(ops[2]->finalize());
-    OIIO_CHECK_NO_THROW(ops[1]->apply(lut1d_outputBuffer_linearinverse, 1)); // fast
-    OIIO_CHECK_NO_THROW(ops[2]->apply(lut1d_outputBuffer_linearinverseEx, 1)); // exact
+    OCIO_CHECK_NO_THROW(ops[1]->finalize());
+    OCIO_CHECK_NO_THROW(ops[2]->finalize());
+    OCIO_CHECK_NO_THROW(ops[1]->apply(lut1d_outputBuffer_linearinverse, 1)); // fast
+    OCIO_CHECK_NO_THROW(ops[2]->apply(lut1d_outputBuffer_linearinverseEx, 1)); // exact
     for (int i = 0; i <4; ++i)
     {
-        OIIO_CHECK_CLOSE(lut1d_outputBuffer_linearinverse[i],
+        OCIO_CHECK_CLOSE(lut1d_outputBuffer_linearinverse[i],
                          inputBuffer_linearinverse[i], 1e-5f);
-        OIIO_CHECK_CLOSE(lut1d_outputBuffer_linearinverseEx[i],
+        OCIO_CHECK_CLOSE(lut1d_outputBuffer_linearinverseEx[i],
                          inputBuffer_linearinverse[i], 1e-5f);
     }
 }
@@ -1663,59 +1663,59 @@ void Apply(const OCIO::OpRcPtrVec & ops, float * img, long numPixels)
 
 }
 
-OIIO_ADD_TEST(Lut1D, apply_half_domain_hue_adjust)
+OCIO_ADD_TEST(Lut1D, apply_half_domain_hue_adjust)
 {
     const std::string ctfFile("lut1d_hd_hueAdjust.ctf");
 
     OCIO::OpRcPtrVec ops;
     OCIO::ContextRcPtr context = OCIO::Context::Create();
-    OIIO_CHECK_NO_THROW(BuildOpsTest(ops, ctfFile, context,
+    OCIO_CHECK_NO_THROW(BuildOpsTest(ops, ctfFile, context,
                                      OCIO::TRANSFORM_DIR_FORWARD));
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     auto op = std::const_pointer_cast<const OCIO::Op>(ops[1]);
     auto opData = op->data();
-    OIIO_CHECK_EQUAL(opData->getType(), OCIO::OpData::Lut1DType);
+    OCIO_CHECK_EQUAL(opData->getType(), OCIO::OpData::Lut1DType);
 
     auto lut = std::dynamic_pointer_cast<const OCIO::Lut1DOpData>(opData);
-    OIIO_REQUIRE_ASSERT(lut);
+    OCIO_REQUIRE_ASSERT(lut);
 
     float inputFrame[] = {
         0.05f, 0.18f, 1.1f, 0.5f,
         2.3f, 0.01f, 0.3f, 1.0f };
 
-    OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops));
-    OIIO_CHECK_NO_THROW(Apply(ops, inputFrame, 2));
+    OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops));
+    OCIO_CHECK_NO_THROW(Apply(ops, inputFrame, 2));
 
     const float rtol = 1e-6f;
     const float minExpected = 1e-3f;
 
-    OIIO_CHECK_ASSERT(
+    OCIO_CHECK_ASSERT(
         OCIO::EqualWithSafeRelError(inputFrame[0], 0.54780269f, rtol, minExpected));
 
-    OIIO_CHECK_ASSERT(
+    OCIO_CHECK_ASSERT(
         OCIO::EqualWithSafeRelError(inputFrame[1],
                                     9.57448578f,
                                     rtol, minExpected));  // would be 5.0 w/out hue adjust
 
-    OIIO_CHECK_ASSERT(
+    OCIO_CHECK_ASSERT(
         OCIO::EqualWithSafeRelError(inputFrame[2], 73.45562744f, rtol, minExpected));
 
-    OIIO_CHECK_EQUAL(inputFrame[3], 0.5f);
+    OCIO_CHECK_EQUAL(inputFrame[3], 0.5f);
 
-    OIIO_CHECK_ASSERT(
+    OCIO_CHECK_ASSERT(
         OCIO::EqualWithSafeRelError(inputFrame[4], 188.087067f, rtol, minExpected));
-    OIIO_CHECK_ASSERT(
+    OCIO_CHECK_ASSERT(
         OCIO::EqualWithSafeRelError(inputFrame[5], 0.0324990489f, rtol, minExpected));
-    OIIO_CHECK_ASSERT(
+    OCIO_CHECK_ASSERT(
         OCIO::EqualWithSafeRelError(inputFrame[6],
                                     23.8472710f,
                                     rtol, minExpected));  // would be 11.3372078 w/out hue adjust
 
-    OIIO_CHECK_EQUAL(inputFrame[7], 1.0f);
+    OCIO_CHECK_EQUAL(inputFrame[7], 1.0f);
 }
 
-OIIO_ADD_TEST(InvLut1D, apply_half)
+OCIO_ADD_TEST(InvLut1D, apply_half)
 {
     const OCIO::BitDepth inBD = OCIO::BIT_DEPTH_F32;
     const OCIO::BitDepth outBD = OCIO::BIT_DEPTH_F32;
@@ -1724,16 +1724,16 @@ OIIO_ADD_TEST(InvLut1D, apply_half)
 
     OCIO::OpRcPtrVec ops;
     OCIO::ContextRcPtr context = OCIO::Context::Create();
-    OIIO_CHECK_NO_THROW(BuildOpsTest(ops, ctfFile, context,
+    OCIO_CHECK_NO_THROW(BuildOpsTest(ops, ctfFile, context,
                                      OCIO::TRANSFORM_DIR_FORWARD));
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     auto op = std::const_pointer_cast<const OCIO::Op>(ops[1]);
     auto opData = op->data();
-    OIIO_CHECK_EQUAL(opData->getType(), OCIO::OpData::Lut1DType);
+    OCIO_CHECK_EQUAL(opData->getType(), OCIO::OpData::Lut1DType);
 
     auto lut = std::dynamic_pointer_cast<const OCIO::Lut1DOpData>(opData);
-    OIIO_REQUIRE_ASSERT(lut);
+    OCIO_REQUIRE_ASSERT(lut);
 
     auto fwdLut = lut->clone();
     fwdLut->setInputBitDepth(outBD);
@@ -1752,8 +1752,8 @@ OIIO_ADD_TEST(InvLut1D, apply_half)
     memcpy(inImage1, inImage, 12 * sizeof(float));
 
     // Apply forward LUT.
-    OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops1));
-    OIIO_CHECK_NO_THROW(Apply(ops1, inImage1, 3));
+    OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops1));
+    OCIO_CHECK_NO_THROW(Apply(ops1, inImage1, 3));
 
     // Apply inverse LUT.
     OCIO::OpRcPtrVec ops2;
@@ -1765,13 +1765,13 @@ OIIO_ADD_TEST(InvLut1D, apply_half)
     float inImage2[12];
     memcpy(inImage2, inImage1, 12 * sizeof(float));
 
-    OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops2));
-    OIIO_CHECK_NO_THROW(Apply(ops2, inImage2, 3));
+    OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops2));
+    OCIO_CHECK_NO_THROW(Apply(ops2, inImage2, 3));
 
     // Compare the two applys
     for (unsigned i = 0; i < 12; ++i)
     {
-        OIIO_CHECK_ASSERT(!OCIO::FloatsDiffer(inImage2[i], inImage[i], 50, false));
+        OCIO_CHECK_ASSERT(!OCIO::FloatsDiffer(inImage2[i], inImage[i], 50, false));
     }
 
     // Repeat with style = LUT_INVERSION_FAST.
@@ -1784,34 +1784,34 @@ OIIO_ADD_TEST(InvLut1D, apply_half)
 
     memcpy(inImage2, inImage1, 12 * sizeof(float));
 
-    OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops3));
-    OIIO_CHECK_NO_THROW(Apply(ops3, inImage2, 3));
+    OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops3));
+    OCIO_CHECK_NO_THROW(Apply(ops3, inImage2, 3));
 
     // Compare the two applys
     for (unsigned i = 0; i < 12; ++i)
     {
-        OIIO_CHECK_ASSERT(!OCIO::FloatsDiffer(inImage2[i], inImage[i], 50, false));
+        OCIO_CHECK_ASSERT(!OCIO::FloatsDiffer(inImage2[i], inImage[i], 50, false));
     }
 }
 
-OIIO_ADD_TEST(Lut1D, lut_1d_compose_with_bit_depth)
+OCIO_ADD_TEST(Lut1D, lut_1d_compose_with_bit_depth)
 {
     const std::string ctfFile("lut1d_comp.clf");
 
     OCIO::OpRcPtrVec ops;
     OCIO::ContextRcPtr context = OCIO::Context::Create();
-    OIIO_CHECK_NO_THROW(BuildOpsTest(ops, ctfFile, context,
+    OCIO_CHECK_NO_THROW(BuildOpsTest(ops, ctfFile, context,
                                      OCIO::TRANSFORM_DIR_FORWARD));
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 3);
+    OCIO_REQUIRE_EQUAL(ops.size(), 3);
     auto op = std::const_pointer_cast<const OCIO::Op>(ops[1]);
     auto opData = op->data();
-    OIIO_CHECK_EQUAL(opData->getType(), OCIO::OpData::Lut1DType);
+    OCIO_CHECK_EQUAL(opData->getType(), OCIO::OpData::Lut1DType);
     auto lut1 = std::dynamic_pointer_cast<const OCIO::Lut1DOpData>(opData);
-    OIIO_REQUIRE_ASSERT(lut1);
+    OCIO_REQUIRE_ASSERT(lut1);
     op = std::const_pointer_cast<const OCIO::Op>(ops[2]);
     opData = op->data();
-    OIIO_CHECK_EQUAL(opData->getType(), OCIO::OpData::Lut1DType);
+    OCIO_CHECK_EQUAL(opData->getType(), OCIO::OpData::Lut1DType);
     auto lut2 = std::dynamic_pointer_cast<const OCIO::Lut1DOpData>(opData);
 
     {
@@ -1819,33 +1819,33 @@ OIIO_ADD_TEST(Lut1D, lut_1d_compose_with_bit_depth)
         OCIO::Lut1DOpData::Compose(lutComposed, lut2, OCIO::Lut1DOpData::COMPOSE_RESAMPLE_NO);
 
         const float error = 1e-5f;
-        OIIO_CHECK_EQUAL(lutComposed->getArray().getLength(), 2);
-        OIIO_CHECK_CLOSE(lutComposed->getArray().getValues()[0], 0.00744791f, error);
-        OIIO_CHECK_CLOSE(lutComposed->getArray().getValues()[1], 0.03172233f, error);
-        OIIO_CHECK_CLOSE(lutComposed->getArray().getValues()[2], 0.07058375f, error);
-        OIIO_CHECK_CLOSE(lutComposed->getArray().getValues()[3], 0.3513808f, error);
-        OIIO_CHECK_CLOSE(lutComposed->getArray().getValues()[4], 0.51819527f, error);
-        OIIO_CHECK_CLOSE(lutComposed->getArray().getValues()[5], 0.67463773f, error);
+        OCIO_CHECK_EQUAL(lutComposed->getArray().getLength(), 2);
+        OCIO_CHECK_CLOSE(lutComposed->getArray().getValues()[0], 0.00744791f, error);
+        OCIO_CHECK_CLOSE(lutComposed->getArray().getValues()[1], 0.03172233f, error);
+        OCIO_CHECK_CLOSE(lutComposed->getArray().getValues()[2], 0.07058375f, error);
+        OCIO_CHECK_CLOSE(lutComposed->getArray().getValues()[3], 0.3513808f, error);
+        OCIO_CHECK_CLOSE(lutComposed->getArray().getValues()[4], 0.51819527f, error);
+        OCIO_CHECK_CLOSE(lutComposed->getArray().getValues()[5], 0.67463773f, error);
     }
     {
         auto lutComposed = lut1->clone();
         OCIO::Lut1DOpData::Compose(lutComposed, lut2, OCIO::Lut1DOpData::COMPOSE_RESAMPLE_INDEPTH);
 
         const float error = 1e-5f;
-        OIIO_CHECK_EQUAL(lutComposed->getArray().getLength(), 256);
-        OIIO_CHECK_CLOSE(lutComposed->getArray().getValues()[0], 0.00744791f, error);
-        OIIO_CHECK_CLOSE(lutComposed->getArray().getValues()[1], 0.03172233f, error);
-        OIIO_CHECK_CLOSE(lutComposed->getArray().getValues()[2], 0.07058375f, error);
-        OIIO_CHECK_CLOSE(lutComposed->getArray().getValues()[383], 0.28073114f, error);
-        OIIO_CHECK_CLOSE(lutComposed->getArray().getValues()[384], 0.09914176f, error);
-        OIIO_CHECK_CLOSE(lutComposed->getArray().getValues()[385], 0.1866852f, error);
-        OIIO_CHECK_CLOSE(lutComposed->getArray().getValues()[765], 0.3513808f, error);
-        OIIO_CHECK_CLOSE(lutComposed->getArray().getValues()[766], 0.51819527f, error);
-        OIIO_CHECK_CLOSE(lutComposed->getArray().getValues()[767], 0.67463773f, error);
+        OCIO_CHECK_EQUAL(lutComposed->getArray().getLength(), 256);
+        OCIO_CHECK_CLOSE(lutComposed->getArray().getValues()[0], 0.00744791f, error);
+        OCIO_CHECK_CLOSE(lutComposed->getArray().getValues()[1], 0.03172233f, error);
+        OCIO_CHECK_CLOSE(lutComposed->getArray().getValues()[2], 0.07058375f, error);
+        OCIO_CHECK_CLOSE(lutComposed->getArray().getValues()[383], 0.28073114f, error);
+        OCIO_CHECK_CLOSE(lutComposed->getArray().getValues()[384], 0.09914176f, error);
+        OCIO_CHECK_CLOSE(lutComposed->getArray().getValues()[385], 0.1866852f, error);
+        OCIO_CHECK_CLOSE(lutComposed->getArray().getValues()[765], 0.3513808f, error);
+        OCIO_CHECK_CLOSE(lutComposed->getArray().getValues()[766], 0.51819527f, error);
+        OCIO_CHECK_CLOSE(lutComposed->getArray().getValues()[767], 0.67463773f, error);
     }
 }
 
-OIIO_ADD_TEST(Lut1D, inverse_twice)
+OCIO_ADD_TEST(Lut1D, inverse_twice)
 {
     // Make a LUT that squares the input.
     OCIO::Lut1DRcPtr lut = CreateSquareLut();
@@ -1853,44 +1853,44 @@ OIIO_ADD_TEST(Lut1D, inverse_twice)
     lut->maxerror = 1e-5f;
     lut->errortype = OCIO::Lut1D::ERROR_RELATIVE;
     bool isNoOp = true;
-    OIIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
-    OIIO_CHECK_ASSERT(!isNoOp);
+    OCIO_CHECK_NO_THROW(isNoOp = lut->isNoOp());
+    OCIO_CHECK_ASSERT(!isNoOp);
 
     const float outputBuffer_linearinverse[4] = { 0.5f, 0.6f, 0.7f, 0.5f };
 
     // Create inverse lut.
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut, OCIO::INTERP_LINEAR,
+    OCIO_CHECK_NO_THROW(CreateLut1DOp(ops, lut, OCIO::INTERP_LINEAR,
                                       OCIO::TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
 
     const float lut1d_inputBuffer_reference[4] = { 0.25f, 0.36f, 0.49f, 0.5f };
     float lut1d_inputBuffer_linearinverse[4] = { 0.25f, 0.36f, 0.49f, 0.5f };
 
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
-    OIIO_CHECK_NO_THROW(ops[0]->apply(lut1d_inputBuffer_linearinverse, 1));
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_CHECK_NO_THROW(ops[0]->apply(lut1d_inputBuffer_linearinverse, 1));
     for (int i = 0; i < 4; ++i)
     {
-        OIIO_CHECK_CLOSE(lut1d_inputBuffer_linearinverse[i],
+        OCIO_CHECK_CLOSE(lut1d_inputBuffer_linearinverse[i],
                          outputBuffer_linearinverse[i], 1e-5f);
     }
 
     // Inverse the inverse.
     OCIO::Lut1DOp * pLut = dynamic_cast<OCIO::Lut1DOp*>(ops[0].get());
-    OIIO_CHECK_ASSERT(pLut);
+    OCIO_CHECK_ASSERT(pLut);
     OCIO::Lut1DOpDataRcPtr lutData = pLut->lut1DData()->inverse();
-    OIIO_CHECK_NO_THROW(OCIO::CreateLut1DOp(ops, lutData,
+    OCIO_CHECK_NO_THROW(OCIO::CreateLut1DOp(ops, lutData,
                                             OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
 
     // Apply the inverse.
-    OIIO_CHECK_NO_THROW(ops[1]->finalize());
-    OIIO_CHECK_NO_THROW(ops[1]->apply(lut1d_inputBuffer_linearinverse, 1));
+    OCIO_CHECK_NO_THROW(ops[1]->finalize());
+    OCIO_CHECK_NO_THROW(ops[1]->apply(lut1d_inputBuffer_linearinverse, 1));
 
     // Verify we are back on the input.
     for (int i = 0; i < 4; ++i)
     {
-        OIIO_CHECK_CLOSE(lut1d_inputBuffer_linearinverse[i],
+        OCIO_CHECK_CLOSE(lut1d_inputBuffer_linearinverse[i],
                          lut1d_inputBuffer_reference[i], 1e-5f);
     }
 }

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOpCPU.cpp
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOpCPU.cpp
@@ -1780,10 +1780,10 @@ OCIO_NAMESPACE_EXIT
 
 namespace OCIO = OCIO_NAMESPACE;
 
-#include "unittest.h"
+#include "UnitTest.h"
 
 
-OIIO_ADD_TEST(GamutMapUtil, order3_test)
+OCIO_ADD_TEST(GamutMapUtil, order3_test)
 {
     const float posinf = std::numeric_limits<float>::infinity();
     const float qnan = std::numeric_limits<float>::quiet_NaN();
@@ -1793,45 +1793,45 @@ OIIO_ADD_TEST(GamutMapUtil, order3_test)
         const float RGB[] = { 65504.f, -qnan, 0.f };
         int min, mid, max;
         OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
-        OIIO_CHECK_EQUAL(max, 2);
-        OIIO_CHECK_EQUAL(mid, 1);
-        OIIO_CHECK_EQUAL(min, 0);
+        OCIO_CHECK_EQUAL(max, 2);
+        OCIO_CHECK_EQUAL(mid, 1);
+        OCIO_CHECK_EQUAL(min, 0);
     }
     // Triple NaN test.
     {
     const float RGB[] = { qnan, qnan, -qnan };
     int min, mid, max;
     OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
-    OIIO_CHECK_EQUAL(max, 2);
-    OIIO_CHECK_EQUAL(mid, 1);
-    OIIO_CHECK_EQUAL(min, 0);
+    OCIO_CHECK_EQUAL(max, 2);
+    OCIO_CHECK_EQUAL(mid, 1);
+    OCIO_CHECK_EQUAL(min, 0);
     }
     // -Inf test.
     {
         const float RGB[] = { 65504.f, -posinf, 0.f };
         int min, mid, max;
         OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
-        OIIO_CHECK_EQUAL(max, 0);
-        OIIO_CHECK_EQUAL(mid, 2);
-        OIIO_CHECK_EQUAL(min, 1);
+        OCIO_CHECK_EQUAL(max, 0);
+        OCIO_CHECK_EQUAL(mid, 2);
+        OCIO_CHECK_EQUAL(min, 1);
     }
     // Inf test.
     {
         const float RGB[] = { 0.f, posinf, -65504.f };
         int min, mid, max;
         OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
-        OIIO_CHECK_EQUAL(max, 1);
-        OIIO_CHECK_EQUAL(mid, 0);
-        OIIO_CHECK_EQUAL(min, 2);
+        OCIO_CHECK_EQUAL(max, 1);
+        OCIO_CHECK_EQUAL(mid, 0);
+        OCIO_CHECK_EQUAL(min, 2);
     }
     // Double Inf test.
     {
         const float RGB[] = { posinf, posinf, -65504.f };
         int min, mid, max;
         OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
-        OIIO_CHECK_EQUAL(max, 1);
-        OIIO_CHECK_EQUAL(mid, 0);
-        OIIO_CHECK_EQUAL(min, 2);
+        OCIO_CHECK_EQUAL(max, 1);
+        OCIO_CHECK_EQUAL(mid, 0);
+        OCIO_CHECK_EQUAL(min, 2);
     }
 
     // Equal values.
@@ -1841,9 +1841,9 @@ OIIO_ADD_TEST(GamutMapUtil, order3_test)
         OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
         // In this case we only really care that they are distinct and in [0,2]
         // so this test could be changed (it is ok, but overly restrictive).
-        OIIO_CHECK_EQUAL(max, 2);
-        OIIO_CHECK_EQUAL(mid, 1);
-        OIIO_CHECK_EQUAL(min, 0);
+        OCIO_CHECK_EQUAL(max, 2);
+        OCIO_CHECK_EQUAL(mid, 1);
+        OCIO_CHECK_EQUAL(min, 0);
     }
 
     // Now test the six typical possibilities.
@@ -1851,54 +1851,54 @@ OIIO_ADD_TEST(GamutMapUtil, order3_test)
         const float RGB[] = { 3.f, 2.f, 1.f };
         int min, mid, max;
         OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
-        OIIO_CHECK_EQUAL(max, 0);
-        OIIO_CHECK_EQUAL(mid, 1);
-        OIIO_CHECK_EQUAL(min, 2);
+        OCIO_CHECK_EQUAL(max, 0);
+        OCIO_CHECK_EQUAL(mid, 1);
+        OCIO_CHECK_EQUAL(min, 2);
     }
     {
         const float RGB[] = { -3.f, -2.f, 1.f };
         int min, mid, max;
         OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
-        OIIO_CHECK_EQUAL(max, 2);
-        OIIO_CHECK_EQUAL(mid, 1);
-        OIIO_CHECK_EQUAL(min, 0);
+        OCIO_CHECK_EQUAL(max, 2);
+        OCIO_CHECK_EQUAL(mid, 1);
+        OCIO_CHECK_EQUAL(min, 0);
     }
     {
         const float RGB[] = { -3.f, 2.f, 1.f };
         int min, mid, max;
         OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
-        OIIO_CHECK_EQUAL(max, 1);
-        OIIO_CHECK_EQUAL(mid, 2);
-        OIIO_CHECK_EQUAL(min, 0);
+        OCIO_CHECK_EQUAL(max, 1);
+        OCIO_CHECK_EQUAL(mid, 2);
+        OCIO_CHECK_EQUAL(min, 0);
     }
     {
         const float RGB[] = { -0.3f, 2.f, -1.f };
         int min, mid, max;
         OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
-        OIIO_CHECK_EQUAL(max, 1);
-        OIIO_CHECK_EQUAL(mid, 0);
-        OIIO_CHECK_EQUAL(min, 2);
+        OCIO_CHECK_EQUAL(max, 1);
+        OCIO_CHECK_EQUAL(mid, 0);
+        OCIO_CHECK_EQUAL(min, 2);
     }
     {
         const float RGB[] = { 3.f, -2.f, 1.f };
         int min, mid, max;
         OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
-        OIIO_CHECK_EQUAL(max, 0);
-        OIIO_CHECK_EQUAL(mid, 2);
-        OIIO_CHECK_EQUAL(min, 1);
+        OCIO_CHECK_EQUAL(max, 0);
+        OCIO_CHECK_EQUAL(mid, 2);
+        OCIO_CHECK_EQUAL(min, 1);
     }
     {
         const float RGB[] = { 3.f, -2.f, 10.f };
         int min, mid, max;
         OCIO::GamutMapUtils::Order3(RGB, min, mid, max);
-        OIIO_CHECK_EQUAL(max, 2);
-        OIIO_CHECK_EQUAL(mid, 0);
-        OIIO_CHECK_EQUAL(min, 1);
+        OCIO_CHECK_EQUAL(max, 2);
+        OCIO_CHECK_EQUAL(mid, 0);
+        OCIO_CHECK_EQUAL(min, 1);
     }
 
 }
 
-OIIO_ADD_TEST(Lut1DRenderer, nan_test)
+OCIO_ADD_TEST(Lut1DRenderer, nan_test)
 {
     OCIO::Lut1DOpDataRcPtr lut =
         std::make_shared<OCIO::Lut1DOpData>(OCIO::BIT_DEPTH_F32,
@@ -1933,21 +1933,21 @@ OIIO_ADD_TEST(Lut1DRenderer, nan_test)
 
     renderer->apply(pixels, pixels, 6);
 
-    OIIO_CHECK_CLOSE(pixels[0], values[0], 1e-7f);
-    OIIO_CHECK_CLOSE(pixels[5], values[1], 1e-7f);
-    OIIO_CHECK_CLOSE(pixels[10], values[2], 1e-7f);
-    OIIO_CHECK_ASSERT(OCIO::IsNan(pixels[15]));
-    OIIO_CHECK_CLOSE(pixels[16], values[21], 1e-7f);
-    OIIO_CHECK_CLOSE(pixels[17], values[22], 1e-7f);
-    OIIO_CHECK_CLOSE(pixels[18], values[23], 1e-7f);
-    OIIO_CHECK_EQUAL(pixels[19], inf);
-    OIIO_CHECK_CLOSE(pixels[20], values[0], 1e-7f);
-    OIIO_CHECK_CLOSE(pixels[21], values[1], 1e-7f);
-    OIIO_CHECK_CLOSE(pixels[22], values[2], 1e-7f);
-    OIIO_CHECK_EQUAL(pixels[23], -inf);
+    OCIO_CHECK_CLOSE(pixels[0], values[0], 1e-7f);
+    OCIO_CHECK_CLOSE(pixels[5], values[1], 1e-7f);
+    OCIO_CHECK_CLOSE(pixels[10], values[2], 1e-7f);
+    OCIO_CHECK_ASSERT(OCIO::IsNan(pixels[15]));
+    OCIO_CHECK_CLOSE(pixels[16], values[21], 1e-7f);
+    OCIO_CHECK_CLOSE(pixels[17], values[22], 1e-7f);
+    OCIO_CHECK_CLOSE(pixels[18], values[23], 1e-7f);
+    OCIO_CHECK_EQUAL(pixels[19], inf);
+    OCIO_CHECK_CLOSE(pixels[20], values[0], 1e-7f);
+    OCIO_CHECK_CLOSE(pixels[21], values[1], 1e-7f);
+    OCIO_CHECK_CLOSE(pixels[22], values[2], 1e-7f);
+    OCIO_CHECK_EQUAL(pixels[23], -inf);
 }
 
-OIIO_ADD_TEST(Lut1DRenderer, nan_half_test)
+OCIO_ADD_TEST(Lut1DRenderer, nan_half_test)
 {
     OCIO::Lut1DOpDataRcPtr lut = std::make_shared<OCIO::Lut1DOpData>(
         OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_F32,
@@ -1979,13 +1979,13 @@ OIIO_ADD_TEST(Lut1DRenderer, nan_half_test)
     // This verifies that a half-domain Lut1D can map NaNs to whatever the LUT author wants.
     // In this test, a different value for R, G, and B.
 
-    OIIO_CHECK_CLOSE(pixels[0], values[nanIdRed], 1e-7f);
-    OIIO_CHECK_CLOSE(pixels[5], values[nanIdRed + 1], 1e-7f);
-    OIIO_CHECK_CLOSE(pixels[10], values[nanIdRed + 2], 1e-7f);
-    OIIO_CHECK_ASSERT(OCIO::IsNan(pixels[15]));
+    OCIO_CHECK_CLOSE(pixels[0], values[nanIdRed], 1e-7f);
+    OCIO_CHECK_CLOSE(pixels[5], values[nanIdRed + 1], 1e-7f);
+    OCIO_CHECK_CLOSE(pixels[10], values[nanIdRed + 2], 1e-7f);
+    OCIO_CHECK_ASSERT(OCIO::IsNan(pixels[15]));
 }
 
-OIIO_ADD_TEST(Lut1DRenderer, bit_depth_support)
+OCIO_ADD_TEST(Lut1DRenderer, bit_depth_support)
 {
     // Unit test to validate the pixel bit depth processing with the 1D LUT.
 
@@ -2281,31 +2281,31 @@ OIIO_ADD_TEST(Lut1DRenderer, bit_depth_support)
         const bool isLookup
             = OCIO::DynamicPtrCast<OCIO::BaseLut1DRenderer<OCIO::BIT_DEPTH_UINT8, 
                                                            OCIO::BIT_DEPTH_UINT8>>(cpuOp)->isLookup();
-        OIIO_CHECK_ASSERT(isLookup);
+        OCIO_CHECK_ASSERT(isLookup);
 
         std::vector<uint8_t> outImg(NB_PIXELS * 4, 0);
 
-        OIIO_CHECK_NO_THROW( cpuOp->apply(&uint8_inImg[0], &outImg[0], NB_PIXELS) );
+        OCIO_CHECK_NO_THROW( cpuOp->apply(&uint8_inImg[0], &outImg[0], NB_PIXELS) );
 
-        OIIO_CHECK_EQUAL(outImg[ 0],   0);
-        OIIO_CHECK_EQUAL(outImg[ 1],   0);
-        OIIO_CHECK_EQUAL(outImg[ 2],   0);
-        OIIO_CHECK_EQUAL(outImg[ 3],   0);
+        OCIO_CHECK_EQUAL(outImg[ 0],   0);
+        OCIO_CHECK_EQUAL(outImg[ 1],   0);
+        OCIO_CHECK_EQUAL(outImg[ 2],   0);
+        OCIO_CHECK_EQUAL(outImg[ 3],   0);
 
-        OIIO_CHECK_EQUAL(outImg[ 4],  17);
-        OIIO_CHECK_EQUAL(outImg[ 5],  18);
-        OIIO_CHECK_EQUAL(outImg[ 6],  18);
-        OIIO_CHECK_EQUAL(outImg[ 7], 255);
+        OCIO_CHECK_EQUAL(outImg[ 4],  17);
+        OCIO_CHECK_EQUAL(outImg[ 5],  18);
+        OCIO_CHECK_EQUAL(outImg[ 6],  18);
+        OCIO_CHECK_EQUAL(outImg[ 7], 255);
 
-        OIIO_CHECK_EQUAL(outImg[ 8], 182);
-        OIIO_CHECK_EQUAL(outImg[ 9], 185);
-        OIIO_CHECK_EQUAL(outImg[10], 188);
-        OIIO_CHECK_EQUAL(outImg[11],   0);
+        OCIO_CHECK_EQUAL(outImg[ 8], 182);
+        OCIO_CHECK_EQUAL(outImg[ 9], 185);
+        OCIO_CHECK_EQUAL(outImg[10], 188);
+        OCIO_CHECK_EQUAL(outImg[11],   0);
 
-        OIIO_CHECK_EQUAL(outImg[12], 255);
-        OIIO_CHECK_EQUAL(outImg[13], 255);
-        OIIO_CHECK_EQUAL(outImg[14], 255);
-        OIIO_CHECK_EQUAL(outImg[15], 255);
+        OCIO_CHECK_EQUAL(outImg[12], 255);
+        OCIO_CHECK_EQUAL(outImg[13], 255);
+        OCIO_CHECK_EQUAL(outImg[14], 255);
+        OCIO_CHECK_EQUAL(outImg[15], 255);
     }
 
     // Processing from UINT8 to UINT8, using the inverse LUT.
@@ -2319,31 +2319,31 @@ OIIO_ADD_TEST(Lut1DRenderer, bit_depth_support)
         const bool isLookup
             = OCIO::DynamicPtrCast<OCIO::BaseLut1DRenderer<OCIO::BIT_DEPTH_UINT8, 
                                                            OCIO::BIT_DEPTH_UINT8>>(cpuOp)->isLookup();
-        OIIO_CHECK_ASSERT(isLookup);
+        OCIO_CHECK_ASSERT(isLookup);
 
         std::vector<uint8_t> outImg(NB_PIXELS * 4, 0);
 
-        OIIO_CHECK_NO_THROW( cpuOp->apply(&uint8_inImg[0], &outImg[0], NB_PIXELS) );
+        OCIO_CHECK_NO_THROW( cpuOp->apply(&uint8_inImg[0], &outImg[0], NB_PIXELS) );
 
-        OIIO_CHECK_EQUAL(outImg[ 0],  24);
-        OIIO_CHECK_EQUAL(outImg[ 1],  25);
-        OIIO_CHECK_EQUAL(outImg[ 2],  27);
-        OIIO_CHECK_EQUAL(outImg[ 3],   0);
+        OCIO_CHECK_EQUAL(outImg[ 0],  24);
+        OCIO_CHECK_EQUAL(outImg[ 1],  25);
+        OCIO_CHECK_EQUAL(outImg[ 2],  27);
+        OCIO_CHECK_EQUAL(outImg[ 3],   0);
 
-        OIIO_CHECK_EQUAL(outImg[ 4],  84);
-        OIIO_CHECK_EQUAL(outImg[ 5],  85);
-        OIIO_CHECK_EQUAL(outImg[ 6],  86);
-        OIIO_CHECK_EQUAL(outImg[ 7], 255);
+        OCIO_CHECK_EQUAL(outImg[ 4],  84);
+        OCIO_CHECK_EQUAL(outImg[ 5],  85);
+        OCIO_CHECK_EQUAL(outImg[ 6],  86);
+        OCIO_CHECK_EQUAL(outImg[ 7], 255);
 
-        OIIO_CHECK_EQUAL(outImg[ 8], 139);
-        OIIO_CHECK_EQUAL(outImg[ 9], 139);
-        OIIO_CHECK_EQUAL(outImg[10], 140);
-        OIIO_CHECK_EQUAL(outImg[11],   0);
+        OCIO_CHECK_EQUAL(outImg[ 8], 139);
+        OCIO_CHECK_EQUAL(outImg[ 9], 139);
+        OCIO_CHECK_EQUAL(outImg[10], 140);
+        OCIO_CHECK_EQUAL(outImg[11],   0);
 
-        OIIO_CHECK_EQUAL(outImg[12], 164);
-        OIIO_CHECK_EQUAL(outImg[13], 167);
-        OIIO_CHECK_EQUAL(outImg[14], 170);
-        OIIO_CHECK_EQUAL(outImg[15], 255);
+        OCIO_CHECK_EQUAL(outImg[12], 164);
+        OCIO_CHECK_EQUAL(outImg[13], 167);
+        OCIO_CHECK_EQUAL(outImg[14], 170);
+        OCIO_CHECK_EQUAL(outImg[15], 255);
     }
 
     // Processing from UINT8 to UINT16.
@@ -2359,31 +2359,31 @@ OIIO_ADD_TEST(Lut1DRenderer, bit_depth_support)
         const bool isLookup
             = OCIO::DynamicPtrCast<OCIO::BaseLut1DRenderer<OCIO::BIT_DEPTH_UINT8, 
                                                            OCIO::BIT_DEPTH_UINT16>>(cpuOp)->isLookup();
-        OIIO_CHECK_ASSERT(isLookup);
+        OCIO_CHECK_ASSERT(isLookup);
 
         std::vector<uint16_t> outImg(NB_PIXELS * 4, 0);
 
-        OIIO_CHECK_NO_THROW( cpuOp->apply(&uint8_inImg[0], &outImg[0], NB_PIXELS) );
+        OCIO_CHECK_NO_THROW( cpuOp->apply(&uint8_inImg[0], &outImg[0], NB_PIXELS) );
 
-        OIIO_CHECK_EQUAL(outImg[ 0], uint16_outImg[ 0]);
-        OIIO_CHECK_EQUAL(outImg[ 1], uint16_outImg[ 1]);
-        OIIO_CHECK_EQUAL(outImg[ 2], uint16_outImg[ 2]);
-        OIIO_CHECK_EQUAL(outImg[ 3], uint16_outImg[ 3]);
+        OCIO_CHECK_EQUAL(outImg[ 0], uint16_outImg[ 0]);
+        OCIO_CHECK_EQUAL(outImg[ 1], uint16_outImg[ 1]);
+        OCIO_CHECK_EQUAL(outImg[ 2], uint16_outImg[ 2]);
+        OCIO_CHECK_EQUAL(outImg[ 3], uint16_outImg[ 3]);
 
-        OIIO_CHECK_EQUAL(outImg[ 4], uint16_outImg[ 4]);
-        OIIO_CHECK_EQUAL(outImg[ 5], uint16_outImg[ 5]);
-        OIIO_CHECK_EQUAL(outImg[ 6], uint16_outImg[ 6]);
-        OIIO_CHECK_EQUAL(outImg[ 7], uint16_outImg[ 7]);
+        OCIO_CHECK_EQUAL(outImg[ 4], uint16_outImg[ 4]);
+        OCIO_CHECK_EQUAL(outImg[ 5], uint16_outImg[ 5]);
+        OCIO_CHECK_EQUAL(outImg[ 6], uint16_outImg[ 6]);
+        OCIO_CHECK_EQUAL(outImg[ 7], uint16_outImg[ 7]);
 
-        OIIO_CHECK_EQUAL(outImg[ 8], uint16_outImg[ 8]);
-        OIIO_CHECK_EQUAL(outImg[ 9], uint16_outImg[ 9]);
-        OIIO_CHECK_EQUAL(outImg[10], uint16_outImg[10]);
-        OIIO_CHECK_EQUAL(outImg[11], uint16_outImg[11]);
+        OCIO_CHECK_EQUAL(outImg[ 8], uint16_outImg[ 8]);
+        OCIO_CHECK_EQUAL(outImg[ 9], uint16_outImg[ 9]);
+        OCIO_CHECK_EQUAL(outImg[10], uint16_outImg[10]);
+        OCIO_CHECK_EQUAL(outImg[11], uint16_outImg[11]);
 
-        OIIO_CHECK_EQUAL(outImg[12], uint16_outImg[12]);
-        OIIO_CHECK_EQUAL(outImg[13], uint16_outImg[13]);
-        OIIO_CHECK_EQUAL(outImg[14], uint16_outImg[14]);
-        OIIO_CHECK_EQUAL(outImg[15], uint16_outImg[15]);
+        OCIO_CHECK_EQUAL(outImg[12], uint16_outImg[12]);
+        OCIO_CHECK_EQUAL(outImg[13], uint16_outImg[13]);
+        OCIO_CHECK_EQUAL(outImg[14], uint16_outImg[14]);
+        OCIO_CHECK_EQUAL(outImg[15], uint16_outImg[15]);
     }
 
     // Processing from UINT8 to F16.
@@ -2399,31 +2399,31 @@ OIIO_ADD_TEST(Lut1DRenderer, bit_depth_support)
         const bool isLookup
             = OCIO::DynamicPtrCast<OCIO::BaseLut1DRenderer<OCIO::BIT_DEPTH_UINT8, 
                                                            OCIO::BIT_DEPTH_F16>>(cpuOp)->isLookup();
-        OIIO_CHECK_ASSERT(isLookup);
+        OCIO_CHECK_ASSERT(isLookup);
 
         std::vector<half> outImg(NB_PIXELS * 4, 0);
 
-        OIIO_CHECK_NO_THROW( cpuOp->apply(&uint8_inImg[0], &outImg[0], NB_PIXELS) );
+        OCIO_CHECK_NO_THROW( cpuOp->apply(&uint8_inImg[0], &outImg[0], NB_PIXELS) );
 
-        OIIO_CHECK_EQUAL(outImg[ 0], 0.0f);
-        OIIO_CHECK_EQUAL(outImg[ 1], 0.0f);
-        OIIO_CHECK_EQUAL(outImg[ 2], 0.0f);
-        OIIO_CHECK_EQUAL(outImg[ 3], 0.0f);
+        OCIO_CHECK_EQUAL(outImg[ 0], 0.0f);
+        OCIO_CHECK_EQUAL(outImg[ 1], 0.0f);
+        OCIO_CHECK_EQUAL(outImg[ 2], 0.0f);
+        OCIO_CHECK_EQUAL(outImg[ 3], 0.0f);
 
-        OIIO_CHECK_CLOSE(outImg[ 4], 0.066650390625f, 1e-6f);
-        OIIO_CHECK_CLOSE(outImg[ 5], 0.070617675781f, 1e-6f);
-        OIIO_CHECK_CLOSE(outImg[ 6], 0.070617675781f, 1e-6f);
-        OIIO_CHECK_EQUAL(outImg[ 7], 1.0f);
+        OCIO_CHECK_CLOSE(outImg[ 4], 0.066650390625f, 1e-6f);
+        OCIO_CHECK_CLOSE(outImg[ 5], 0.070617675781f, 1e-6f);
+        OCIO_CHECK_CLOSE(outImg[ 6], 0.070617675781f, 1e-6f);
+        OCIO_CHECK_EQUAL(outImg[ 7], 1.0f);
 
-        OIIO_CHECK_CLOSE(outImg[ 8], 0.7138671875f, 1e-6f);
-        OIIO_CHECK_CLOSE(outImg[ 9], 0.7255859375f, 1e-6f);
-        OIIO_CHECK_CLOSE(outImg[10], 0.7373046875f, 1e-6f);
-        OIIO_CHECK_EQUAL(outImg[11], 0.0f);
+        OCIO_CHECK_CLOSE(outImg[ 8], 0.7138671875f, 1e-6f);
+        OCIO_CHECK_CLOSE(outImg[ 9], 0.7255859375f, 1e-6f);
+        OCIO_CHECK_CLOSE(outImg[10], 0.7373046875f, 1e-6f);
+        OCIO_CHECK_EQUAL(outImg[11], 0.0f);
 
-        OIIO_CHECK_EQUAL(outImg[12], 1.0f);
-        OIIO_CHECK_EQUAL(outImg[13], 1.0f);
-        OIIO_CHECK_EQUAL(outImg[14], 1.0f);
-        OIIO_CHECK_EQUAL(outImg[15], 1.0f);
+        OCIO_CHECK_EQUAL(outImg[12], 1.0f);
+        OCIO_CHECK_EQUAL(outImg[13], 1.0f);
+        OCIO_CHECK_EQUAL(outImg[14], 1.0f);
+        OCIO_CHECK_EQUAL(outImg[15], 1.0f);
     }
 
     // Processing from UINT8 to F32.
@@ -2439,31 +2439,31 @@ OIIO_ADD_TEST(Lut1DRenderer, bit_depth_support)
         const bool isLookup
             = OCIO::DynamicPtrCast<OCIO::BaseLut1DRenderer<OCIO::BIT_DEPTH_UINT8, 
                                                            OCIO::BIT_DEPTH_F32>>(cpuOp)->isLookup();
-        OIIO_CHECK_ASSERT(isLookup);
+        OCIO_CHECK_ASSERT(isLookup);
 
         std::vector<float> outImg(NB_PIXELS * 4, 0);
 
-        OIIO_CHECK_NO_THROW( cpuOp->apply(&uint8_inImg[0], &outImg[0], NB_PIXELS) );
+        OCIO_CHECK_NO_THROW( cpuOp->apply(&uint8_inImg[0], &outImg[0], NB_PIXELS) );
 
-        OIIO_CHECK_EQUAL(outImg[ 0], 0.0f);
-        OIIO_CHECK_EQUAL(outImg[ 1], 0.0f);
-        OIIO_CHECK_EQUAL(outImg[ 2], 0.0f);
-        OIIO_CHECK_EQUAL(outImg[ 3], 0.0f);
+        OCIO_CHECK_EQUAL(outImg[ 0], 0.0f);
+        OCIO_CHECK_EQUAL(outImg[ 1], 0.0f);
+        OCIO_CHECK_EQUAL(outImg[ 2], 0.0f);
+        OCIO_CHECK_EQUAL(outImg[ 3], 0.0f);
 
-        OIIO_CHECK_CLOSE(outImg[ 4], 0.06666666666666667f, 1e-6f);
-        OIIO_CHECK_CLOSE(outImg[ 5], 0.07058823529411765f, 1e-6f);
-        OIIO_CHECK_CLOSE(outImg[ 6], 0.07058823529411765f, 1e-6f);
-        OIIO_CHECK_EQUAL(outImg[ 7], 1.0f);
+        OCIO_CHECK_CLOSE(outImg[ 4], 0.06666666666666667f, 1e-6f);
+        OCIO_CHECK_CLOSE(outImg[ 5], 0.07058823529411765f, 1e-6f);
+        OCIO_CHECK_CLOSE(outImg[ 6], 0.07058823529411765f, 1e-6f);
+        OCIO_CHECK_EQUAL(outImg[ 7], 1.0f);
 
-        OIIO_CHECK_CLOSE(outImg[ 8], 0.7137254901960784f, 1e-6f);
-        OIIO_CHECK_CLOSE(outImg[ 9], 0.7254901960784313f, 1e-6f);
-        OIIO_CHECK_CLOSE(outImg[10], 0.7372549019607844f, 1e-6f);
-        OIIO_CHECK_EQUAL(outImg[11], 0.0f);
+        OCIO_CHECK_CLOSE(outImg[ 8], 0.7137254901960784f, 1e-6f);
+        OCIO_CHECK_CLOSE(outImg[ 9], 0.7254901960784313f, 1e-6f);
+        OCIO_CHECK_CLOSE(outImg[10], 0.7372549019607844f, 1e-6f);
+        OCIO_CHECK_EQUAL(outImg[11], 0.0f);
 
-        OIIO_CHECK_EQUAL(outImg[12], 1.0f);
-        OIIO_CHECK_EQUAL(outImg[13], 1.0f);
-        OIIO_CHECK_EQUAL(outImg[14], 1.0f);
-        OIIO_CHECK_EQUAL(outImg[15], 1.0f);
+        OCIO_CHECK_EQUAL(outImg[12], 1.0f);
+        OCIO_CHECK_EQUAL(outImg[13], 1.0f);
+        OCIO_CHECK_EQUAL(outImg[14], 1.0f);
+        OCIO_CHECK_EQUAL(outImg[15], 1.0f);
     }
 
     // Use scaled previous input values so previous output values could be 
@@ -2489,31 +2489,31 @@ OIIO_ADD_TEST(Lut1DRenderer, bit_depth_support)
         const bool isLookup
             = OCIO::DynamicPtrCast<OCIO::BaseLut1DRenderer<OCIO::BIT_DEPTH_F32, 
                                                            OCIO::BIT_DEPTH_UINT8>>(cpuOp)->isLookup();
-        OIIO_CHECK_ASSERT(!isLookup);
+        OCIO_CHECK_ASSERT(!isLookup);
 
         std::vector<uint8_t> outImg(NB_PIXELS * 4, 0);
 
-        OIIO_CHECK_NO_THROW( cpuOp->apply(&float_inImg[0], &outImg[0], NB_PIXELS) );
+        OCIO_CHECK_NO_THROW( cpuOp->apply(&float_inImg[0], &outImg[0], NB_PIXELS) );
 
-        OIIO_CHECK_EQUAL(outImg[ 0],   0);
-        OIIO_CHECK_EQUAL(outImg[ 1],   0);
-        OIIO_CHECK_EQUAL(outImg[ 2],   0);
-        OIIO_CHECK_EQUAL(outImg[ 3],   0);
+        OCIO_CHECK_EQUAL(outImg[ 0],   0);
+        OCIO_CHECK_EQUAL(outImg[ 1],   0);
+        OCIO_CHECK_EQUAL(outImg[ 2],   0);
+        OCIO_CHECK_EQUAL(outImg[ 3],   0);
 
-        OIIO_CHECK_EQUAL(outImg[ 4],  17);
-        OIIO_CHECK_EQUAL(outImg[ 5],  18);
-        OIIO_CHECK_EQUAL(outImg[ 6],  18);
-        OIIO_CHECK_EQUAL(outImg[ 7], 255);
+        OCIO_CHECK_EQUAL(outImg[ 4],  17);
+        OCIO_CHECK_EQUAL(outImg[ 5],  18);
+        OCIO_CHECK_EQUAL(outImg[ 6],  18);
+        OCIO_CHECK_EQUAL(outImg[ 7], 255);
 
-        OIIO_CHECK_EQUAL(outImg[ 8], 182);
-        OIIO_CHECK_EQUAL(outImg[ 9], 185);
-        OIIO_CHECK_EQUAL(outImg[10], 188);
-        OIIO_CHECK_EQUAL(outImg[11],   0);
+        OCIO_CHECK_EQUAL(outImg[ 8], 182);
+        OCIO_CHECK_EQUAL(outImg[ 9], 185);
+        OCIO_CHECK_EQUAL(outImg[10], 188);
+        OCIO_CHECK_EQUAL(outImg[11],   0);
 
-        OIIO_CHECK_EQUAL(outImg[12], 255);
-        OIIO_CHECK_EQUAL(outImg[13], 255);
-        OIIO_CHECK_EQUAL(outImg[14], 255);
-        OIIO_CHECK_EQUAL(outImg[15], 255);
+        OCIO_CHECK_EQUAL(outImg[12], 255);
+        OCIO_CHECK_EQUAL(outImg[13], 255);
+        OCIO_CHECK_EQUAL(outImg[14], 255);
+        OCIO_CHECK_EQUAL(outImg[15], 255);
     }
 
     // LUT will not be a lookup table.
@@ -2530,31 +2530,31 @@ OIIO_ADD_TEST(Lut1DRenderer, bit_depth_support)
         const bool isLookup
             = OCIO::DynamicPtrCast<OCIO::BaseLut1DRenderer<OCIO::BIT_DEPTH_F32, 
                                                            OCIO::BIT_DEPTH_UINT16>>(cpuOp)->isLookup();
-        OIIO_CHECK_ASSERT(!isLookup);
+        OCIO_CHECK_ASSERT(!isLookup);
 
         std::vector<uint16_t> outImg(NB_PIXELS * 4, 0);
 
-        OIIO_CHECK_NO_THROW( cpuOp->apply(&float_inImg[0], &outImg[0], NB_PIXELS) );
+        OCIO_CHECK_NO_THROW( cpuOp->apply(&float_inImg[0], &outImg[0], NB_PIXELS) );
 
-        OIIO_CHECK_EQUAL(outImg[ 0], uint16_outImg[ 0]);
-        OIIO_CHECK_EQUAL(outImg[ 1], uint16_outImg[ 1]);
-        OIIO_CHECK_EQUAL(outImg[ 2], uint16_outImg[ 2]);
-        OIIO_CHECK_EQUAL(outImg[ 3], uint16_outImg[ 3]);
+        OCIO_CHECK_EQUAL(outImg[ 0], uint16_outImg[ 0]);
+        OCIO_CHECK_EQUAL(outImg[ 1], uint16_outImg[ 1]);
+        OCIO_CHECK_EQUAL(outImg[ 2], uint16_outImg[ 2]);
+        OCIO_CHECK_EQUAL(outImg[ 3], uint16_outImg[ 3]);
 
-        OIIO_CHECK_EQUAL(outImg[ 4], uint16_outImg[ 4]);
-        OIIO_CHECK_EQUAL(outImg[ 5], uint16_outImg[ 5]);
-        OIIO_CHECK_EQUAL(outImg[ 6], uint16_outImg[ 6]);
-        OIIO_CHECK_EQUAL(outImg[ 7], uint16_outImg[ 7]);
+        OCIO_CHECK_EQUAL(outImg[ 4], uint16_outImg[ 4]);
+        OCIO_CHECK_EQUAL(outImg[ 5], uint16_outImg[ 5]);
+        OCIO_CHECK_EQUAL(outImg[ 6], uint16_outImg[ 6]);
+        OCIO_CHECK_EQUAL(outImg[ 7], uint16_outImg[ 7]);
 
-        OIIO_CHECK_EQUAL(outImg[ 8], uint16_outImg[ 8]);
-        OIIO_CHECK_EQUAL(outImg[ 9], uint16_outImg[ 9]);
-        OIIO_CHECK_EQUAL(outImg[10], uint16_outImg[10]);
-        OIIO_CHECK_EQUAL(outImg[11], uint16_outImg[11]);
+        OCIO_CHECK_EQUAL(outImg[ 8], uint16_outImg[ 8]);
+        OCIO_CHECK_EQUAL(outImg[ 9], uint16_outImg[ 9]);
+        OCIO_CHECK_EQUAL(outImg[10], uint16_outImg[10]);
+        OCIO_CHECK_EQUAL(outImg[11], uint16_outImg[11]);
 
-        OIIO_CHECK_EQUAL(outImg[12], uint16_outImg[12]);
-        OIIO_CHECK_EQUAL(outImg[13], uint16_outImg[13]);
-        OIIO_CHECK_EQUAL(outImg[14], uint16_outImg[14]);
-        OIIO_CHECK_EQUAL(outImg[15], uint16_outImg[15]);
+        OCIO_CHECK_EQUAL(outImg[12], uint16_outImg[12]);
+        OCIO_CHECK_EQUAL(outImg[13], uint16_outImg[13]);
+        OCIO_CHECK_EQUAL(outImg[14], uint16_outImg[14]);
+        OCIO_CHECK_EQUAL(outImg[15], uint16_outImg[15]);
     }
 }
 

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOpData.cpp
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOpData.cpp
@@ -1270,70 +1270,70 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 
-OIIO_ADD_TEST(Lut1DOpData, get_lut_ideal_size)
+OCIO_ADD_TEST(Lut1DOpData, get_lut_ideal_size)
 {
-    OIIO_CHECK_EQUAL(OCIO::Lut1DOpData::GetLutIdealSize(OCIO::BIT_DEPTH_UINT8), 256);
-    OIIO_CHECK_EQUAL(OCIO::Lut1DOpData::GetLutIdealSize(OCIO::BIT_DEPTH_UINT16), 65536);
+    OCIO_CHECK_EQUAL(OCIO::Lut1DOpData::GetLutIdealSize(OCIO::BIT_DEPTH_UINT8), 256);
+    OCIO_CHECK_EQUAL(OCIO::Lut1DOpData::GetLutIdealSize(OCIO::BIT_DEPTH_UINT16), 65536);
 
-    OIIO_CHECK_EQUAL(OCIO::Lut1DOpData::GetLutIdealSize(OCIO::BIT_DEPTH_F16), 65536);
-    OIIO_CHECK_EQUAL(OCIO::Lut1DOpData::GetLutIdealSize(OCIO::BIT_DEPTH_F32), 65536);
+    OCIO_CHECK_EQUAL(OCIO::Lut1DOpData::GetLutIdealSize(OCIO::BIT_DEPTH_F16), 65536);
+    OCIO_CHECK_EQUAL(OCIO::Lut1DOpData::GetLutIdealSize(OCIO::BIT_DEPTH_F32), 65536);
 }
 
-OIIO_ADD_TEST(Lut1DOpData, constructor)
+OCIO_ADD_TEST(Lut1DOpData, constructor)
 {
     OCIO::Lut1DOpData lut(2);
 
-    OIIO_CHECK_ASSERT(lut.getType() == OCIO::OpData::Lut1DType);
-    OIIO_CHECK_ASSERT(!lut.isNoOp());
-    OIIO_CHECK_ASSERT(lut.isIdentity());
-    OIIO_CHECK_EQUAL(lut.getArray().getLength(), 2);
-    OIIO_CHECK_EQUAL(lut.getInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_NO_THROW(lut.validate());
+    OCIO_CHECK_ASSERT(lut.getType() == OCIO::OpData::Lut1DType);
+    OCIO_CHECK_ASSERT(!lut.isNoOp());
+    OCIO_CHECK_ASSERT(lut.isIdentity());
+    OCIO_CHECK_EQUAL(lut.getArray().getLength(), 2);
+    OCIO_CHECK_EQUAL(lut.getInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_NO_THROW(lut.validate());
 }
 
-OIIO_ADD_TEST(Lut1DOpData, accessors)
+OCIO_ADD_TEST(Lut1DOpData, accessors)
 {
     OCIO::Lut1DOpData l(17);
     l.setInputBitDepth(OCIO::BIT_DEPTH_UINT10);
     l.setOutputBitDepth(OCIO::BIT_DEPTH_UINT10);
     l.setInterpolation(OCIO::INTERP_LINEAR);
 
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_ASSERT(!l.isNoOp());
-    OIIO_CHECK_ASSERT(l.isIdentity());
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_ASSERT(!l.isNoOp());
+    OCIO_CHECK_ASSERT(l.isIdentity());
+    OCIO_CHECK_NO_THROW(l.validate());
 
-    OIIO_CHECK_EQUAL(l.getHueAdjust(), OCIO::Lut1DOpData::HUE_NONE);
+    OCIO_CHECK_EQUAL(l.getHueAdjust(), OCIO::Lut1DOpData::HUE_NONE);
     l.setHueAdjust(OCIO::Lut1DOpData::HUE_DW3);
-    OIIO_CHECK_EQUAL(l.getHueAdjust(), OCIO::Lut1DOpData::HUE_DW3);
+    OCIO_CHECK_EQUAL(l.getHueAdjust(), OCIO::Lut1DOpData::HUE_DW3);
 
     // Note: Hue and Sat adjust do not affect identity status.
-    OIIO_CHECK_ASSERT(l.isIdentity());
+    OCIO_CHECK_ASSERT(l.isIdentity());
 
     l.getArray()[1] = 1.0f;
-    OIIO_CHECK_ASSERT(!l.isNoOp());
-    OIIO_CHECK_ASSERT(!l.isIdentity());
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_ASSERT(!l.isNoOp());
+    OCIO_CHECK_ASSERT(!l.isIdentity());
+    OCIO_CHECK_NO_THROW(l.validate());
 
     l.setInterpolation(OCIO::INTERP_BEST);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_BEST);
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_BEST);
 
-    OIIO_CHECK_EQUAL(l.getArray().getLength(), 17);
-    OIIO_CHECK_EQUAL(l.getArray().getNumValues(), 17 * 3);
-    OIIO_CHECK_EQUAL(l.getArray().getNumColorComponents(), 3);
+    OCIO_CHECK_EQUAL(l.getArray().getLength(), 17);
+    OCIO_CHECK_EQUAL(l.getArray().getNumValues(), 17 * 3);
+    OCIO_CHECK_EQUAL(l.getArray().getNumColorComponents(), 3);
 
     l.getArray().resize(65, 3);
 
-    OIIO_CHECK_EQUAL(l.getArray().getLength(), 65);
-    OIIO_CHECK_EQUAL(l.getArray().getNumValues(), 65 * 3);
-    OIIO_CHECK_EQUAL(l.getArray().getNumColorComponents(), 3);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getArray().getLength(), 65);
+    OCIO_CHECK_EQUAL(l.getArray().getNumValues(), 65 * 3);
+    OCIO_CHECK_EQUAL(l.getArray().getNumColorComponents(), 3);
+    OCIO_CHECK_NO_THROW(l.validate());
 }
 
-OIIO_ADD_TEST(Lut1DOpData, identity_bitdepth)
+OCIO_ADD_TEST(Lut1DOpData, identity_bitdepth)
 {
     OCIO::Lut1DOpData l1(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT8,
                          "", OCIO::OpData::Descriptions(),
@@ -1344,13 +1344,13 @@ OIIO_ADD_TEST(Lut1DOpData, identity_bitdepth)
                          OCIO::INTERP_LINEAR,
                          OCIO::Lut1DOpData::LUT_STANDARD);
 
-    OIIO_CHECK_ASSERT(!l1.isNoOp());
-    OIIO_CHECK_ASSERT(l1.isIdentity());
-    OIIO_CHECK_NO_THROW(l1.validate());
+    OCIO_CHECK_ASSERT(!l1.isNoOp());
+    OCIO_CHECK_ASSERT(l1.isIdentity());
+    OCIO_CHECK_NO_THROW(l1.validate());
 
-    OIIO_CHECK_ASSERT(!l2.isNoOp());
-    OIIO_CHECK_ASSERT(l2.isIdentity());
-    OIIO_CHECK_NO_THROW(l2.validate());
+    OCIO_CHECK_ASSERT(!l2.isNoOp());
+    OCIO_CHECK_ASSERT(l2.isIdentity());
+    OCIO_CHECK_NO_THROW(l2.validate());
 
     const float coeff
         = OCIO::GetBitDepthMaxValue(l2.getOutputBitDepth())
@@ -1361,15 +1361,15 @@ OIIO_ADD_TEST(Lut1DOpData, identity_bitdepth)
     const float error = 1e-6f;
     for (unsigned long idx = 0; idx<l2.getArray().getLength(); ++idx)
     {
-        OIIO_CHECK_CLOSE(l1.getArray().getValues()[idx * 3 + 0] * coeff,
+        OCIO_CHECK_CLOSE(l1.getArray().getValues()[idx * 3 + 0] * coeff,
                          l2.getArray().getValues()[idx * 3 + 0],
                          error);
 
-        OIIO_CHECK_CLOSE(l1.getArray().getValues()[idx * 3 + 1] * coeff,
+        OCIO_CHECK_CLOSE(l1.getArray().getValues()[idx * 3 + 1] * coeff,
                          l2.getArray().getValues()[idx * 3 + 1],
                          error);
 
-        OIIO_CHECK_CLOSE(l1.getArray().getValues()[idx * 3 + 2] * coeff,
+        OCIO_CHECK_CLOSE(l1.getArray().getValues()[idx * 3 + 2] * coeff,
                          l2.getArray().getValues()[idx * 3 + 2],
                          error);
     }
@@ -1379,17 +1379,17 @@ OIIO_ADD_TEST(Lut1DOpData, identity_bitdepth)
                          OCIO::INTERP_LINEAR,
                          OCIO::Lut1DOpData::LUT_INPUT_HALF_CODE);
 
-    OIIO_CHECK_ASSERT(l3.isIdentity());
+    OCIO_CHECK_ASSERT(l3.isIdentity());
 }
 
-OIIO_ADD_TEST(Lut1DOpData, is_identity)
+OCIO_ADD_TEST(Lut1DOpData, is_identity)
 {
     OCIO::Lut1DOpData l1(OCIO::BIT_DEPTH_UINT10, OCIO::BIT_DEPTH_UINT10,
                          "", OCIO::OpData::Descriptions(),
                          OCIO::INTERP_LINEAR,
                          OCIO::Lut1DOpData::LUT_STANDARD);
 
-    OIIO_CHECK_ASSERT(l1.isIdentity());
+    OCIO_CHECK_ASSERT(l1.isIdentity());
 
     // The tolerance will be 1023*1e-5 = 0.01023.
     const unsigned long lastId = (unsigned long)l1.getArray().getValues().size() - 1;
@@ -1398,15 +1398,15 @@ OIIO_ADD_TEST(Lut1DOpData, is_identity)
 
     l1.getArray()[0] = first + 0.01f;
     l1.getArray()[lastId] = last + 0.01f;
-    OIIO_CHECK_ASSERT(l1.isIdentity());
+    OCIO_CHECK_ASSERT(l1.isIdentity());
 
     l1.getArray()[0] = first + 0.02f;
     l1.getArray()[lastId] = last;
-    OIIO_CHECK_ASSERT(!l1.isIdentity());
+    OCIO_CHECK_ASSERT(!l1.isIdentity());
 
     l1.getArray()[0] = first;
     l1.getArray()[lastId] = last + 0.02f;
-    OIIO_CHECK_ASSERT(!l1.isIdentity());
+    OCIO_CHECK_ASSERT(!l1.isIdentity());
 
 
     OCIO::Lut1DOpData l2(OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_UINT10,
@@ -1426,25 +1426,25 @@ OIIO_ADD_TEST(Lut1DOpData, is_identity)
     // scaled -> 32736.0f
     const float ERROR_31700 = 32736.0f;
 
-    OIIO_CHECK_ASSERT(l2.isIdentity());
+    OCIO_CHECK_ASSERT(l2.isIdentity());
 
     l2.getArray()[0] = first2 + ERROR_0;
     l2.getArray()[id2] = last2 + ERROR_31700;
 
-    OIIO_CHECK_ASSERT(l2.isIdentity());
+    OCIO_CHECK_ASSERT(l2.isIdentity());
 
     l2.getArray()[0] = first2 + 2 * ERROR_0;
     l2.getArray()[id2] = last2;
 
-    OIIO_CHECK_ASSERT(!l2.isIdentity());
+    OCIO_CHECK_ASSERT(!l2.isIdentity());
 
     l2.getArray()[0] = first2;
     l2.getArray()[id2] = last2 + 2 * ERROR_31700;
 
-    OIIO_CHECK_ASSERT(!l2.isIdentity());
+    OCIO_CHECK_ASSERT(!l2.isIdentity());
 }
 
-OIIO_ADD_TEST(Lut1DOpData, clone)
+OCIO_ADD_TEST(Lut1DOpData, clone)
 {
     OCIO::Lut1DOpData ref(20);
     ref.getArray()[1] = 0.5f;
@@ -1452,14 +1452,14 @@ OIIO_ADD_TEST(Lut1DOpData, clone)
 
     OCIO::Lut1DOpDataRcPtr pClone = ref.clone();
 
-    OIIO_CHECK_ASSERT(!pClone->isNoOp());
-    OIIO_CHECK_ASSERT(!pClone->isIdentity());
-    OIIO_CHECK_NO_THROW(pClone->validate());
-    OIIO_CHECK_ASSERT(pClone->getArray() == ref.getArray());
-    OIIO_CHECK_EQUAL(pClone->getHueAdjust(), OCIO::Lut1DOpData::HUE_DW3);
+    OCIO_CHECK_ASSERT(!pClone->isNoOp());
+    OCIO_CHECK_ASSERT(!pClone->isIdentity());
+    OCIO_CHECK_NO_THROW(pClone->validate());
+    OCIO_CHECK_ASSERT(pClone->getArray() == ref.getArray());
+    OCIO_CHECK_EQUAL(pClone->getHueAdjust(), OCIO::Lut1DOpData::HUE_DW3);
 }
 
-OIIO_ADD_TEST(Lut1DOpData, output_depth_scaling)
+OCIO_ADD_TEST(Lut1DOpData, output_depth_scaling)
 {
     OCIO::Lut1DOpData ref(OCIO::BIT_DEPTH_UINT8,
                           OCIO::BIT_DEPTH_UINT10,
@@ -1477,26 +1477,26 @@ OIIO_ADD_TEST(Lut1DOpData, output_depth_scaling)
     ref.setOutputBitDepth(newBitdepth);
     // Now we need to make sure that the bitdepth was changed from the overriden
     // method.
-    OIIO_CHECK_EQUAL(ref.getOutputBitDepth(), newBitdepth);
+    OCIO_CHECK_EQUAL(ref.getOutputBitDepth(), newBitdepth);
 
     // Now we need to check the scaling between the new array and initial array
     // matches the factor computed above.
     const OCIO::Array::Values& newArrValues = ref.getArray().getValues();
 
     // Sanity check first.
-    OIIO_CHECK_EQUAL(initialArrValues.size(), newArrValues.size());
+    OCIO_CHECK_EQUAL(initialArrValues.size(), newArrValues.size());
 
     float expectedValue = 0.0f;
     const float error = 1e-6f;
     for (unsigned long i = 0; i < newArrValues.size(); i++)
     {
         expectedValue = initialArrValues[i] * factor;
-        OIIO_CHECK_CLOSE(expectedValue, newArrValues[i], error);
+        OCIO_CHECK_CLOSE(expectedValue, newArrValues[i], error);
     }
 
 }
 
-OIIO_ADD_TEST(Lut1DOpData, equality_test)
+OCIO_ADD_TEST(Lut1DOpData, equality_test)
 {
     OCIO::Lut1DOpData l1(OCIO::BIT_DEPTH_UINT10, OCIO::BIT_DEPTH_UINT10,
                          "", OCIO::OpData::Descriptions(),
@@ -1508,41 +1508,41 @@ OIIO_ADD_TEST(Lut1DOpData, equality_test)
                          OCIO::INTERP_NEAREST,
                          OCIO::Lut1DOpData::LUT_STANDARD);
 
-    OIIO_CHECK_ASSERT(!(l1 == l2));
+    OCIO_CHECK_ASSERT(!(l1 == l2));
 
     OCIO::Lut1DOpData l3(OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_UINT10,
                          "", OCIO::OpData::Descriptions(),
                          OCIO::INTERP_LINEAR,
                          OCIO::Lut1DOpData::LUT_STANDARD);
 
-    OIIO_CHECK_ASSERT(!(l1 == l3) && !(l3 == l2));
+    OCIO_CHECK_ASSERT(!(l1 == l3) && !(l3 == l2));
 
     OCIO::Lut1DOpData l4(OCIO::BIT_DEPTH_UINT10, OCIO::BIT_DEPTH_UINT10,
                          "", OCIO::OpData::Descriptions(),
                          OCIO::INTERP_LINEAR,
                          OCIO::Lut1DOpData::LUT_STANDARD);
 
-    OIIO_CHECK_ASSERT(l1 == l4);
+    OCIO_CHECK_ASSERT(l1 == l4);
 
     l1.setHueAdjust(OCIO::Lut1DOpData::HUE_DW3);
 
-    OIIO_CHECK_ASSERT(!(l1 == l4));
+    OCIO_CHECK_ASSERT(!(l1 == l4));
 
     // Inversion quality does not affect forward ops equality.
     l4.setHueAdjust(OCIO::Lut1DOpData::HUE_DW3);
     l1.setInversionQuality(OCIO::LUT_INVERSION_BEST);
 
-    OIIO_CHECK_ASSERT(l1 == l4);
+    OCIO_CHECK_ASSERT(l1 == l4);
 
     // Inversion quality does not affect inverse ops equality.
     // Even so applying the ops could lead to small differences.
     auto l5 = l1.inverse();
     auto l6 = l4.inverse();
 
-    OIIO_CHECK_ASSERT(*l5 == *l6);
+    OCIO_CHECK_ASSERT(*l5 == *l6);
 }
 
-OIIO_ADD_TEST(Lut1DOpData, channel)
+OCIO_ADD_TEST(Lut1DOpData, channel)
 {
     OCIO::Lut1DOpDataRcPtr L1 = std::make_shared<OCIO::Lut1DOpData>(
         OCIO::BIT_DEPTH_UINT10, OCIO::BIT_DEPTH_UINT10,
@@ -1559,103 +1559,103 @@ OIIO_ADD_TEST(Lut1DOpData, channel)
         20);
 
     // False: identity.
-    OIIO_CHECK_ASSERT(!L1->hasChannelCrosstalk());
-    OIIO_CHECK_ASSERT(L1->mayCompose(L2));
+    OCIO_CHECK_ASSERT(!L1->hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(L1->mayCompose(L2));
 
     L1->setHueAdjust(OCIO::Lut1DOpData::HUE_DW3);
     
     // True: hue restore is on, it's an identity LUT, but this is not
     // tested for efficency.
-    OIIO_CHECK_ASSERT(L1->hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(L1->hasChannelCrosstalk());
     
-    OIIO_CHECK_ASSERT(!L1->mayCompose(L2));
+    OCIO_CHECK_ASSERT(!L1->mayCompose(L2));
 
     OCIO::ConstLut1DOpDataRcPtr L1C = L1;
-    OIIO_CHECK_ASSERT(!L2->mayCompose(L1C));
+    OCIO_CHECK_ASSERT(!L2->mayCompose(L1C));
 
     L1->setHueAdjust(OCIO::Lut1DOpData::HUE_NONE);
     L1->getArray()[1] = 3.0f;
     // False: non-identity.
-    OIIO_CHECK_ASSERT(!L1->hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(!L1->hasChannelCrosstalk());
 
     L1->setHueAdjust(OCIO::Lut1DOpData::HUE_DW3);
     // True: non-identity w/hue restore.
-    OIIO_CHECK_ASSERT(L1->hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(L1->hasChannelCrosstalk());
 }
 
-OIIO_ADD_TEST(Lut1DOpData, interpolation)
+OCIO_ADD_TEST(Lut1DOpData, interpolation)
 {
     OCIO::Lut1DOpData l(17);
     l.setInputBitDepth(OCIO::BIT_DEPTH_F32);
     l.setOutputBitDepth(OCIO::BIT_DEPTH_F32);
 
     l.setInterpolation(OCIO::INTERP_LINEAR);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_NO_THROW(l.validate());
 
     l.setInterpolation(OCIO::INTERP_BEST);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_BEST);
-    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_BEST);
+    OCIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_NO_THROW(l.validate());
 
     l.setInterpolation(OCIO::INTERP_CUBIC);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_CUBIC);
-    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_THROW_WHAT(l.validate(), OCIO::Exception, "does not support interpolation algorithm");
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_CUBIC);
+    OCIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_THROW_WHAT(l.validate(), OCIO::Exception, "does not support interpolation algorithm");
 
     l.setInterpolation(OCIO::INTERP_DEFAULT);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_DEFAULT);
-    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_DEFAULT);
+    OCIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_NO_THROW(l.validate());
 
     // TODO: INTERP_NEAREST is currently implemented as INTERP_LINEAR.
     l.setInterpolation(OCIO::INTERP_NEAREST);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_NEAREST);
-    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_NEAREST);
+    OCIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_NO_THROW(l.validate());
 
     // Invalid interpolation type do not get translated
     // by getConcreteInterpolation.
     l.setInterpolation(OCIO::INTERP_UNKNOWN);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_UNKNOWN);
-    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_THROW_WHAT(l.validate(), OCIO::Exception, "does not support interpolation algorithm");
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_UNKNOWN);
+    OCIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_THROW_WHAT(l.validate(), OCIO::Exception, "does not support interpolation algorithm");
 
     l.setInterpolation(OCIO::INTERP_TETRAHEDRAL);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_TETRAHEDRAL);
-    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_THROW_WHAT(l.validate(), OCIO::Exception, " does not support interpolation algorithm");
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_TETRAHEDRAL);
+    OCIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_THROW_WHAT(l.validate(), OCIO::Exception, " does not support interpolation algorithm");
 }
 
-OIIO_ADD_TEST(Lut1DOpData, inversion_quality)
+OCIO_ADD_TEST(Lut1DOpData, inversion_quality)
 {
     OCIO::Lut1DOpData l(17);
     l.setInputBitDepth(OCIO::BIT_DEPTH_F32);
     l.setOutputBitDepth(OCIO::BIT_DEPTH_F32);
 
     l.setInversionQuality(OCIO::LUT_INVERSION_EXACT);
-    OIIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_EXACT);
-    OIIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_EXACT);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_EXACT);
+    OCIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_EXACT);
+    OCIO_CHECK_NO_THROW(l.validate());
 
     l.setInversionQuality(OCIO::LUT_INVERSION_FAST);
-    OIIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_FAST);
-    OIIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_FAST);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_FAST);
+    OCIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_FAST);
+    OCIO_CHECK_NO_THROW(l.validate());
 
     l.setInversionQuality(OCIO::LUT_INVERSION_DEFAULT);
-    OIIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_DEFAULT);
-    OIIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_FAST);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_DEFAULT);
+    OCIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_FAST);
+    OCIO_CHECK_NO_THROW(l.validate());
 
     l.setInversionQuality(OCIO::LUT_INVERSION_BEST);
-    OIIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_BEST);
-    OIIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_EXACT);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_BEST);
+    OCIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_EXACT);
+    OCIO_CHECK_NO_THROW(l.validate());
 }
 
-OIIO_ADD_TEST(Lut1DOpData, lut_1d_compose)
+OCIO_ADD_TEST(Lut1DOpData, lut_1d_compose)
 {
     OCIO::Lut1DOpDataRcPtr lut1 =
         std::make_shared<OCIO::Lut1DOpData>(OCIO::BIT_DEPTH_F32,
@@ -1702,35 +1702,35 @@ OIIO_ADD_TEST(Lut1DOpData, lut_1d_compose)
 
         values = &lut1->getArray().getValues()[0];
 
-        OIIO_CHECK_EQUAL(lut1->getArray().getLength(), 8);
+        OCIO_CHECK_EQUAL(lut1->getArray().getLength(), 8);
 
-        OIIO_CHECK_CLOSE(values[0], 0.0f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[1], 0.0f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[2], 0.00254739914f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[0], 0.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[1], 0.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[2], 0.00254739914f, 1e-6f);
 
-        OIIO_CHECK_CLOSE(values[3], 0.0f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[4], 0.00669934973f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[5], 0.00378420483f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[3], 0.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[4], 0.00669934973f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[5], 0.00378420483f, 1e-6f);
 
-        OIIO_CHECK_CLOSE(values[6], 0.0f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[7], 0.0121908365f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[8], 0.0619750582f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[6], 0.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[7], 0.0121908365f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[8], 0.0619750582f, 1e-6f);
 
-        OIIO_CHECK_CLOSE(values[9], 0.00682150759f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[10], 0.0272925831f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[11], 0.096942015f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[9], 0.00682150759f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[10], 0.0272925831f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[11], 0.096942015f, 1e-6f);
 
-        OIIO_CHECK_CLOSE(values[12], 0.0206955168f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[13], 0.0308703855f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[14], 0.12295182f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[12], 0.0206955168f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[13], 0.0308703855f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[14], 0.12295182f, 1e-6f);
 
-        OIIO_CHECK_CLOSE(values[15], 0.716288447f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[16], 0.0731772855f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[17], 1.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[15], 0.716288447f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[16], 0.0731772855f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[17], 1.0f, 1e-6f);
 
-        OIIO_CHECK_CLOSE(values[18], 0.725044191f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[19], 0.857842028f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[20], 1.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[18], 0.725044191f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[19], 0.857842028f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[20], 1.0f, 1e-6f);
     }
 
     {
@@ -1740,47 +1740,47 @@ OIIO_ADD_TEST(Lut1DOpData, lut_1d_compose)
 
         values = &lut1Cloned->getArray().getValues()[0];
 
-        OIIO_CHECK_EQUAL(lut1Cloned->getArray().getLength(), 65536);
+        OCIO_CHECK_EQUAL(lut1Cloned->getArray().getLength(), 65536);
 
-        OIIO_CHECK_CLOSE(values[0], 0.0f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[1], 0.0f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[2], 0.00254739914f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[0], 0.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[1], 0.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[2], 0.00254739914f, 1e-6f);
 
-        OIIO_CHECK_CLOSE(values[3], 0.0f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[4], 6.34463504e-07f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[5], 0.00254753046f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[3], 0.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[4], 6.34463504e-07f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[5], 0.00254753046f, 1e-6f);
 
-        OIIO_CHECK_CLOSE(values[6], 0.0f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[7], 1.26915984e-06f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[8], 0.00254766271f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[6], 0.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[7], 1.26915984e-06f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[8], 0.00254766271f, 1e-6f);
 
-        OIIO_CHECK_CLOSE(values[9], 0.0f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[10], 1.90362334e-06f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[11], 0.00254779495f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[9], 0.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[10], 1.90362334e-06f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[11], 0.00254779495f, 1e-6f);
 
-        OIIO_CHECK_CLOSE(values[12], 0.0f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[13], 2.53855251e-06f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[14], 0.0025479272f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[12], 0.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[13], 2.53855251e-06f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[14], 0.0025479272f, 1e-6f);
 
-        OIIO_CHECK_CLOSE(values[15], 0.0f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[16], 3.17324884e-06f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[17], 0.00254805945f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[15], 0.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[16], 3.17324884e-06f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[17], 0.00254805945f, 1e-6f);
 
-        OIIO_CHECK_CLOSE(values[300], 0.0f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[301], 6.3463347e-05f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[302], 0.00256060902f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[300], 0.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[301], 6.3463347e-05f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[302], 0.00256060902f, 1e-6f);
 
-        OIIO_CHECK_CLOSE(values[900], 0.0f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[901], 0.000190390972f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[902], 0.00258703064f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[900], 0.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[901], 0.000190390972f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[902], 0.00258703064f, 1e-6f);
 
-        OIIO_CHECK_CLOSE(values[2700], 0.0f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[2701], 0.000571172219f, 1e-6f);
-        OIIO_CHECK_CLOSE(values[2702], 0.00266629551f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[2700], 0.0f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[2701], 0.000571172219f, 1e-6f);
+        OCIO_CHECK_CLOSE(values[2702], 0.00266629551f, 1e-6f);
     }
 }
 
-OIIO_ADD_TEST(Lut1DOpData, lut_1d_compose_sc)
+OCIO_ADD_TEST(Lut1DOpData, lut_1d_compose_sc)
 {
     OCIO::Lut1DOpDataRcPtr lut1 =
         std::make_shared<OCIO::Lut1DOpData>(OCIO::BIT_DEPTH_UINT8,
@@ -1837,39 +1837,39 @@ OIIO_ADD_TEST(Lut1DOpData, lut_1d_compose_sc)
 
     {
         OCIO::Lut1DOpDataRcPtr lComp = lut1->clone();
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_NO_THROW(
             OCIO::Lut1DOpData::Compose(lComp, lut2C, OCIO::Lut1DOpData::COMPOSE_RESAMPLE_NO));
 
-        OIIO_CHECK_EQUAL(lComp->getArray().getLength(), 2);
-        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[0], 0.00744791f, 1e-6f);
-        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[1], 0.03172233f, 1e-6f);
-        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[2], 0.07058375f, 1e-6f);
-        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[3], 0.3513808f, 1e-6f);
-        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[4], 0.51819527f, 1e-6f);
-        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[5], 0.67463773f, 1e-6f);
+        OCIO_CHECK_EQUAL(lComp->getArray().getLength(), 2);
+        OCIO_CHECK_CLOSE(lComp->getArray().getValues()[0], 0.00744791f, 1e-6f);
+        OCIO_CHECK_CLOSE(lComp->getArray().getValues()[1], 0.03172233f, 1e-6f);
+        OCIO_CHECK_CLOSE(lComp->getArray().getValues()[2], 0.07058375f, 1e-6f);
+        OCIO_CHECK_CLOSE(lComp->getArray().getValues()[3], 0.3513808f, 1e-6f);
+        OCIO_CHECK_CLOSE(lComp->getArray().getValues()[4], 0.51819527f, 1e-6f);
+        OCIO_CHECK_CLOSE(lComp->getArray().getValues()[5], 0.67463773f, 1e-6f);
     }
 
     {
         OCIO::Lut1DOpDataRcPtr lComp = lut1->clone();
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_NO_THROW(
             OCIO::Lut1DOpData::Compose(lComp, lut2C, OCIO::Lut1DOpData::COMPOSE_RESAMPLE_INDEPTH));
 
-        OIIO_CHECK_EQUAL(lComp->getArray().getLength(), 256);
-        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[0], 0.00744791f, 1e-6f);
-        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[1], 0.03172233f, 1e-6f);
-        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[2], 0.07058375f, 1e-6f);
-        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[383], 0.28073114f, 1e-6f);
-        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[384], 0.09914176f, 1e-6f);
-        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[385], 0.1866852f, 1e-6f);
-        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[765], 0.3513808f, 1e-6f);
-        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[766], 0.51819527f, 1e-6f);
-        OIIO_CHECK_CLOSE(lComp->getArray().getValues()[767], 0.67463773f, 1e-6f);
+        OCIO_CHECK_EQUAL(lComp->getArray().getLength(), 256);
+        OCIO_CHECK_CLOSE(lComp->getArray().getValues()[0], 0.00744791f, 1e-6f);
+        OCIO_CHECK_CLOSE(lComp->getArray().getValues()[1], 0.03172233f, 1e-6f);
+        OCIO_CHECK_CLOSE(lComp->getArray().getValues()[2], 0.07058375f, 1e-6f);
+        OCIO_CHECK_CLOSE(lComp->getArray().getValues()[383], 0.28073114f, 1e-6f);
+        OCIO_CHECK_CLOSE(lComp->getArray().getValues()[384], 0.09914176f, 1e-6f);
+        OCIO_CHECK_CLOSE(lComp->getArray().getValues()[385], 0.1866852f, 1e-6f);
+        OCIO_CHECK_CLOSE(lComp->getArray().getValues()[765], 0.3513808f, 1e-6f);
+        OCIO_CHECK_CLOSE(lComp->getArray().getValues()[766], 0.51819527f, 1e-6f);
+        OCIO_CHECK_CLOSE(lComp->getArray().getValues()[767], 0.67463773f, 1e-6f);
     }
 
     {
         OCIO::ConstLut1DOpDataRcPtr lut1C = lut1;
         OCIO::Lut1DOpDataRcPtr lComp = lut2->clone();
-        OIIO_CHECK_THROW_WHAT(
+        OCIO_CHECK_THROW_WHAT(
             OCIO::Lut1DOpData::Compose(lComp, lut1C, OCIO::Lut1DOpData::COMPOSE_RESAMPLE_NO),
             OCIO::Exception, "bit-depth mismatch forbids the composition");
 
@@ -1901,27 +1901,27 @@ void checkInverse_bitDepths_domain(
 
     // Get inverse of reference 1D LUT operation.
     OCIO::Lut1DOpDataRcPtr invLut1d;
-    OIIO_CHECK_NO_THROW(invLut1d = refLut1d.inverse());
-    OIIO_REQUIRE_ASSERT(invLut1d);
+    OCIO_CHECK_NO_THROW(invLut1d = refLut1d.inverse());
+    OCIO_REQUIRE_ASSERT(invLut1d);
 
-    OIIO_CHECK_EQUAL(invLut1d->getInputBitDepth(),
+    OCIO_CHECK_EQUAL(invLut1d->getInputBitDepth(),
                      expectedInvInputBitDepth);
 
-    OIIO_CHECK_EQUAL(invLut1d->getOutputBitDepth(),
+    OCIO_CHECK_EQUAL(invLut1d->getOutputBitDepth(),
                      expectedInvOutputBitDepth);
 
-    OIIO_CHECK_EQUAL(invLut1d->getInterpolation(),
+    OCIO_CHECK_EQUAL(invLut1d->getInterpolation(),
                      expectedInvInterpolationAlgo);
 
-    OIIO_CHECK_EQUAL(invLut1d->getHalfFlags(),
+    OCIO_CHECK_EQUAL(invLut1d->getHalfFlags(),
                      expectedInvHalfFlags);
 
-    OIIO_CHECK_EQUAL(invLut1d->getHueAdjust(),
+    OCIO_CHECK_EQUAL(invLut1d->getHueAdjust(),
                      OCIO::Lut1DOpData::HUE_NONE);
 }
 
 
-OIIO_ADD_TEST(Lut1DOpData, inverse_bitDepth_domain)
+OCIO_ADD_TEST(Lut1DOpData, inverse_bitDepth_domain)
 {
     checkInverse_bitDepths_domain(
         // Reference
@@ -1964,7 +1964,7 @@ OIIO_ADD_TEST(Lut1DOpData, inverse_bitDepth_domain)
         OCIO::Lut1DOpData::LUT_INPUT_HALF_CODE);
 }
 
-OIIO_ADD_TEST(Lut1DOpData, inverse_hueadjust)
+OCIO_ADD_TEST(Lut1DOpData, inverse_hueadjust)
 {
     OCIO::Lut1DOpData refLut1d(OCIO::BIT_DEPTH_F32,
                                OCIO::BIT_DEPTH_F32,
@@ -1976,14 +1976,14 @@ OIIO_ADD_TEST(Lut1DOpData, inverse_hueadjust)
 
     // Get inverse of reference lut1d operation.
     OCIO::Lut1DOpDataRcPtr invLut1d;
-    OIIO_CHECK_NO_THROW(invLut1d = refLut1d.inverse());
-    OIIO_REQUIRE_ASSERT(invLut1d);
+    OCIO_CHECK_NO_THROW(invLut1d = refLut1d.inverse());
+    OCIO_REQUIRE_ASSERT(invLut1d);
 
-    OIIO_CHECK_EQUAL(invLut1d->getHueAdjust(),
+    OCIO_CHECK_EQUAL(invLut1d->getHueAdjust(),
                      OCIO::Lut1DOpData::HUE_DW3);
 }
 
-OIIO_ADD_TEST(Lut1DOpData, is_inverse)
+OCIO_ADD_TEST(Lut1DOpData, is_inverse)
 {
     // Create forward LUT.
     OCIO::Lut1DOpDataRcPtr L1 = std::make_shared<OCIO::Lut1DOpData>(
@@ -1998,33 +1998,33 @@ OIIO_ADD_TEST(Lut1DOpData, is_inverse)
     OCIO::Array & array = L1->getArray();
     OCIO::Array::Values & values = array.getValues();
     values[0] = 20.f;
-    OIIO_CHECK_ASSERT(!L1->isIdentity());
+    OCIO_CHECK_ASSERT(!L1->isIdentity());
 
     // Create an inverse LUT with same basics.
     OCIO::Lut1DOpDataRcPtr L2 = L1->inverse();
-    OIIO_REQUIRE_ASSERT(L2);
+    OCIO_REQUIRE_ASSERT(L2);
 
-    OIIO_CHECK_ASSERT(!(*L1 == *L2));
+    OCIO_CHECK_ASSERT(!(*L1 == *L2));
 
     OCIO::ConstLut1DOpDataRcPtr L1C = L1;
     OCIO::ConstLut1DOpDataRcPtr L2C = L2;
 
     // Check isInverse.
-    OIIO_CHECK_ASSERT(L1->isInverse(L2C));
-    OIIO_CHECK_ASSERT(L2->isInverse(L1C));
+    OCIO_CHECK_ASSERT(L1->isInverse(L2C));
+    OCIO_CHECK_ASSERT(L2->isInverse(L1C));
 
     // Arrays are the same if you normalize for the scaling difference.
     L1->setOutputBitDepth(OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_ASSERT(L1->isInverse(L2C));
-    OIIO_CHECK_ASSERT(L2->isInverse(L1C));
+    OCIO_CHECK_ASSERT(L1->isInverse(L2C));
+    OCIO_CHECK_ASSERT(L2->isInverse(L1C));
 
     // Catch the situation where the arrays are the same even though the
     // bit-depths don't match and hence the arrays effectively aren't the same.
     L1->setOutputBitDepth(OCIO::BIT_DEPTH_UINT10);  // restore original
-    OIIO_CHECK_ASSERT(L1->isInverse(L2C));
+    OCIO_CHECK_ASSERT(L1->isInverse(L2C));
     L1->OpData::setOutputBitDepth(OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_ASSERT(!L1->isInverse(L2C));
-    OIIO_CHECK_ASSERT(!L2->isInverse(L1C));
+    OCIO_CHECK_ASSERT(!L1->isInverse(L2C));
+    OCIO_CHECK_ASSERT(!L2->isInverse(L1C));
 }
 
 void SetLutArray(OCIO::Lut1DOpData & op,
@@ -2070,8 +2070,8 @@ void CheckInverse_IncreasingEffectiveDomain(
     SetLutArray(refLut1dOp, dimension, channels, fwdArrayData);
 
     OCIO::Lut1DOpDataRcPtr invLut1dOp = refLut1dOp.inverse();
-    OIIO_REQUIRE_ASSERT(invLut1dOp);
-    OIIO_CHECK_NO_THROW(invLut1dOp->finalize());
+    OCIO_REQUIRE_ASSERT(invLut1dOp);
+    OCIO_CHECK_NO_THROW(invLut1dOp->finalize());
 
     const OCIO::Lut1DOpData::ComponentProperties &
         redProperties = invLut1dOp->getRedProperties();
@@ -2082,20 +2082,20 @@ void CheckInverse_IncreasingEffectiveDomain(
     const OCIO::Lut1DOpData::ComponentProperties &
         blueProperties = invLut1dOp->getBlueProperties();
 
-    OIIO_CHECK_EQUAL(redProperties.isIncreasing, expIncreasingR);
-    OIIO_CHECK_EQUAL(redProperties.startDomain, expStartDomainR);
-    OIIO_CHECK_EQUAL(redProperties.endDomain, expEndDomainR);
+    OCIO_CHECK_EQUAL(redProperties.isIncreasing, expIncreasingR);
+    OCIO_CHECK_EQUAL(redProperties.startDomain, expStartDomainR);
+    OCIO_CHECK_EQUAL(redProperties.endDomain, expEndDomainR);
 
-    OIIO_CHECK_EQUAL(greenProperties.isIncreasing, expIncreasingG);
-    OIIO_CHECK_EQUAL(greenProperties.startDomain, expStartDomainG);
-    OIIO_CHECK_EQUAL(greenProperties.endDomain, expEndDomainG);
+    OCIO_CHECK_EQUAL(greenProperties.isIncreasing, expIncreasingG);
+    OCIO_CHECK_EQUAL(greenProperties.startDomain, expStartDomainG);
+    OCIO_CHECK_EQUAL(greenProperties.endDomain, expEndDomainG);
 
-    OIIO_CHECK_EQUAL(blueProperties.isIncreasing, expIncreasingB);
-    OIIO_CHECK_EQUAL(blueProperties.startDomain, expStartDomainB);
-    OIIO_CHECK_EQUAL(blueProperties.endDomain, expEndDomainB);
+    OCIO_CHECK_EQUAL(blueProperties.isIncreasing, expIncreasingB);
+    OCIO_CHECK_EQUAL(blueProperties.startDomain, expStartDomainB);
+    OCIO_CHECK_EQUAL(blueProperties.endDomain, expEndDomainB);
 }
 
-OIIO_ADD_TEST(Lut1DOpData, inverse_increasing_effective_domain)
+OCIO_ADD_TEST(Lut1DOpData, inverse_increasing_effective_domain)
 {
     {
         const float fwdData[] = { 0.1f, 0.8f, 0.1f,    // 0
@@ -2188,7 +2188,7 @@ void CheckInverse_Flatten(unsigned long dimension,
     SetLutArray(refLut1dOp, dimension, channels, fwdArrayData);
 
     OCIO::Lut1DOpDataRcPtr invLut1dOp = refLut1dOp.inverse();
-    OIIO_REQUIRE_ASSERT(invLut1dOp);
+    OCIO_REQUIRE_ASSERT(invLut1dOp);
     invLut1dOp->finalize();
 
     const OCIO::Array::Values &
@@ -2196,11 +2196,11 @@ void CheckInverse_Flatten(unsigned long dimension,
 
     for (unsigned long i = 0; i < dimension * channels; ++i)
     {
-        OIIO_CHECK_EQUAL(invValues[i], expInvArrayData[i]);
+        OCIO_CHECK_EQUAL(invValues[i], expInvArrayData[i]);
     }
 }
 
-OIIO_ADD_TEST(Lut1DOpData, inverse_flatten_test)
+OCIO_ADD_TEST(Lut1DOpData, inverse_flatten_test)
 {
     {
         const float fwdData[] = { 0.10f, 0.90f, 0.25f,    // 0
@@ -2291,7 +2291,7 @@ void SetLutArrayHalf(const OCIO::Lut1DOpDataRcPtr & op, unsigned long channels)
     }
 }
 
-OIIO_ADD_TEST(Lut1DOpData, inverse_half_domain)
+OCIO_ADD_TEST(Lut1DOpData, inverse_half_domain)
 {
     OCIO::Lut1DOpDataRcPtr refLut1dOp = std::make_shared<OCIO::Lut1DOpData>(
         OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32,
@@ -2302,7 +2302,7 @@ OIIO_ADD_TEST(Lut1DOpData, inverse_half_domain)
     SetLutArrayHalf(refLut1dOp, 3u);
 
     OCIO::Lut1DOpDataRcPtr invLut1dOp = refLut1dOp->inverse();
-    OIIO_REQUIRE_ASSERT(invLut1dOp);
+    OCIO_REQUIRE_ASSERT(invLut1dOp);
     invLut1dOp->finalize();
 
     const OCIO::Lut1DOpData::ComponentProperties &
@@ -2318,34 +2318,34 @@ OIIO_ADD_TEST(Lut1DOpData, inverse_half_domain)
         invValues = invLut1dOp->getArray().getValues();
 
     // Check increasing/decreasing and start/end domain.
-    OIIO_CHECK_EQUAL(redProperties.isIncreasing, true);
-    OIIO_CHECK_EQUAL(redProperties.startDomain, 0u);
-    OIIO_CHECK_EQUAL(redProperties.endDomain, 25000u);
-    OIIO_CHECK_EQUAL(redProperties.negStartDomain, 44100u);  // -0.2/3 (flattened to remove overlap)
-    OIIO_CHECK_EQUAL(redProperties.negEndDomain, 60000u);
+    OCIO_CHECK_EQUAL(redProperties.isIncreasing, true);
+    OCIO_CHECK_EQUAL(redProperties.startDomain, 0u);
+    OCIO_CHECK_EQUAL(redProperties.endDomain, 25000u);
+    OCIO_CHECK_EQUAL(redProperties.negStartDomain, 44100u);  // -0.2/3 (flattened to remove overlap)
+    OCIO_CHECK_EQUAL(redProperties.negEndDomain, 60000u);
 
-    OIIO_CHECK_EQUAL(greenProperties.isIncreasing, false);
-    OIIO_CHECK_EQUAL(greenProperties.startDomain, 0u);
-    OIIO_CHECK_EQUAL(greenProperties.endDomain, 25000u);
-    OIIO_CHECK_EQUAL(greenProperties.negStartDomain, 32768u);
-    OIIO_CHECK_EQUAL(greenProperties.negEndDomain, 60000u);
+    OCIO_CHECK_EQUAL(greenProperties.isIncreasing, false);
+    OCIO_CHECK_EQUAL(greenProperties.startDomain, 0u);
+    OCIO_CHECK_EQUAL(greenProperties.endDomain, 25000u);
+    OCIO_CHECK_EQUAL(greenProperties.negStartDomain, 32768u);
+    OCIO_CHECK_EQUAL(greenProperties.negEndDomain, 60000u);
 
-    OIIO_CHECK_EQUAL(blueProperties.isIncreasing, true);
-    OIIO_CHECK_EQUAL(blueProperties.startDomain, 11878u);
-    OIIO_CHECK_EQUAL(blueProperties.endDomain, 31743u);      // see note in invLut1DOp.cpp
-    OIIO_CHECK_EQUAL(blueProperties.negStartDomain, 44646u);
-    OIIO_CHECK_EQUAL(blueProperties.negEndDomain, 64511u);
+    OCIO_CHECK_EQUAL(blueProperties.isIncreasing, true);
+    OCIO_CHECK_EQUAL(blueProperties.startDomain, 11878u);
+    OCIO_CHECK_EQUAL(blueProperties.endDomain, 31743u);      // see note in invLut1DOp.cpp
+    OCIO_CHECK_EQUAL(blueProperties.negStartDomain, 44646u);
+    OCIO_CHECK_EQUAL(blueProperties.negEndDomain, 64511u);
 
     // Check reversals are removed.
     half act, aim;
     act = invValues[16000 * 3];
-    OIIO_CHECK_EQUAL(act.bits(), 15922);  // halfToFloat(15000) * 2 - 0.1
+    OCIO_CHECK_EQUAL(act.bits(), 15922);  // halfToFloat(15000) * 2 - 0.1
     act = invValues[52000 * 3];
-    OIIO_CHECK_EQUAL(act.bits(), 51567);  // halfToFloat(50000) * 3 + 0.1
+    OCIO_CHECK_EQUAL(act.bits(), 51567);  // halfToFloat(50000) * 3 + 0.1
     act = invValues[16000 * 3 + 1];
-    OIIO_CHECK_EQUAL(act.bits(), 46662);  // halfToFloat(15000) * -0.5 + 0.02
+    OCIO_CHECK_EQUAL(act.bits(), 46662);  // halfToFloat(15000) * -0.5 + 0.02
     act = invValues[52000 * 3 + 1];
-    OIIO_CHECK_EQUAL(act.bits(), 15885);  // halfToFloat(50000) * -0.4 + 0.05
+    OCIO_CHECK_EQUAL(act.bits(), 15885);  // halfToFloat(50000) * -0.4 + 0.05
 
     bool reversal = false;
     for (unsigned long i = 1; i < 31745; i++)
@@ -2353,25 +2353,25 @@ OIIO_ADD_TEST(Lut1DOpData, inverse_half_domain)
         if (invValues[i * 3] < invValues[(i - 1) * 3])           // increasing red
             reversal = true;
     }
-    OIIO_CHECK_ASSERT(!reversal);
+    OCIO_CHECK_ASSERT(!reversal);
     // Check no overlap at +0 and -0.
-    OIIO_CHECK_ASSERT(invValues[0] >= invValues[32768 * 3]);
+    OCIO_CHECK_ASSERT(invValues[0] >= invValues[32768 * 3]);
     reversal = false;
     for (unsigned long i = 1; i < 31745; i++)
     {
         if (invValues[i * 3 + 1] > invValues[(i - 1) * 3 + 1])   // decreasing grn
             reversal = true;
     }
-    OIIO_CHECK_ASSERT(!reversal);
-    OIIO_CHECK_ASSERT(invValues[0 + 1] <= invValues[32768 * 3 + 1]);
+    OCIO_CHECK_ASSERT(!reversal);
+    OCIO_CHECK_ASSERT(invValues[0 + 1] <= invValues[32768 * 3 + 1]);
     reversal = false;
     for (unsigned long i = 1; i < 31745; i++)
     {
         if (invValues[i * 3 + 2] < invValues[(i - 1) * 3 + 2])   // increasing blu
             reversal = true;
     }
-    OIIO_CHECK_ASSERT(!reversal);
-    OIIO_CHECK_ASSERT(invValues[0 + 2] >= invValues[32768 * 3 + 2]);
+    OCIO_CHECK_ASSERT(!reversal);
+    OCIO_CHECK_ASSERT(invValues[0 + 2] >= invValues[32768 * 3 + 2]);
 }
 
 

--- a/src/OpenColorIO/ops/Lut1D/Lut1DOpGPU.cpp
+++ b/src/OpenColorIO/ops/Lut1D/Lut1DOpGPU.cpp
@@ -316,9 +316,9 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(Lut1DOp, pad_lut_one_dimension)
+OCIO_ADD_TEST(Lut1DOp, pad_lut_one_dimension)
 {
     const unsigned width = 6;
 
@@ -339,21 +339,21 @@ OIIO_ADD_TEST(Lut1DOp, pad_lut_one_dimension)
     // Pad the texture values.
 
     std::vector<float> chn;
-    OIIO_CHECK_NO_THROW(OCIO::PadLutChannels(width, 1, channel, chn));
+    OCIO_CHECK_NO_THROW(OCIO::PadLutChannels(width, 1, channel, chn));
 
     // Check the values.
 
     const float res[18] = { 0.0f, 0.1f, 0.2f, 1.0f, 1.1f, 1.2f,
                             2.0f, 2.1f, 2.2f, 3.0f, 3.1f, 3.2f,
                             3.0f, 3.1f, 3.2f, 3.0f, 3.1f, 3.2f };
-    OIIO_CHECK_EQUAL(chn.size(), 18);
+    OCIO_CHECK_EQUAL(chn.size(), 18);
     for (unsigned idx = 0; idx<chn.size(); ++idx)
     {
-        OIIO_CHECK_EQUAL(chn[idx], res[idx]);
+        OCIO_CHECK_EQUAL(chn[idx], res[idx]);
     }
 }
 
-OIIO_ADD_TEST(Lut1DOp, pad_lut_two_dimension_1)
+OCIO_ADD_TEST(Lut1DOp, pad_lut_two_dimension_1)
 {
     const unsigned width = 4;
     const unsigned height = 3;
@@ -369,20 +369,20 @@ OIIO_ADD_TEST(Lut1DOp, pad_lut_two_dimension_1)
     }
 
     std::vector<float> chn;
-    OIIO_CHECK_NO_THROW(OCIO::PadLutChannels(width, height, channel, chn));
+    OCIO_CHECK_NO_THROW(OCIO::PadLutChannels(width, height, channel, chn));
 
     const float res[] = {
         0.0f, 0.1f, 0.2f, 1.0f, 1.1f, 1.2f, 2.0f, 2.1f, 2.2f, 3.0f, 3.1f, 3.2f,
         3.0f, 3.1f, 3.2f, 4.0f, 4.1f, 4.2f, 5.0f, 5.1f, 5.2f, 6.0f, 6.1f, 6.2f, 
         6.0f, 6.1f, 6.2f, 7.0f, 7.1f, 7.2f, 7.0f, 7.1f, 7.2f, 7.0f, 7.1f, 7.2f };
-    OIIO_CHECK_EQUAL(chn.size(), 36);
+    OCIO_CHECK_EQUAL(chn.size(), 36);
     for (unsigned idx = 0; idx<chn.size(); ++idx)
     {
-        OIIO_CHECK_EQUAL(chn[idx], res[idx]);
+        OCIO_CHECK_EQUAL(chn[idx], res[idx]);
     }
 }
 
-OIIO_ADD_TEST(Lut1DOp, pad_lut_two_dimension_2)
+OCIO_ADD_TEST(Lut1DOp, pad_lut_two_dimension_2)
 {
     const unsigned width = 4;
     const unsigned height = 3;
@@ -399,7 +399,7 @@ OIIO_ADD_TEST(Lut1DOp, pad_lut_two_dimension_2)
 
     // Special case where size%(width-1) = 0
     std::vector<float> chn;
-    OIIO_CHECK_NO_THROW(OCIO::PadLutChannels(width, height, channel, chn));
+    OCIO_CHECK_NO_THROW(OCIO::PadLutChannels(width, height, channel, chn));
 
     // Check the values
 
@@ -408,11 +408,11 @@ OIIO_ADD_TEST(Lut1DOp, pad_lut_two_dimension_2)
         3.0f, 3.1f, 3.2f, 4.0f, 4.1f, 4.2f, 5.0f, 5.1f, 5.2f, 6.0f, 6.1f, 6.2f,
         6.0f, 6.1f, 6.2f, 7.0f, 7.1f, 7.2f, 8.0f, 8.1f, 8.2f, 8.0f, 8.1f, 8.2f };
     
-    OIIO_CHECK_EQUAL(chn.size(), 36);
+    OCIO_CHECK_EQUAL(chn.size(), 36);
 
     for (unsigned idx = 0; idx<chn.size(); ++idx)
     {
-        OIIO_CHECK_EQUAL(chn[idx], res[idx]);
+        OCIO_CHECK_EQUAL(chn[idx], res[idx]);
     }
 }
 

--- a/src/OpenColorIO/ops/Lut3D/Lut3DOp.cpp
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOp.cpp
@@ -877,10 +877,10 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 
 #include "BitDepthUtils.h"
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
-OIIO_ADD_TEST(Lut3DOpStruct, nan_inf_value_check)
+OCIO_ADD_TEST(Lut3DOpStruct, nan_inf_value_check)
 {
     OCIO::Lut3DRcPtr lut = OCIO::Lut3D::Create();
     
@@ -890,7 +890,7 @@ OIIO_ADD_TEST(Lut3DOpStruct, nan_inf_value_check)
     
     lut->lut.resize(lut->size[0]*lut->size[1]*lut->size[2]*3);
     
-    OIIO_CHECK_NO_THROW(GenerateIdentityLut3D(
+    OCIO_CHECK_NO_THROW(GenerateIdentityLut3D(
         &lut->lut[0], lut->size[0], 3, OCIO::LUT3DORDER_FAST_RED));
     for(size_t i=0; i<lut->lut.size(); ++i)
     {
@@ -911,7 +911,7 @@ OIIO_ADD_TEST(Lut3DOpStruct, nan_inf_value_check)
 }
 
 
-OIIO_ADD_TEST(Lut3DOpStruct, value_check)
+OCIO_ADD_TEST(Lut3DOpStruct, value_check)
 {
     const float error = 1e-5f;
 
@@ -919,8 +919,8 @@ OIIO_ADD_TEST(Lut3DOpStruct, value_check)
 
     for (int i = 0; i < 3; ++i)
     {
-        OIIO_CHECK_CLOSE(lut->from_min[i], 0.0f, error);
-        OIIO_CHECK_CLOSE(lut->from_max[i], 1.0f, error);
+        OCIO_CHECK_CLOSE(lut->from_min[i], 0.0f, error);
+        OCIO_CHECK_CLOSE(lut->from_max[i], 1.0f, error);
     }
 
     lut->size[0] = 32;
@@ -928,7 +928,7 @@ OIIO_ADD_TEST(Lut3DOpStruct, value_check)
     lut->size[2] = 32;
 
     lut->lut.resize(lut->size[0] * lut->size[1] * lut->size[2] * 3);
-    OIIO_CHECK_NO_THROW(GenerateIdentityLut3D(
+    OCIO_CHECK_NO_THROW(GenerateIdentityLut3D(
         &lut->lut[0], lut->size[0], 3, OCIO::LUT3DORDER_FAST_RED));
     for (size_t i = 0; i < lut->lut.size(); ++i)
     {
@@ -936,13 +936,13 @@ OIIO_ADD_TEST(Lut3DOpStruct, value_check)
     }
 
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateLut3DOp(ops, lut, OCIO::INTERP_NEAREST,
+    OCIO_CHECK_NO_THROW(CreateLut3DOp(ops, lut, OCIO::INTERP_NEAREST,
                                       OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateLut3DOp(ops, lut, OCIO::INTERP_LINEAR,
+    OCIO_CHECK_NO_THROW(CreateLut3DOp(ops, lut, OCIO::INTERP_LINEAR,
                                       OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateLut3DOp(ops, lut, OCIO::INTERP_TETRAHEDRAL,
+    OCIO_CHECK_NO_THROW(CreateLut3DOp(ops, lut, OCIO::INTERP_TETRAHEDRAL,
                                       OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 3);
+    OCIO_REQUIRE_EQUAL(ops.size(), 3);
     ops[0]->finalize();
     ops[1]->finalize();
     ops[2]->finalize();
@@ -974,9 +974,9 @@ OIIO_ADD_TEST(Lut3DOpStruct, value_check)
     ops[0]->apply(color2, 3);
     for(long i=0; i<12; ++i)
     {
-        OIIO_CHECK_CLOSE(color[i], nearest[i], 1e-8);
+        OCIO_CHECK_CLOSE(color[i], nearest[i], 1e-8);
         // NB: In OCIO v2, INTERP_NEAREST is implemented as trilinear.
-        OIIO_CHECK_CLOSE(color2[i], linear[i], 1e-8);
+        OCIO_CHECK_CLOSE(color2[i], linear[i], 1e-8);
     }
 
     // Check linear.
@@ -986,8 +986,8 @@ OIIO_ADD_TEST(Lut3DOpStruct, value_check)
     ops[1]->apply(color2, 3);
     for(long i=0; i<12; ++i)
     {
-        OIIO_CHECK_CLOSE(color[i], linear[i], 1e-8);
-        OIIO_CHECK_CLOSE(color2[i], linear[i], 1e-8);
+        OCIO_CHECK_CLOSE(color[i], linear[i], 1e-8);
+        OCIO_CHECK_CLOSE(color2[i], linear[i], 1e-8);
     }
 
     // Check tetrahedral
@@ -997,12 +997,12 @@ OIIO_ADD_TEST(Lut3DOpStruct, value_check)
     ops[2]->apply(color2, 3);
     for(long i=0; i<12; ++i)
     {
-        OIIO_CHECK_CLOSE(color[i], tetrahedral[i], 1e-8);
-        OIIO_CHECK_CLOSE(color2[i], tetrahedral[i], 1e-7);
+        OCIO_CHECK_CLOSE(color[i], tetrahedral[i], 1e-8);
+        OCIO_CHECK_CLOSE(color2[i], tetrahedral[i], 1e-7);
     }
 }
 
-OIIO_ADD_TEST(Lut3DOp, lut3d_tetrahedral)
+OCIO_ADD_TEST(Lut3DOp, lut3d_tetrahedral)
 {
     OCIO::Lut3DRcPtr lut = OCIO::Lut3D::Create();
     lut->size[0] = 3;
@@ -1039,11 +1039,11 @@ OIIO_ADD_TEST(Lut3DOp, lut3d_tetrahedral)
                   1.08504403f,    0.879765391f,    1.17302048f };
 
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateLut3DOp(ops, lut, OCIO::INTERP_LINEAR,
+    OCIO_CHECK_NO_THROW(CreateLut3DOp(ops, lut, OCIO::INTERP_LINEAR,
                                       OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateLut3DOp(ops, lut, OCIO::INTERP_TETRAHEDRAL,
+    OCIO_CHECK_NO_THROW(CreateLut3DOp(ops, lut, OCIO::INTERP_TETRAHEDRAL,
                                       OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     ops[0]->finalize();
     ops[1]->finalize();
 
@@ -1067,8 +1067,8 @@ OIIO_ADD_TEST(Lut3DOp, lut3d_tetrahedral)
     ops[0]->apply(color2, 2);
     for (long i = 0; i < 8; ++i)
     {
-        OIIO_CHECK_CLOSE(color[i], linear[i], 1e-7);
-        OIIO_CHECK_CLOSE(color2[i], linear[i], 1e-7);
+        OCIO_CHECK_CLOSE(color[i], linear[i], 1e-7);
+        OCIO_CHECK_CLOSE(color2[i], linear[i], 1e-7);
     }
 
     // Check tetrahedral.
@@ -1078,21 +1078,21 @@ OIIO_ADD_TEST(Lut3DOp, lut3d_tetrahedral)
     ops[1]->apply(color2, 2);
     for (long i = 0; i < 8; ++i)
     {
-        OIIO_CHECK_CLOSE(color[i], tetrahedral[i], 1e-7);
-        OIIO_CHECK_CLOSE(color2[i], tetrahedral[i], 1e-7);
+        OCIO_CHECK_CLOSE(color[i], tetrahedral[i], 1e-7);
+        OCIO_CHECK_CLOSE(color2[i], tetrahedral[i], 1e-7);
     }
 
 }
 
 
-OIIO_ADD_TEST(Lut3DOpStruct, inverse_comparison_check)
+OCIO_ADD_TEST(Lut3DOpStruct, inverse_comparison_check)
 {
     OCIO::Lut3DRcPtr lut_a = OCIO::Lut3D::Create();
     lut_a->size[0] = 32;
     lut_a->size[1] = 32;
     lut_a->size[2] = 32;
     lut_a->lut.resize(lut_a->size[0]*lut_a->size[1]*lut_a->size[2]*3);
-    OIIO_CHECK_NO_THROW(GenerateIdentityLut3D(
+    OCIO_CHECK_NO_THROW(GenerateIdentityLut3D(
         &lut_a->lut[0], lut_a->size[0], 3, OCIO::LUT3DORDER_FAST_RED));
     
     OCIO::Lut3DRcPtr lut_b = OCIO::Lut3D::Create();
@@ -1106,22 +1106,22 @@ OIIO_ADD_TEST(Lut3DOpStruct, inverse_comparison_check)
     lut_b->size[1] = 16;
     lut_b->size[2] = 16;
     lut_b->lut.resize(lut_b->size[0]*lut_b->size[1]*lut_b->size[2]*3);
-    OIIO_CHECK_NO_THROW(GenerateIdentityLut3D(
+    OCIO_CHECK_NO_THROW(GenerateIdentityLut3D(
         &lut_b->lut[0], lut_b->size[0], 3, OCIO::LUT3DORDER_FAST_RED));
     
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateLut3DOp(ops,
+    OCIO_CHECK_NO_THROW(CreateLut3DOp(ops,
         lut_a, OCIO::INTERP_NEAREST, OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateLut3DOp(ops,
+    OCIO_CHECK_NO_THROW(CreateLut3DOp(ops,
         lut_a, OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_INVERSE));
     // Add Matrix and LUT.
-    OIIO_CHECK_NO_THROW(CreateLut3DOp(ops,
+    OCIO_CHECK_NO_THROW(CreateLut3DOp(ops,
         lut_b, OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_FORWARD));
     // Add LUT and Matrix.
-    OIIO_CHECK_NO_THROW(CreateLut3DOp(ops,
+    OCIO_CHECK_NO_THROW(CreateLut3DOp(ops,
         lut_b, OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_INVERSE));
     
-    OIIO_REQUIRE_EQUAL(ops.size(), 6);
+    OCIO_REQUIRE_EQUAL(ops.size(), 6);
 
     OCIO::ConstOpRcPtr op1 = ops[1];
     OCIO::ConstOpRcPtr op2 = ops[2];
@@ -1129,18 +1129,18 @@ OIIO_ADD_TEST(Lut3DOpStruct, inverse_comparison_check)
     OCIO::ConstOpRcPtr op4 = ops[4];
     OCIO::ConstOpRcPtr op4Cloned = op4->clone();
 
-    OIIO_CHECK_ASSERT(ops[0]->isSameType(op1));
-    OIIO_CHECK_ASSERT(ops[0]->isSameType(op3));
-    OIIO_CHECK_ASSERT(ops[0]->isSameType(op4Cloned));
+    OCIO_CHECK_ASSERT(ops[0]->isSameType(op1));
+    OCIO_CHECK_ASSERT(ops[0]->isSameType(op3));
+    OCIO_CHECK_ASSERT(ops[0]->isSameType(op4Cloned));
 
-    OIIO_CHECK_ASSERT(ops[0]->isInverse(op1));
-    OIIO_CHECK_ASSERT(!ops[0]->isInverse(op3));
-    OIIO_CHECK_ASSERT(!ops[0]->isInverse(op4));
-    OIIO_CHECK_ASSERT(ops[3]->isInverse(op4));
+    OCIO_CHECK_ASSERT(ops[0]->isInverse(op1));
+    OCIO_CHECK_ASSERT(!ops[0]->isInverse(op3));
+    OCIO_CHECK_ASSERT(!ops[0]->isInverse(op4));
+    OCIO_CHECK_ASSERT(ops[3]->isInverse(op4));
 }
 
 /*
-OIIO_ADD_TEST(Lut3DOp, PerformanceCheck)
+OCIO_ADD_TEST(Lut3DOp, PerformanceCheck)
 {
     OCIO::Lut3D lut;
 
@@ -1206,11 +1206,11 @@ OIIO_ADD_TEST(Lut3DOp, PerformanceCheck)
 }
 */
 
-OIIO_ADD_TEST(Lut3DOpStruct, throw_lut)
+OCIO_ADD_TEST(Lut3DOpStruct, throw_lut)
 {
     // std::string Lut3D::getCacheID() const when LUT is empty.
     OCIO::Lut3DRcPtr lut = OCIO::Lut3D::Create();
-    OIIO_CHECK_THROW_WHAT(lut->getCacheID(), OCIO::Exception, "invalid Lut3D");
+    OCIO_CHECK_THROW_WHAT(lut->getCacheID(), OCIO::Exception, "invalid Lut3D");
 
     // GenerateIdentityLut3D with less than 3 channels
     lut->size[0] = 3;
@@ -1219,21 +1219,21 @@ OIIO_ADD_TEST(Lut3DOpStruct, throw_lut)
 
     lut->lut.resize(lut->size[0] * lut->size[1] * lut->size[2] * 3);
 
-    OIIO_CHECK_THROW_WHAT(GenerateIdentityLut3D(
+    OCIO_CHECK_THROW_WHAT(GenerateIdentityLut3D(
         &lut->lut[0], lut->size[0], 2, OCIO::LUT3DORDER_FAST_RED),
         OCIO::Exception, "less than 3 channels");
 
     // GenerateIdentityLut3D with unknown order.
-    OIIO_CHECK_THROW_WHAT(GenerateIdentityLut3D(
+    OCIO_CHECK_THROW_WHAT(GenerateIdentityLut3D(
         &lut->lut[0], lut->size[0], 3, (OCIO::Lut3DOrder)42),
         OCIO::Exception, "Unknown Lut3DOrder");
 
     // Get3DLutEdgeLenFromNumPixels with not cubic size.
-    OIIO_CHECK_THROW_WHAT(OCIO::Get3DLutEdgeLenFromNumPixels(10),
+    OCIO_CHECK_THROW_WHAT(OCIO::Get3DLutEdgeLenFromNumPixels(10),
         OCIO::Exception, "Cannot infer 3D LUT size");
 }
 
-OIIO_ADD_TEST(Lut3DOpStruct, throw_lut_op)
+OCIO_ADD_TEST(Lut3DOpStruct, throw_lut_op)
 {
     OCIO::Lut3DRcPtr lut = OCIO::Lut3D::Create();
     lut->size[0] = 3;
@@ -1241,20 +1241,20 @@ OIIO_ADD_TEST(Lut3DOpStruct, throw_lut_op)
     lut->size[2] = 3;
     lut->lut.resize(lut->size[0] * lut->size[1] * lut->size[2] * 3);
 
-    OIIO_CHECK_NO_THROW(GenerateIdentityLut3D(
+    OCIO_CHECK_NO_THROW(GenerateIdentityLut3D(
         &lut->lut[0], lut->size[0], 3, OCIO::LUT3DORDER_FAST_RED));
 
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateLut3DOp(ops,
+    OCIO_CHECK_NO_THROW(CreateLut3DOp(ops,
         lut, OCIO::INTERP_LINEAR, OCIO::TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
 
     // Inverse is fine.
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
     ops.clear();
 
     // Only valid interpolation.
-    OIIO_CHECK_THROW_WHAT(CreateLut3DOp(ops,
+    OCIO_CHECK_THROW_WHAT(CreateLut3DOp(ops,
                                         lut,
                                         OCIO::INTERP_UNKNOWN,
                                         OCIO::TRANSFORM_DIR_FORWARD),
@@ -1264,7 +1264,7 @@ OIIO_ADD_TEST(Lut3DOpStruct, throw_lut_op)
 
     // Change size so that it does not match.
     lut->lut.resize(lut->size[0] * lut->size[1] * lut->size[2]);
-    OIIO_CHECK_THROW_WHAT(CreateLut3DOp(ops,
+    OCIO_CHECK_THROW_WHAT(CreateLut3DOp(ops,
                                         lut,
                                         OCIO::INTERP_LINEAR,
                                         OCIO::TRANSFORM_DIR_FORWARD),
@@ -1273,7 +1273,7 @@ OIIO_ADD_TEST(Lut3DOpStruct, throw_lut_op)
 
 }
 
-OIIO_ADD_TEST(Lut3DOpStruct, cache_id)
+OCIO_ADD_TEST(Lut3DOpStruct, cache_id)
 {
     OCIO::OpRcPtrVec ops;
     for (int i = 0; i < 2; ++i)
@@ -1284,40 +1284,40 @@ OIIO_ADD_TEST(Lut3DOpStruct, cache_id)
         lut->size[2] = 3;
         lut->lut.resize(lut->size[0] * lut->size[1] * lut->size[2] * 3);
 
-        OIIO_CHECK_NO_THROW(GenerateIdentityLut3D(
+        OCIO_CHECK_NO_THROW(GenerateIdentityLut3D(
             &lut->lut[0], lut->size[0], 3, OCIO::LUT3DORDER_FAST_RED));
 
-        OIIO_CHECK_NO_THROW(CreateLut3DOp(ops, lut, OCIO::INTERP_LINEAR,
+        OCIO_CHECK_NO_THROW(CreateLut3DOp(ops, lut, OCIO::INTERP_LINEAR,
                                           OCIO::TRANSFORM_DIR_FORWARD));
     }
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
 
-    OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops));
+    OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops));
 
     const std::string cacheID = ops[0]->getCacheID();
-    OIIO_CHECK_ASSERT(!cacheID.empty());
+    OCIO_CHECK_ASSERT(!cacheID.empty());
     // Identical LUTs have the same cacheID.
-    OIIO_CHECK_EQUAL(cacheID, ops[1]->getCacheID());
+    OCIO_CHECK_EQUAL(cacheID, ops[1]->getCacheID());
 }
 
-OIIO_ADD_TEST(Lut3DOp, edge_len_from_num_pixels)
+OCIO_ADD_TEST(Lut3DOp, edge_len_from_num_pixels)
 {
-    OIIO_CHECK_THROW_WHAT(OCIO::Get3DLutEdgeLenFromNumPixels(10),
+    OCIO_CHECK_THROW_WHAT(OCIO::Get3DLutEdgeLenFromNumPixels(10),
                           OCIO::Exception, "Cannot infer 3D LUT size");
     int expectedRes = 33;
     int res = 0;
-    OIIO_CHECK_NO_THROW(res = OCIO::Get3DLutEdgeLenFromNumPixels(
+    OCIO_CHECK_NO_THROW(res = OCIO::Get3DLutEdgeLenFromNumPixels(
         expectedRes*expectedRes*expectedRes));
-    OIIO_CHECK_EQUAL(res, expectedRes);
+    OCIO_CHECK_EQUAL(res, expectedRes);
 
     expectedRes = 1290; // Maximum value such that v^3 is still an int.
-    OIIO_CHECK_NO_THROW(res = OCIO::Get3DLutEdgeLenFromNumPixels(
+    OCIO_CHECK_NO_THROW(res = OCIO::Get3DLutEdgeLenFromNumPixels(
         expectedRes*expectedRes*expectedRes));
-    OIIO_CHECK_EQUAL(res, expectedRes);
+    OCIO_CHECK_EQUAL(res, expectedRes);
 }
 
-OIIO_ADD_TEST(Lut3DOpStruct, lut3d_order)
+OCIO_ADD_TEST(Lut3DOpStruct, lut3d_order)
 {
     OCIO::Lut3DRcPtr lut_r = OCIO::Lut3D::Create();
 
@@ -1327,25 +1327,25 @@ OIIO_ADD_TEST(Lut3DOpStruct, lut3d_order)
 
     lut_r->lut.resize(lut_r->size[0] * lut_r->size[1] * lut_r->size[2] * 3);
 
-    OIIO_CHECK_NO_THROW(GenerateIdentityLut3D(
+    OCIO_CHECK_NO_THROW(GenerateIdentityLut3D(
         &lut_r->lut[0], lut_r->size[0], 3, OCIO::LUT3DORDER_FAST_RED));
 
     // First 3 values have red changing.
-    OIIO_CHECK_EQUAL(lut_r->lut[0], 0.0f);
-    OIIO_CHECK_EQUAL(lut_r->lut[3], 0.5f);
-    OIIO_CHECK_EQUAL(lut_r->lut[6], 1.0f);
+    OCIO_CHECK_EQUAL(lut_r->lut[0], 0.0f);
+    OCIO_CHECK_EQUAL(lut_r->lut[3], 0.5f);
+    OCIO_CHECK_EQUAL(lut_r->lut[6], 1.0f);
     // Blue is all 0.
-    OIIO_CHECK_EQUAL(lut_r->lut[2], 0.0f);
-    OIIO_CHECK_EQUAL(lut_r->lut[5], 0.0f);
-    OIIO_CHECK_EQUAL(lut_r->lut[8], 0.0f);
+    OCIO_CHECK_EQUAL(lut_r->lut[2], 0.0f);
+    OCIO_CHECK_EQUAL(lut_r->lut[5], 0.0f);
+    OCIO_CHECK_EQUAL(lut_r->lut[8], 0.0f);
     // Last 3 values have red changing.
-    OIIO_CHECK_EQUAL(lut_r->lut[72], 0.0f);
-    OIIO_CHECK_EQUAL(lut_r->lut[75], 0.5f);
-    OIIO_CHECK_EQUAL(lut_r->lut[78], 1.0f);
+    OCIO_CHECK_EQUAL(lut_r->lut[72], 0.0f);
+    OCIO_CHECK_EQUAL(lut_r->lut[75], 0.5f);
+    OCIO_CHECK_EQUAL(lut_r->lut[78], 1.0f);
     // Blue is all 1.
-    OIIO_CHECK_EQUAL(lut_r->lut[74], 1.0f);
-    OIIO_CHECK_EQUAL(lut_r->lut[77], 1.0f);
-    OIIO_CHECK_EQUAL(lut_r->lut[80], 1.0f);
+    OCIO_CHECK_EQUAL(lut_r->lut[74], 1.0f);
+    OCIO_CHECK_EQUAL(lut_r->lut[77], 1.0f);
+    OCIO_CHECK_EQUAL(lut_r->lut[80], 1.0f);
 
     OCIO::Lut3DRcPtr lut_b = OCIO::Lut3D::Create();
 
@@ -1355,29 +1355,29 @@ OIIO_ADD_TEST(Lut3DOpStruct, lut3d_order)
 
     lut_b->lut.resize(lut_b->size[0] * lut_b->size[1] * lut_b->size[2] * 3);
 
-    OIIO_CHECK_NO_THROW(GenerateIdentityLut3D(
+    OCIO_CHECK_NO_THROW(GenerateIdentityLut3D(
         &lut_b->lut[0], lut_b->size[0], 3, OCIO::LUT3DORDER_FAST_BLUE));
 
     // First 3 values have blue changing.
-    OIIO_CHECK_EQUAL(lut_b->lut[2], 0.0f);
-    OIIO_CHECK_EQUAL(lut_b->lut[5], 0.5f);
-    OIIO_CHECK_EQUAL(lut_b->lut[8], 1.0f);
+    OCIO_CHECK_EQUAL(lut_b->lut[2], 0.0f);
+    OCIO_CHECK_EQUAL(lut_b->lut[5], 0.5f);
+    OCIO_CHECK_EQUAL(lut_b->lut[8], 1.0f);
     // Red is all 0.
-    OIIO_CHECK_EQUAL(lut_b->lut[0], 0.0f);
-    OIIO_CHECK_EQUAL(lut_b->lut[3], 0.0f);
-    OIIO_CHECK_EQUAL(lut_b->lut[6], 0.0f);
+    OCIO_CHECK_EQUAL(lut_b->lut[0], 0.0f);
+    OCIO_CHECK_EQUAL(lut_b->lut[3], 0.0f);
+    OCIO_CHECK_EQUAL(lut_b->lut[6], 0.0f);
     // Last 3 values have blue changing.
-    OIIO_CHECK_EQUAL(lut_b->lut[74], 0.0f);
-    OIIO_CHECK_EQUAL(lut_b->lut[77], 0.5f);
-    OIIO_CHECK_EQUAL(lut_b->lut[80], 1.0f);
+    OCIO_CHECK_EQUAL(lut_b->lut[74], 0.0f);
+    OCIO_CHECK_EQUAL(lut_b->lut[77], 0.5f);
+    OCIO_CHECK_EQUAL(lut_b->lut[80], 1.0f);
     // Red is all 1.
-    OIIO_CHECK_EQUAL(lut_b->lut[72], 1.0f);
-    OIIO_CHECK_EQUAL(lut_b->lut[75], 1.0f);
-    OIIO_CHECK_EQUAL(lut_b->lut[78], 1.0f);
+    OCIO_CHECK_EQUAL(lut_b->lut[72], 1.0f);
+    OCIO_CHECK_EQUAL(lut_b->lut[75], 1.0f);
+    OCIO_CHECK_EQUAL(lut_b->lut[78], 1.0f);
 
 }
 
-OIIO_ADD_TEST(Lut3DOp, convert_lut)
+OCIO_ADD_TEST(Lut3DOp, convert_lut)
 {
     OCIO::Lut3DRcPtr lut_r = OCIO::Lut3D::Create();
 
@@ -1387,36 +1387,36 @@ OIIO_ADD_TEST(Lut3DOp, convert_lut)
 
     lut_r->lut.resize(lut_r->size[0] * lut_r->size[1] * lut_r->size[2] * 3);
 
-    OIIO_CHECK_NO_THROW(GenerateIdentityLut3D(
+    OCIO_CHECK_NO_THROW(GenerateIdentityLut3D(
         &lut_r->lut[0], lut_r->size[0], 3, OCIO::LUT3DORDER_FAST_RED));
 
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateLut3DOp(ops, lut_r, OCIO::INTERP_LINEAR,
+    OCIO_CHECK_NO_THROW(CreateLut3DOp(ops, lut_r, OCIO::INTERP_LINEAR,
                                       OCIO::TRANSFORM_DIR_FORWARD));
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
 
     const OCIO::Lut3DOpRcPtr pLB = OCIO::DynamicPtrCast<OCIO::Lut3DOp>(ops[0]);
 
     // First 3 values have blue changing.
-    OIIO_CHECK_EQUAL(pLB->getArray().getValues()[2], 0.0f);
-    OIIO_CHECK_EQUAL(pLB->getArray().getValues()[5], 0.5f);
-    OIIO_CHECK_EQUAL(pLB->getArray().getValues()[8], 1.0f);
+    OCIO_CHECK_EQUAL(pLB->getArray().getValues()[2], 0.0f);
+    OCIO_CHECK_EQUAL(pLB->getArray().getValues()[5], 0.5f);
+    OCIO_CHECK_EQUAL(pLB->getArray().getValues()[8], 1.0f);
     // Red is all 0.
-    OIIO_CHECK_EQUAL(pLB->getArray().getValues()[0], 0.0f);
-    OIIO_CHECK_EQUAL(pLB->getArray().getValues()[3], 0.0f);
-    OIIO_CHECK_EQUAL(pLB->getArray().getValues()[6], 0.0f);
+    OCIO_CHECK_EQUAL(pLB->getArray().getValues()[0], 0.0f);
+    OCIO_CHECK_EQUAL(pLB->getArray().getValues()[3], 0.0f);
+    OCIO_CHECK_EQUAL(pLB->getArray().getValues()[6], 0.0f);
     // Last 3 values have blue changing.
-    OIIO_CHECK_EQUAL(pLB->getArray().getValues()[74], 0.0f);
-    OIIO_CHECK_EQUAL(pLB->getArray().getValues()[77], 0.5f);
-    OIIO_CHECK_EQUAL(pLB->getArray().getValues()[80], 1.0f);
+    OCIO_CHECK_EQUAL(pLB->getArray().getValues()[74], 0.0f);
+    OCIO_CHECK_EQUAL(pLB->getArray().getValues()[77], 0.5f);
+    OCIO_CHECK_EQUAL(pLB->getArray().getValues()[80], 1.0f);
     // Red is all 1.
-    OIIO_CHECK_EQUAL(pLB->getArray().getValues()[72], 1.0f);
-    OIIO_CHECK_EQUAL(pLB->getArray().getValues()[75], 1.0f);
-    OIIO_CHECK_EQUAL(pLB->getArray().getValues()[78], 1.0f);
+    OCIO_CHECK_EQUAL(pLB->getArray().getValues()[72], 1.0f);
+    OCIO_CHECK_EQUAL(pLB->getArray().getValues()[75], 1.0f);
+    OCIO_CHECK_EQUAL(pLB->getArray().getValues()[78], 1.0f);
 }
 
-OIIO_ADD_TEST(Lut3DOp, cpu_renderer_lut3d)
+OCIO_ADD_TEST(Lut3DOp, cpu_renderer_lut3d)
 {
     const OCIO::BitDepth bitDepth = OCIO::BIT_DEPTH_F32;
 
@@ -1429,9 +1429,9 @@ OIIO_ADD_TEST(Lut3DOp, cpu_renderer_lut3d)
 
     OCIO::Lut3DOp lut(lutData);
 
-    OIIO_CHECK_NO_THROW(lut.finalize());
-    OIIO_CHECK_ASSERT(lutData->isIdentity());
-    OIIO_CHECK_ASSERT(!lut.isNoOp());
+    OCIO_CHECK_NO_THROW(lut.finalize());
+    OCIO_CHECK_ASSERT(lutData->isIdentity());
+    OCIO_CHECK_ASSERT(!lut.isNoOp());
 
     // Use an input value exactly at a grid point so the output value is 
     // just the grid value, regardless of interpolation.
@@ -1443,81 +1443,81 @@ OIIO_ADD_TEST(Lut3DOp, cpu_renderer_lut3d)
                          0.0f, 0.0f, step, 1.0f };
 
     {
-        OIIO_CHECK_NO_THROW(lut.apply(myImage, myImage, 2));
+        OCIO_CHECK_NO_THROW(lut.apply(myImage, myImage, 2));
 
-        OIIO_CHECK_EQUAL(myImage[0], 0.0f);
-        OIIO_CHECK_EQUAL(myImage[1], 0.0f);
-        OIIO_CHECK_EQUAL(myImage[2], 0.0f);
-        OIIO_CHECK_EQUAL(myImage[3], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[0], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[1], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[2], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[3], 0.0f);
 
-        OIIO_CHECK_EQUAL(myImage[4], 0.0f);
-        OIIO_CHECK_EQUAL(myImage[5], 0.0f);
-        OIIO_CHECK_EQUAL(myImage[6], step);
-        OIIO_CHECK_EQUAL(myImage[7], 1.0f);
+        OCIO_CHECK_EQUAL(myImage[4], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[5], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[6], step);
+        OCIO_CHECK_EQUAL(myImage[7], 1.0f);
     }
 
     // No more an 'identity LUT 3D'.
     const float arbitraryVal = 0.123456f;
     lutData->getArray()[5] = arbitraryVal;
 
-    OIIO_CHECK_NO_THROW(lut.finalize());
-    OIIO_CHECK_ASSERT(!lutData->isIdentity());
-    OIIO_CHECK_ASSERT(!lut.isNoOp());
+    OCIO_CHECK_NO_THROW(lut.finalize());
+    OCIO_CHECK_ASSERT(!lutData->isIdentity());
+    OCIO_CHECK_ASSERT(!lut.isNoOp());
 
     {
-        OIIO_CHECK_NO_THROW(lut.apply(myImage, myImage, 2));
+        OCIO_CHECK_NO_THROW(lut.apply(myImage, myImage, 2));
 
-        OIIO_CHECK_EQUAL(myImage[0], 0.0f);
-        OIIO_CHECK_EQUAL(myImage[1], 0.0f);
-        OIIO_CHECK_EQUAL(myImage[2], 0.0f);
-        OIIO_CHECK_EQUAL(myImage[3], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[0], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[1], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[2], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[3], 0.0f);
 
-        OIIO_CHECK_EQUAL(myImage[4], 0.0f);
-        OIIO_CHECK_EQUAL(myImage[5], 0.0f);
-        OIIO_CHECK_EQUAL(myImage[6], arbitraryVal);
-        OIIO_CHECK_EQUAL(myImage[7], 1.0f);
+        OCIO_CHECK_EQUAL(myImage[4], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[5], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[6], arbitraryVal);
+        OCIO_CHECK_EQUAL(myImage[7], 1.0f);
     }
 
     // Change interpolation.
     lutData->setInterpolation(OCIO::INTERP_TETRAHEDRAL);
-    OIIO_CHECK_NO_THROW(lut.finalize());
-    OIIO_CHECK_ASSERT(!lutData->isIdentity());
-    OIIO_CHECK_ASSERT(!lut.isNoOp());
+    OCIO_CHECK_NO_THROW(lut.finalize());
+    OCIO_CHECK_ASSERT(!lutData->isIdentity());
+    OCIO_CHECK_ASSERT(!lut.isNoOp());
     myImage[6] = step;
     {
-        OIIO_CHECK_NO_THROW(lut.apply(myImage, myImage, 2));
+        OCIO_CHECK_NO_THROW(lut.apply(myImage, myImage, 2));
 
-        OIIO_CHECK_EQUAL(myImage[0], 0.0f);
-        OIIO_CHECK_EQUAL(myImage[1], 0.0f);
-        OIIO_CHECK_EQUAL(myImage[2], 0.0f);
-        OIIO_CHECK_EQUAL(myImage[3], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[0], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[1], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[2], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[3], 0.0f);
 
-        OIIO_CHECK_EQUAL(myImage[4], 0.0f);
-        OIIO_CHECK_EQUAL(myImage[5], 0.0f);
-        OIIO_CHECK_EQUAL(myImage[6], arbitraryVal);
-        OIIO_CHECK_EQUAL(myImage[7], 1.0f);
+        OCIO_CHECK_EQUAL(myImage[4], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[5], 0.0f);
+        OCIO_CHECK_EQUAL(myImage[6], arbitraryVal);
+        OCIO_CHECK_EQUAL(myImage[7], 1.0f);
     }
 }
 
-OIIO_ADD_TEST(Lut3DOp, cpu_renderer_inv_lut3d)
+OCIO_ADD_TEST(Lut3DOp, cpu_renderer_inv_lut3d)
 {
     const std::string fileName("lut3d_17x17x17_10i_12i.clf");
     OCIO::OpRcPtrVec ops;
     OCIO::ContextRcPtr context = OCIO::Context::Create();
-    OIIO_CHECK_NO_THROW(BuildOpsTest(ops, fileName, context,
+    OCIO_CHECK_NO_THROW(BuildOpsTest(ops, fileName, context,
                                      OCIO::TRANSFORM_DIR_FORWARD));
 
     // TODO: BitDepth support: FinalizeOpVec is currently switching ops to 32F.
-    OIIO_REQUIRE_EQUAL(2, ops.size());
-    OIIO_CHECK_EQUAL(ops[1]->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_EQUAL(ops[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops));
-    OIIO_REQUIRE_EQUAL(1, ops.size());
-    OIIO_CHECK_EQUAL(ops[0]->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_REQUIRE_EQUAL(2, ops.size());
+    OCIO_CHECK_EQUAL(ops[1]->getInputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(ops[1]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops));
+    OCIO_REQUIRE_EQUAL(1, ops.size());
+    OCIO_CHECK_EQUAL(ops[0]->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
     auto op0 = OCIO::DynamicPtrCast<const OCIO::Lut3DOp>(ops[0]);
-    OIIO_REQUIRE_ASSERT(op0);
+    OCIO_REQUIRE_ASSERT(op0);
     auto fwdLutData = OCIO::DynamicPtrCast<const OCIO::Lut3DOpData>(op0->data());
     auto fwdLutDataCloned = fwdLutData->clone();
     // Inversion is based on tetrahedral interpolation, so need to make sure 
@@ -1534,7 +1534,7 @@ OIIO_ADD_TEST(Lut3DOp, cpu_renderer_inv_lut3d)
     OCIO::Lut3DOp invinvLut(invinvLutData);
 
     // Default Inversion quality should be 'FAST' but we test the 'EXACT' first.
-    OIIO_CHECK_EQUAL(invLutData->getInversionQuality(), OCIO::LUT_INVERSION_FAST);
+    OCIO_CHECK_EQUAL(invLutData->getInversionQuality(), OCIO::LUT_INVERSION_FAST);
     invLutData->setInversionQuality(OCIO::LUT_INVERSION_EXACT);
 
     const float inImage[] = {
@@ -1553,25 +1553,25 @@ OIIO_ADD_TEST(Lut3DOp, cpu_renderer_inv_lut3d)
     memcpy(bufferImageClone2, inImage, 12 * sizeof(float));
 
     // Apply forward LUT.
-    OIIO_CHECK_NO_THROW(fwdLut.finalize());
-    OIIO_CHECK_NO_THROW(fwdLut.apply(bufferImage, 3));
+    OCIO_CHECK_NO_THROW(fwdLut.finalize());
+    OCIO_CHECK_NO_THROW(fwdLut.apply(bufferImage, 3));
 
     // Clone and verify clone is giving same results.
     OCIO::OpRcPtr fwdLutCloned = fwdLut.clone();
-    OIIO_CHECK_NO_THROW(fwdLutCloned->finalize());
-    OIIO_CHECK_NO_THROW(fwdLutCloned->apply(bufferImageClone, 3));
+    OCIO_CHECK_NO_THROW(fwdLutCloned->finalize());
+    OCIO_CHECK_NO_THROW(fwdLutCloned->apply(bufferImageClone, 3));
     const float error = 1e-6f;
     for (unsigned i = 0; i < 12; ++i)
     {
-        OIIO_CHECK_CLOSE(bufferImageClone[i], bufferImage[i], error);
+        OCIO_CHECK_CLOSE(bufferImageClone[i], bufferImage[i], error);
     }
 
     // Inverse of inverse is the same as forward.
-    OIIO_CHECK_NO_THROW(invinvLut.finalize());
-    OIIO_CHECK_NO_THROW(invinvLut.apply(bufferImageClone2, 3));
+    OCIO_CHECK_NO_THROW(invinvLut.finalize());
+    OCIO_CHECK_NO_THROW(invinvLut.apply(bufferImageClone2, 3));
     for (unsigned i = 0; i < 12; ++i)
     {
-        OIIO_CHECK_CLOSE(bufferImageClone2[i], bufferImage[i], error);
+        OCIO_CHECK_CLOSE(bufferImageClone2[i], bufferImage[i], error);
     }
 
     float outImage1[12];
@@ -1579,17 +1579,17 @@ OIIO_ADD_TEST(Lut3DOp, cpu_renderer_inv_lut3d)
     memcpy(bufferImageClone, bufferImage, 12 * sizeof(float));
 
     // Apply inverse LUT.
-    OIIO_CHECK_NO_THROW(invLut.finalize());
-    OIIO_CHECK_NO_THROW(invLut.apply(bufferImage, 3));
+    OCIO_CHECK_NO_THROW(invLut.finalize());
+    OCIO_CHECK_NO_THROW(invLut.apply(bufferImage, 3));
 
     // Clone the inverse and do same transform.
     OCIO::OpRcPtr invLutCloned = invLut.clone();
-    OIIO_CHECK_NO_THROW(invLutCloned->finalize());
-    OIIO_CHECK_NO_THROW(invLutCloned->apply(bufferImageClone, 3));
+    OCIO_CHECK_NO_THROW(invLutCloned->finalize());
+    OCIO_CHECK_NO_THROW(invLutCloned->apply(bufferImageClone, 3));
 
     for (unsigned i = 0; i < 12; ++i)
     {
-        OIIO_CHECK_CLOSE(bufferImageClone[i], bufferImage[i], error);
+        OCIO_CHECK_CLOSE(bufferImageClone[i], bufferImage[i], error);
     }
 
     // Need to do another foward apply.  This is due to precision issues.
@@ -1599,11 +1599,11 @@ OIIO_ADD_TEST(Lut3DOp, cpu_renderer_inv_lut3d)
     // for this particular LUT as the original input.  In other words, when the
     // forward LUT has a small derivative, precision issues imply that there will
     // be a range of inverses which should be considered valid.
-    OIIO_CHECK_NO_THROW(fwdLut.apply(bufferImage, 3));
+    OCIO_CHECK_NO_THROW(fwdLut.apply(bufferImage, 3));
 
     for (unsigned i = 0; i < 12; ++i)
     {
-        OIIO_CHECK_CLOSE(outImage1[i], bufferImage[i], error);
+        OCIO_CHECK_CLOSE(outImage1[i], bufferImage[i], error);
     }
 
     // Repeat with inversion quality FAST.
@@ -1612,17 +1612,17 @@ OIIO_ADD_TEST(Lut3DOp, cpu_renderer_inv_lut3d)
     memcpy(bufferImage, outImage1, 12 * sizeof(float));
 
     // Apply inverse LUT.
-    OIIO_CHECK_NO_THROW(invLut.finalize());
-    OIIO_CHECK_NO_THROW(invLut.apply(bufferImage, 3));
+    OCIO_CHECK_NO_THROW(invLut.finalize());
+    OCIO_CHECK_NO_THROW(invLut.apply(bufferImage, 3));
 
-    OIIO_CHECK_NO_THROW(fwdLut.apply(bufferImage, 3));
+    OCIO_CHECK_NO_THROW(fwdLut.apply(bufferImage, 3));
 
     // Note that, even more than with Lut1D, the FAST inv Lut3D renderer is not exact.
     // It is expected that a fairly loose tolerance must be used here.
     const float errorLoose = 0.015f;
     for (unsigned i = 0; i < 12; ++i)
     {
-        OIIO_CHECK_CLOSE(outImage1[i], bufferImage[i], errorLoose);
+        OCIO_CHECK_CLOSE(outImage1[i], bufferImage[i], errorLoose);
     }
 
     // Test clamping of large values in EXACT mode.
@@ -1631,27 +1631,27 @@ OIIO_ADD_TEST(Lut3DOp, cpu_renderer_inv_lut3d)
 
     bufferImage[0] = 100.f;
 
-    OIIO_CHECK_NO_THROW(invLut.finalize());
-    OIIO_CHECK_NO_THROW(invLut.apply(bufferImage, 1));
+    OCIO_CHECK_NO_THROW(invLut.finalize());
+    OCIO_CHECK_NO_THROW(invLut.apply(bufferImage, 1));
 
     // This tests that extreme large values get inverted.
     // (If no inverse is found, apply() currently returns zeros.)
-    OIIO_CHECK_ASSERT(bufferImage[0] > 0.5f);
+    OCIO_CHECK_ASSERT(bufferImage[0] > 0.5f);
 }
 
-OIIO_ADD_TEST(Lut3DOp, cpu_renderer_lut3d_with_nan)
+OCIO_ADD_TEST(Lut3DOp, cpu_renderer_lut3d_with_nan)
 {
     const std::string fileName("lut3d_2x2x2_32f_32f.clf");
     OCIO::OpRcPtrVec ops;
 
     OCIO::ContextRcPtr context = OCIO::Context::Create();
-    OIIO_CHECK_NO_THROW(BuildOpsTest(ops, fileName, context,
+    OCIO_CHECK_NO_THROW(BuildOpsTest(ops, fileName, context,
                                      OCIO::TRANSFORM_DIR_FORWARD));
 
-    OIIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops));
-    OIIO_REQUIRE_EQUAL(1, ops.size());
+    OCIO_CHECK_NO_THROW(OCIO::FinalizeOpVec(ops));
+    OCIO_REQUIRE_EQUAL(1, ops.size());
     OCIO::ConstOpRcPtr op0 = ops[0];
-    OIIO_CHECK_EQUAL(op0->data()->getType(), OCIO::OpData::Lut3DType);
+    OCIO_CHECK_EQUAL(op0->data()->getType(), OCIO::OpData::Lut3DType);
 
     const float qnan = std::numeric_limits<float>::quiet_NaN();
     float myImage[]
@@ -1661,22 +1661,22 @@ OIIO_ADD_TEST(Lut3DOp, cpu_renderer_lut3d_with_nan)
             0.25f, 0.25f, 0.0f, qnan,
             0.5f, 0.5f,  0.5f,  0.0f };
 
-    OIIO_CHECK_NO_THROW(op0->apply(myImage, 5));
+    OCIO_CHECK_NO_THROW(op0->apply(myImage, 5));
 
-    OIIO_CHECK_EQUAL(myImage[0], 0.0f);
-    OIIO_CHECK_EQUAL(myImage[1], 0.25f);
-    OIIO_CHECK_EQUAL(myImage[2], 0.25f);
-    OIIO_CHECK_EQUAL(myImage[3], 0.0f);
+    OCIO_CHECK_EQUAL(myImage[0], 0.0f);
+    OCIO_CHECK_EQUAL(myImage[1], 0.25f);
+    OCIO_CHECK_EQUAL(myImage[2], 0.25f);
+    OCIO_CHECK_EQUAL(myImage[3], 0.0f);
 
-    OIIO_CHECK_EQUAL(myImage[5], 0.0f);
-    OIIO_CHECK_EQUAL(myImage[10], 0.0f);
+    OCIO_CHECK_EQUAL(myImage[5], 0.0f);
+    OCIO_CHECK_EQUAL(myImage[10], 0.0f);
 
-    OIIO_CHECK_ASSERT(OCIO::IsNan(myImage[15]));
+    OCIO_CHECK_ASSERT(OCIO::IsNan(myImage[15]));
 
-    OIIO_CHECK_EQUAL(myImage[16], 0.5f);
-    OIIO_CHECK_EQUAL(myImage[17], 0.5f);
-    OIIO_CHECK_EQUAL(myImage[18], 0.5f);
-    OIIO_CHECK_EQUAL(myImage[19], 0.0f);
+    OCIO_CHECK_EQUAL(myImage[16], 0.5f);
+    OCIO_CHECK_EQUAL(myImage[17], 0.5f);
+    OCIO_CHECK_EQUAL(myImage[18], 0.5f);
+    OCIO_CHECK_EQUAL(myImage[19], 0.0f);
 }
 
 

--- a/src/OpenColorIO/ops/Lut3D/Lut3DOpCPU.cpp
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOpCPU.cpp
@@ -1992,7 +1992,7 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 
 #include <limits>
-#include "unittest.h"
+#include "UnitTest.h"
 
 void Lut3DRendererNaNTest(OCIO::Interpolation interpol)
 {
@@ -2020,26 +2020,26 @@ void Lut3DRendererNaNTest(OCIO::Interpolation interpol)
 
     renderer->apply(pixels, pixels, 4);
 
-    OIIO_CHECK_CLOSE(pixels[0], values[0], 1e-7f);
-    OIIO_CHECK_CLOSE(pixels[1], values[1], 1e-7f);
-    OIIO_CHECK_CLOSE(pixels[2], values[2], 1e-7f);
-    OIIO_CHECK_ASSERT(OCIO::IsNan(pixels[7]));
-    OIIO_CHECK_CLOSE(pixels[8], 1.0f, 1e-7f);
-    OIIO_CHECK_CLOSE(pixels[9], 1.0f, 1e-7f);
-    OIIO_CHECK_CLOSE(pixels[10], 1.0f, 1e-7f);
-    OIIO_CHECK_EQUAL(pixels[11], inf);
-    OIIO_CHECK_CLOSE(pixels[12], 0.0f, 1e-7f);
-    OIIO_CHECK_CLOSE(pixels[13], 0.0f, 1e-7f);
-    OIIO_CHECK_CLOSE(pixels[14], 0.0f, 1e-7f);
-    OIIO_CHECK_EQUAL(pixels[15], -inf);
+    OCIO_CHECK_CLOSE(pixels[0], values[0], 1e-7f);
+    OCIO_CHECK_CLOSE(pixels[1], values[1], 1e-7f);
+    OCIO_CHECK_CLOSE(pixels[2], values[2], 1e-7f);
+    OCIO_CHECK_ASSERT(OCIO::IsNan(pixels[7]));
+    OCIO_CHECK_CLOSE(pixels[8], 1.0f, 1e-7f);
+    OCIO_CHECK_CLOSE(pixels[9], 1.0f, 1e-7f);
+    OCIO_CHECK_CLOSE(pixels[10], 1.0f, 1e-7f);
+    OCIO_CHECK_EQUAL(pixels[11], inf);
+    OCIO_CHECK_CLOSE(pixels[12], 0.0f, 1e-7f);
+    OCIO_CHECK_CLOSE(pixels[13], 0.0f, 1e-7f);
+    OCIO_CHECK_CLOSE(pixels[14], 0.0f, 1e-7f);
+    OCIO_CHECK_EQUAL(pixels[15], -inf);
 }
 
-OIIO_ADD_TEST(Lut3DRenderer, nan_linear_test)
+OCIO_ADD_TEST(Lut3DRenderer, nan_linear_test)
 {
     Lut3DRendererNaNTest(OCIO::INTERP_LINEAR);
 }
 
-OIIO_ADD_TEST(Lut3DRenderer, nan_tetra_test)
+OCIO_ADD_TEST(Lut3DRenderer, nan_tetra_test)
 {
     Lut3DRendererNaNTest(OCIO::INTERP_TETRAHEDRAL);
 }

--- a/src/OpenColorIO/ops/Lut3D/Lut3DOpData.cpp
+++ b/src/OpenColorIO/ops/Lut3D/Lut3DOpData.cpp
@@ -619,21 +619,21 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
-OIIO_ADD_TEST(Lut3DOpData, empty)
+OCIO_ADD_TEST(Lut3DOpData, empty)
 {
     OCIO::Lut3DOpData l(2);
-    OIIO_CHECK_NO_THROW(l.validate());
-    OIIO_CHECK_ASSERT(l.isIdentity());
-    OIIO_CHECK_ASSERT(!l.isNoOp());
-    OIIO_CHECK_EQUAL(l.getType(), OCIO::OpData::Lut3DType);
-    OIIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_FAST);
-    OIIO_CHECK_EQUAL(l.getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_ASSERT(l.isIdentity());
+    OCIO_CHECK_ASSERT(!l.isNoOp());
+    OCIO_CHECK_EQUAL(l.getType(), OCIO::OpData::Lut3DType);
+    OCIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_FAST);
+    OCIO_CHECK_EQUAL(l.getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
 }
 
-OIIO_ADD_TEST(Lut3DOpData, accessors)
+OCIO_ADD_TEST(Lut3DOpData, accessors)
 {
     OCIO::Interpolation interpol = OCIO::INTERP_LINEAR;
 
@@ -641,39 +641,39 @@ OIIO_ADD_TEST(Lut3DOpData, accessors)
                         "uid", OCIO::OpData::Descriptions(),
                         interpol, 33);
 
-    OIIO_CHECK_EQUAL(l.getInterpolation(), interpol);
-    OIIO_CHECK_ASSERT(l.isIdentity());
+    OCIO_CHECK_EQUAL(l.getInterpolation(), interpol);
+    OCIO_CHECK_ASSERT(l.isIdentity());
 
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_NO_THROW(l.validate());
 
     l.getArray()[0] = 1.0f;
 
-    OIIO_CHECK_ASSERT(!l.isIdentity());
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_ASSERT(!l.isIdentity());
+    OCIO_CHECK_NO_THROW(l.validate());
 
     interpol = OCIO::INTERP_TETRAHEDRAL;
     l.setInterpolation(interpol);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), interpol);
+    OCIO_CHECK_EQUAL(l.getInterpolation(), interpol);
 
-    OIIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_FAST);
+    OCIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_FAST);
     l.setInversionQuality(OCIO::LUT_INVERSION_BEST);
-    OIIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_BEST);
-    OIIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_EXACT);
+    OCIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_BEST);
+    OCIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_EXACT);
     l.setInversionQuality(OCIO::LUT_INVERSION_FAST);
 
-    OIIO_CHECK_EQUAL(l.getArray().getLength(), (long)33);
-    OIIO_CHECK_EQUAL(l.getArray().getNumValues(), (long)33 * 33 * 33 * 3);
-    OIIO_CHECK_EQUAL(l.getArray().getNumColorComponents(), (long)3);
+    OCIO_CHECK_EQUAL(l.getArray().getLength(), (long)33);
+    OCIO_CHECK_EQUAL(l.getArray().getNumValues(), (long)33 * 33 * 33 * 3);
+    OCIO_CHECK_EQUAL(l.getArray().getNumColorComponents(), (long)3);
 
     l.getArray().resize(17, 3);
 
-    OIIO_CHECK_EQUAL(l.getArray().getLength(), (long)17);
-    OIIO_CHECK_EQUAL(l.getArray().getNumValues(), (long)17 * 17 * 17 * 3);
-    OIIO_CHECK_EQUAL(l.getArray().getNumColorComponents(), (long)3);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getArray().getLength(), (long)17);
+    OCIO_CHECK_EQUAL(l.getArray().getNumValues(), (long)17 * 17 * 17 * 3);
+    OCIO_CHECK_EQUAL(l.getArray().getNumColorComponents(), (long)3);
+    OCIO_CHECK_NO_THROW(l.validate());
 }
 
-OIIO_ADD_TEST(Lut3DOpData, diff_bitdepth)
+OCIO_ADD_TEST(Lut3DOpData, diff_bitdepth)
 {
     OCIO::Interpolation interpol = OCIO::INTERP_LINEAR;
     OCIO::Lut3DOpData l1(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT8,
@@ -683,10 +683,10 @@ OIIO_ADD_TEST(Lut3DOpData, diff_bitdepth)
                          "uid", OCIO::OpData::Descriptions(),
                          interpol, 33);
 
-    OIIO_CHECK_ASSERT(l1.isIdentity());
-    OIIO_CHECK_NO_THROW(l1.validate());
-    OIIO_CHECK_ASSERT(l2.isIdentity());
-    OIIO_CHECK_NO_THROW(l2.validate());
+    OCIO_CHECK_ASSERT(l1.isIdentity());
+    OCIO_CHECK_NO_THROW(l1.validate());
+    OCIO_CHECK_ASSERT(l2.isIdentity());
+    OCIO_CHECK_NO_THROW(l2.validate());
 
     const float coeff
         = OCIO::GetBitDepthMaxValue(l2.getOutputBitDepth())
@@ -697,45 +697,45 @@ OIIO_ADD_TEST(Lut3DOpData, diff_bitdepth)
     const float error = 1e-4f;
     for (unsigned long idx = 0; idx<l2.getArray().getLength(); ++idx)
     {
-        OIIO_CHECK_CLOSE(l1.getArray().getValues()[idx * 3 + 0] * coeff,
+        OCIO_CHECK_CLOSE(l1.getArray().getValues()[idx * 3 + 0] * coeff,
                          l2.getArray().getValues()[idx * 3 + 0],
                          error);
-        OIIO_CHECK_CLOSE(l1.getArray().getValues()[idx * 3 + 1] * coeff,
+        OCIO_CHECK_CLOSE(l1.getArray().getValues()[idx * 3 + 1] * coeff,
                          l2.getArray().getValues()[idx * 3 + 1],
                          error);
-        OIIO_CHECK_CLOSE(l1.getArray().getValues()[idx * 3 + 2] * coeff,
+        OCIO_CHECK_CLOSE(l1.getArray().getValues()[idx * 3 + 2] * coeff,
                          l2.getArray().getValues()[idx * 3 + 2],
                          error);
     }
 }
 
-OIIO_ADD_TEST(Lut3DOpData, clone)
+OCIO_ADD_TEST(Lut3DOpData, clone)
 {
     OCIO::Lut3DOpData ref(33);
     ref.getArray()[1] = 0.1f;
 
     OCIO::Lut3DOpDataRcPtr pClone = ref.clone();
 
-    OIIO_CHECK_ASSERT(pClone.get());
-    OIIO_CHECK_ASSERT(!pClone->isNoOp());
-    OIIO_CHECK_ASSERT(!pClone->isIdentity());
-    OIIO_CHECK_NO_THROW(pClone->validate());
-    OIIO_CHECK_ASSERT(pClone->getArray()==ref.getArray());
+    OCIO_CHECK_ASSERT(pClone.get());
+    OCIO_CHECK_ASSERT(!pClone->isNoOp());
+    OCIO_CHECK_ASSERT(!pClone->isIdentity());
+    OCIO_CHECK_NO_THROW(pClone->validate());
+    OCIO_CHECK_ASSERT(pClone->getArray()==ref.getArray());
 }
 
-OIIO_ADD_TEST(Lut3DOpData, not_supported_length)
+OCIO_ADD_TEST(Lut3DOpData, not_supported_length)
 {
     const OCIO::Lut3DOpData ref1(OCIO::Lut3DOpData::maxSupportedLength);
 
-    OIIO_CHECK_NO_THROW(ref1.validate());
+    OCIO_CHECK_NO_THROW(ref1.validate());
 
     const OCIO::Lut3DOpData ref2(OCIO::Lut3DOpData::maxSupportedLength + 1);
 
-    OIIO_CHECK_THROW_WHAT(ref2.validate(), OCIO::Exception, "is not supported");
+    OCIO_CHECK_THROW_WHAT(ref2.validate(), OCIO::Exception, "is not supported");
 
 }
 
-OIIO_ADD_TEST(Lut3DOpData, ouput_depth_scaling)
+OCIO_ADD_TEST(Lut3DOpData, ouput_depth_scaling)
 {
     OCIO::Interpolation interpol = OCIO::INTERP_LINEAR;
     OCIO::Lut3DOpData ref(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT10,
@@ -756,27 +756,27 @@ OIIO_ADD_TEST(Lut3DOpData, ouput_depth_scaling)
     ref.setOutputBitDepth(newBitdepth);
     // Now we need to make sure that the bitdepth was changed from the overriden
     // method.
-    OIIO_CHECK_EQUAL(ref.getOutputBitDepth(), newBitdepth);
+    OCIO_CHECK_EQUAL(ref.getOutputBitDepth(), newBitdepth);
 
     // Now we need to check if the scaling between the new array and initial array
     // matches the factor computed above.
     const OCIO::Array::Values& newArrValues = ref.getArray().getValues();
 
     // Sanity check first.
-    OIIO_CHECK_EQUAL(initialArrValues.size(), newArrValues.size());
+    OCIO_CHECK_EQUAL(initialArrValues.size(), newArrValues.size());
 
     float expectedValue = 0.0f;
 
     for(unsigned long i = 0; i < (unsigned long)newArrValues.size(); i++)
     {
         expectedValue = initialArrValues[i] * factor;
-        OIIO_CHECK_ASSERT(OCIO::EqualWithAbsError(expectedValue,
+        OCIO_CHECK_ASSERT(OCIO::EqualWithAbsError(expectedValue,
                                                   newArrValues[i],
                                                   0.0001f));
     }
 }
 
-OIIO_ADD_TEST(Lut3DOpData, equality)
+OCIO_ADD_TEST(Lut3DOpData, equality)
 {
     OCIO::Lut3DOpData l1(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32,
                          "", OCIO::OpData::Descriptions(), 
@@ -786,103 +786,103 @@ OIIO_ADD_TEST(Lut3DOpData, equality)
                          "", OCIO::OpData::Descriptions(), 
                          OCIO::INTERP_BEST, 33);  
 
-    OIIO_CHECK_ASSERT(!(l1 == l2));
+    OCIO_CHECK_ASSERT(!(l1 == l2));
 
     OCIO::Lut3DOpData l3(OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_F32,
                          "", OCIO::OpData::Descriptions(), 
                          OCIO::INTERP_LINEAR, 33);
 
-    OIIO_CHECK_ASSERT(!(l1 == l3) && !(l2 == l3));
+    OCIO_CHECK_ASSERT(!(l1 == l3) && !(l2 == l3));
 
     OCIO::Lut3DOpData l4(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32,
                          "", OCIO::OpData::Descriptions(),
                          OCIO::INTERP_LINEAR, 33);  
 
-    OIIO_CHECK_ASSERT(l1 == l4);
+    OCIO_CHECK_ASSERT(l1 == l4);
 
     // Inversion quality does not affect forward ops equality.
     l1.setInversionQuality(OCIO::LUT_INVERSION_BEST);
 
-    OIIO_CHECK_ASSERT(l1 == l4);
+    OCIO_CHECK_ASSERT(l1 == l4);
 
     // Inversion quality does not affect inverse ops equality.
     // Even so applying the ops could lead to small differences.
     auto l5 = l1.inverse();
     auto l6 = l4.inverse();
 
-    OIIO_CHECK_ASSERT(*l5 == *l6);
+    OCIO_CHECK_ASSERT(*l5 == *l6);
 }
 
-OIIO_ADD_TEST(Lut3DOpData, interpolation)
+OCIO_ADD_TEST(Lut3DOpData, interpolation)
 {
     OCIO::Lut3DOpData l(2);
     l.setInputBitDepth(OCIO::BIT_DEPTH_F32);
     l.setOutputBitDepth(OCIO::BIT_DEPTH_F32);
     
     l.setInterpolation(OCIO::INTERP_LINEAR);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_NO_THROW(l.validate());
 
     l.setInterpolation(OCIO::INTERP_CUBIC);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_CUBIC);
-    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_THROW_WHAT(l.validate(), OCIO::Exception, "invalid interpolation");
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_CUBIC);
+    OCIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_THROW_WHAT(l.validate(), OCIO::Exception, "invalid interpolation");
 
     l.setInterpolation(OCIO::INTERP_TETRAHEDRAL);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_TETRAHEDRAL);
-    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_TETRAHEDRAL);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_TETRAHEDRAL);
+    OCIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_TETRAHEDRAL);
+    OCIO_CHECK_NO_THROW(l.validate());
 
     l.setInterpolation(OCIO::INTERP_DEFAULT);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_DEFAULT);
-    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_DEFAULT);
+    OCIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_NO_THROW(l.validate());
 
     l.setInterpolation(OCIO::INTERP_BEST);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_BEST);
-    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_TETRAHEDRAL);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_BEST);
+    OCIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_TETRAHEDRAL);
+    OCIO_CHECK_NO_THROW(l.validate());
 
     // NB: INTERP_NEAREST is currently implemented as INTERP_LINEAR.
     l.setInterpolation(OCIO::INTERP_NEAREST);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_NEAREST);
-    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_NEAREST);
+    OCIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_NO_THROW(l.validate());
 
     // Invalid interpolation type are implemented as INTERP_LINEAR
     // but can not be used because validation throws.
     l.setInterpolation(OCIO::INTERP_UNKNOWN);
-    OIIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_UNKNOWN);
-    OIIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
-    OIIO_CHECK_THROW_WHAT(l.validate(), OCIO::Exception, "invalid interpolation");
+    OCIO_CHECK_EQUAL(l.getInterpolation(), OCIO::INTERP_UNKNOWN);
+    OCIO_CHECK_EQUAL(l.getConcreteInterpolation(), OCIO::INTERP_LINEAR);
+    OCIO_CHECK_THROW_WHAT(l.validate(), OCIO::Exception, "invalid interpolation");
 }
 
-OIIO_ADD_TEST(Lut3DOpData, inversion_quality)
+OCIO_ADD_TEST(Lut3DOpData, inversion_quality)
 {
     OCIO::Lut3DOpData l(2);
     l.setInputBitDepth(OCIO::BIT_DEPTH_F32);
     l.setOutputBitDepth(OCIO::BIT_DEPTH_F32);
 
     l.setInversionQuality(OCIO::LUT_INVERSION_EXACT);
-    OIIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_EXACT);
-    OIIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_EXACT);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_EXACT);
+    OCIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_EXACT);
+    OCIO_CHECK_NO_THROW(l.validate());
 
     l.setInversionQuality(OCIO::LUT_INVERSION_FAST);
-    OIIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_FAST);
-    OIIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_FAST);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_FAST);
+    OCIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_FAST);
+    OCIO_CHECK_NO_THROW(l.validate());
 
     l.setInversionQuality(OCIO::LUT_INVERSION_DEFAULT);
-    OIIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_DEFAULT);
-    OIIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_FAST);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_DEFAULT);
+    OCIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_FAST);
+    OCIO_CHECK_NO_THROW(l.validate());
 
     l.setInversionQuality(OCIO::LUT_INVERSION_BEST);
-    OIIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_BEST);
-    OIIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_EXACT);
-    OIIO_CHECK_NO_THROW(l.validate());
+    OCIO_CHECK_EQUAL(l.getInversionQuality(), OCIO::LUT_INVERSION_BEST);
+    OCIO_CHECK_EQUAL(l.getConcreteInversionQuality(), OCIO::LUT_INVERSION_EXACT);
+    OCIO_CHECK_NO_THROW(l.validate());
 }
 
 namespace
@@ -907,19 +907,19 @@ void checkInverse_bitDepths_domain(
     // Get inverse of reference 3D LUT operation 
     OCIO::Lut3DOpDataRcPtr invLut3d = refLut3d.inverse();
 
-    OIIO_CHECK_ASSERT(invLut3d);
+    OCIO_CHECK_ASSERT(invLut3d);
 
-    OIIO_CHECK_EQUAL(invLut3d->getInputBitDepth(),
+    OCIO_CHECK_EQUAL(invLut3d->getInputBitDepth(),
                      expectedInvInputBitDepth);
 
-    OIIO_CHECK_EQUAL(invLut3d->getOutputBitDepth(),
+    OCIO_CHECK_EQUAL(invLut3d->getOutputBitDepth(),
                      expectedInvOutputBitDepth);
 
-    OIIO_CHECK_EQUAL(invLut3d->getInterpolation(),
+    OCIO_CHECK_EQUAL(invLut3d->getInterpolation(),
                      expectedInvInterpolationAlgo);
 }
 
-OIIO_ADD_TEST(Lut3DOpData, inverse_bitDepth_domain)
+OCIO_ADD_TEST(Lut3DOpData, inverse_bitDepth_domain)
 {
     checkInverse_bitDepths_domain(
         // reference
@@ -938,7 +938,7 @@ OIIO_ADD_TEST(Lut3DOpData, inverse_bitDepth_domain)
         OCIO::INTERP_TETRAHEDRAL);
 }
 
-OIIO_ADD_TEST(Lut3DOpData, is_inverse)
+OCIO_ADD_TEST(Lut3DOpData, is_inverse)
 {
     // Create forward LUT.
     OCIO::Lut3DOpDataRcPtr L1NC =
@@ -948,52 +948,52 @@ OIIO_ADD_TEST(Lut3DOpData, is_inverse)
     OCIO::Array& array = L1NC->getArray();
     OCIO::Array::Values& values = array.getValues();
     values[0] = 20.f;
-    OIIO_CHECK_ASSERT(!L1NC->isIdentity());
+    OCIO_CHECK_ASSERT(!L1NC->isIdentity());
 
     // Create an inverse LUT with same basics.
     OCIO::ConstLut3DOpDataRcPtr L1 = L1NC;
     OCIO::ConstLut3DOpDataRcPtr L2 = L1->inverse();
     OCIO::ConstLut3DOpDataRcPtr L3 = L2->inverse();
-    OIIO_CHECK_ASSERT(*L3 == *L1);
-    OIIO_CHECK_ASSERT(!(*L1 == *L2));
+    OCIO_CHECK_ASSERT(*L3 == *L1);
+    OCIO_CHECK_ASSERT(!(*L1 == *L2));
 
     // Check isInverse.
-    OIIO_CHECK_ASSERT(L1->isInverse(L2));
-    OIIO_CHECK_ASSERT(L2->isInverse(L1));
+    OCIO_CHECK_ASSERT(L1->isInverse(L2));
+    OCIO_CHECK_ASSERT(L2->isInverse(L1));
 
     // This should pass, since the arrays are actually the same if you
     // normalize for the scaling difference.
     L1NC->setOutputBitDepth(OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_ASSERT(L1->isInverse(L2));
-    OIIO_CHECK_ASSERT(L2->isInverse(L1));
+    OCIO_CHECK_ASSERT(L1->isInverse(L2));
+    OCIO_CHECK_ASSERT(L2->isInverse(L1));
 
     // Catch the situation where the arrays are the same even though the
     // bit-depths don't match and hence the arrays effectively aren't the same.
     L1NC->setOutputBitDepth(OCIO::BIT_DEPTH_UINT10);  // restore original
-    OIIO_CHECK_ASSERT(L1->isInverse(L2));
+    OCIO_CHECK_ASSERT(L1->isInverse(L2));
     L1NC->OpData::setOutputBitDepth(OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_ASSERT(!L1->isInverse(L2));
-    OIIO_CHECK_ASSERT(!L2->isInverse(L1));
+    OCIO_CHECK_ASSERT(!L1->isInverse(L2));
+    OCIO_CHECK_ASSERT(!L2->isInverse(L1));
 }
 
-OIIO_ADD_TEST(Lut3DOpData, compose)
+OCIO_ADD_TEST(Lut3DOpData, compose)
 {
     const std::string spi3dFile("spi_ocio_srgb_test.spi3d");
     OCIO::OpRcPtrVec ops;
 
     OCIO::ContextRcPtr context = OCIO::Context::Create();
-    OIIO_CHECK_NO_THROW(BuildOpsTest(ops, spi3dFile, context,
+    OCIO_CHECK_NO_THROW(BuildOpsTest(ops, spi3dFile, context,
                                      OCIO::TRANSFORM_DIR_FORWARD));
 
     // First op is a FileNoOp.
-    OIIO_REQUIRE_EQUAL(2, ops.size());
+    OCIO_REQUIRE_EQUAL(2, ops.size());
 
     const std::string spi3dFile1("comp2.spi3d");
     OCIO::OpRcPtrVec ops1;
-    OIIO_CHECK_NO_THROW(BuildOpsTest(ops1, spi3dFile1, context,
+    OCIO_CHECK_NO_THROW(BuildOpsTest(ops1, spi3dFile1, context,
                                      OCIO::TRANSFORM_DIR_FORWARD));
 
-    OIIO_REQUIRE_EQUAL(2, ops1.size());
+    OCIO_REQUIRE_EQUAL(2, ops1.size());
 
     OCIO_SHARED_PTR<const OCIO::Op> op0 = ops[1];
     OCIO_SHARED_PTR<const OCIO::Op> op1 = ops1[1];
@@ -1006,53 +1006,53 @@ OIIO_ADD_TEST(Lut3DOpData, compose)
     OCIO::ConstLut3DOpDataRcPtr lutData1 =
         OCIO::DynamicPtrCast<const OCIO::Lut3DOpData>(opData1);
 
-    OIIO_REQUIRE_ASSERT(lutData0);
-    OIIO_REQUIRE_ASSERT(lutData1);
+    OCIO_REQUIRE_ASSERT(lutData0);
+    OCIO_REQUIRE_ASSERT(lutData1);
 
     OCIO::Lut3DOpDataRcPtr composed = lutData0->clone();
     OCIO::Lut3DOpData::Compose(composed, lutData1);
 
-    OIIO_CHECK_EQUAL(composed->getArray().getLength(), (unsigned long)32);
-    OIIO_CHECK_EQUAL(composed->getArray().getNumColorComponents(),
+    OCIO_CHECK_EQUAL(composed->getArray().getLength(), (unsigned long)32);
+    OCIO_CHECK_EQUAL(composed->getArray().getNumColorComponents(),
         (unsigned long)3);
-    OIIO_CHECK_EQUAL(composed->getArray().getNumValues(),
+    OCIO_CHECK_EQUAL(composed->getArray().getNumValues(),
         (unsigned long)32 * 32 * 32 * 3);
 
-    OIIO_CHECK_CLOSE(composed->getArray().getValues()[0], 0.0288210791f, 1e-7f);
-    OIIO_CHECK_CLOSE(composed->getArray().getValues()[1], 0.0280428901f, 1e-7f);
-    OIIO_CHECK_CLOSE(composed->getArray().getValues()[2], 0.0262413863f, 1e-7f);
+    OCIO_CHECK_CLOSE(composed->getArray().getValues()[0], 0.0288210791f, 1e-7f);
+    OCIO_CHECK_CLOSE(composed->getArray().getValues()[1], 0.0280428901f, 1e-7f);
+    OCIO_CHECK_CLOSE(composed->getArray().getValues()[2], 0.0262413863f, 1e-7f);
 
-    OIIO_CHECK_CLOSE(composed->getArray().getValues()[666], 0.0f, 1e-7f);
-    OIIO_CHECK_CLOSE(composed->getArray().getValues()[667], 0.274289876f, 1e-7f);
-    OIIO_CHECK_CLOSE(composed->getArray().getValues()[668], 0.854598403f, 1e-7f);
+    OCIO_CHECK_CLOSE(composed->getArray().getValues()[666], 0.0f, 1e-7f);
+    OCIO_CHECK_CLOSE(composed->getArray().getValues()[667], 0.274289876f, 1e-7f);
+    OCIO_CHECK_CLOSE(composed->getArray().getValues()[668], 0.854598403f, 1e-7f);
 
-    OIIO_CHECK_CLOSE(composed->getArray().getValues()[1800], 0.0f, 1e-7f);
-    OIIO_CHECK_CLOSE(composed->getArray().getValues()[1801], 0.411249638f, 1e-7f);
-    OIIO_CHECK_CLOSE(composed->getArray().getValues()[1802], 0.881694913f, 1e-7f);
+    OCIO_CHECK_CLOSE(composed->getArray().getValues()[1800], 0.0f, 1e-7f);
+    OCIO_CHECK_CLOSE(composed->getArray().getValues()[1801], 0.411249638f, 1e-7f);
+    OCIO_CHECK_CLOSE(composed->getArray().getValues()[1802], 0.881694913f, 1e-7f);
 
-    OIIO_CHECK_CLOSE(composed->getArray().getValues()[96903], 1.0f, 1e-7f);
-    OIIO_CHECK_CLOSE(composed->getArray().getValues()[96904], 0.588273168f, 1e-7f);
-    OIIO_CHECK_CLOSE(composed->getArray().getValues()[96905], 0.0f, 1e-7f);
+    OCIO_CHECK_CLOSE(composed->getArray().getValues()[96903], 1.0f, 1e-7f);
+    OCIO_CHECK_CLOSE(composed->getArray().getValues()[96904], 0.588273168f, 1e-7f);
+    OCIO_CHECK_CLOSE(composed->getArray().getValues()[96905], 0.0f, 1e-7f);
 
 }
 
-OIIO_ADD_TEST(Lut3DOpData, compose_2)
+OCIO_ADD_TEST(Lut3DOpData, compose_2)
 {
     const std::string clfFile("lut3d_bizarre.clf");
     OCIO::OpRcPtrVec ops;
 
     OCIO::ContextRcPtr context = OCIO::Context::Create();
-    OIIO_CHECK_NO_THROW(BuildOpsTest(ops, clfFile, context,
+    OCIO_CHECK_NO_THROW(BuildOpsTest(ops, clfFile, context,
                                      OCIO::TRANSFORM_DIR_FORWARD));
 
-    OIIO_REQUIRE_EQUAL(2, ops.size());
+    OCIO_REQUIRE_EQUAL(2, ops.size());
 
     const std::string clfFile1("lut3d_17x17x17_10i_12i.clf");
     OCIO::OpRcPtrVec ops1;
-    OIIO_CHECK_NO_THROW(BuildOpsTest(ops1, clfFile1, context,
+    OCIO_CHECK_NO_THROW(BuildOpsTest(ops1, clfFile1, context,
                                      OCIO::TRANSFORM_DIR_FORWARD));
 
-    OIIO_REQUIRE_EQUAL(2, ops1.size());
+    OCIO_REQUIRE_EQUAL(2, ops1.size());
 
     OCIO_SHARED_PTR<const OCIO::Op> op0 = ops[1];
     OCIO_SHARED_PTR<const OCIO::Op> op1 = ops1[1];
@@ -1065,55 +1065,55 @@ OIIO_ADD_TEST(Lut3DOpData, compose_2)
     OCIO::ConstLut3DOpDataRcPtr lutData1 =
         OCIO::DynamicPtrCast<const OCIO::Lut3DOpData>(opData1);
 
-    OIIO_REQUIRE_ASSERT(lutData0);
-    OIIO_REQUIRE_ASSERT(lutData1);
+    OCIO_REQUIRE_ASSERT(lutData0);
+    OCIO_REQUIRE_ASSERT(lutData1);
 
     OCIO::Lut3DOpDataRcPtr composed = lutData0->clone();
-    OIIO_CHECK_NO_THROW(OCIO::Lut3DOpData::Compose(composed, lutData1));
+    OCIO_CHECK_NO_THROW(OCIO::Lut3DOpData::Compose(composed, lutData1));
 
-    OIIO_CHECK_EQUAL(composed->getArray().getLength(), (unsigned long)17);
+    OCIO_CHECK_EQUAL(composed->getArray().getLength(), (unsigned long)17);
     const std::vector<float> & a = composed->getArray().getValues();
-    OIIO_CHECK_CLOSE(a[6]     / 4095.0f,    2.5942142f  / 4095.0f, 1e-7f);
-    OIIO_CHECK_CLOSE(a[7]     / 4095.0f,   29.60961342f / 4095.0f, 1e-7f);
-    OIIO_CHECK_CLOSE(a[8]     / 4095.0f,  154.82646179f / 4095.0f, 1e-7f);
-    OIIO_CHECK_CLOSE(a[8289]  / 4095.0f, 1184.69213867f / 4095.0f, 1e-6f);
-    OIIO_CHECK_CLOSE(a[8290]  / 4095.0f, 1854.97229004f / 4095.0f, 1e-7f);
-    OIIO_CHECK_CLOSE(a[8291]  / 4095.0f, 1996.75830078f / 4095.0f, 1e-7f);
-    OIIO_CHECK_CLOSE(a[14736] / 4095.0f, 4094.07617188f / 4095.0f, 1e-7f);
-    OIIO_CHECK_CLOSE(a[14737] / 4095.0f, 4067.37231445f / 4095.0f, 1e-6f);
-    OIIO_CHECK_CLOSE(a[14738] / 4095.0f, 4088.30493164f / 4095.0f, 1e-6f);
+    OCIO_CHECK_CLOSE(a[6]     / 4095.0f,    2.5942142f  / 4095.0f, 1e-7f);
+    OCIO_CHECK_CLOSE(a[7]     / 4095.0f,   29.60961342f / 4095.0f, 1e-7f);
+    OCIO_CHECK_CLOSE(a[8]     / 4095.0f,  154.82646179f / 4095.0f, 1e-7f);
+    OCIO_CHECK_CLOSE(a[8289]  / 4095.0f, 1184.69213867f / 4095.0f, 1e-6f);
+    OCIO_CHECK_CLOSE(a[8290]  / 4095.0f, 1854.97229004f / 4095.0f, 1e-7f);
+    OCIO_CHECK_CLOSE(a[8291]  / 4095.0f, 1996.75830078f / 4095.0f, 1e-7f);
+    OCIO_CHECK_CLOSE(a[14736] / 4095.0f, 4094.07617188f / 4095.0f, 1e-7f);
+    OCIO_CHECK_CLOSE(a[14737] / 4095.0f, 4067.37231445f / 4095.0f, 1e-6f);
+    OCIO_CHECK_CLOSE(a[14738] / 4095.0f, 4088.30493164f / 4095.0f, 1e-6f);
 
     // Check that if the connecting bit-depths don't match, it's an exception.
     OCIO::Lut3DOpDataRcPtr composed1 = lutData1->clone();
-    OIIO_CHECK_THROW_WHAT(OCIO::Lut3DOpData::Compose(composed1, lutData0),
+    OCIO_CHECK_THROW_WHAT(OCIO::Lut3DOpData::Compose(composed1, lutData0),
                           OCIO::Exception, "bit depth mismatch");
 
 }
 
-OIIO_ADD_TEST(Lut3DOpData, inv_lut3d_lut_size)
+OCIO_ADD_TEST(Lut3DOpData, inv_lut3d_lut_size)
 {
     const std::string fileName("lut3d_17x17x17_10i_12i.clf");
     OCIO::OpRcPtrVec ops;
     OCIO::ContextRcPtr context = OCIO::Context::Create();
-    OIIO_CHECK_NO_THROW(BuildOpsTest(ops, fileName, context,
+    OCIO_CHECK_NO_THROW(BuildOpsTest(ops, fileName, context,
                                      OCIO::TRANSFORM_DIR_FORWARD));
 
-    OIIO_REQUIRE_EQUAL(2, ops.size());
+    OCIO_REQUIRE_EQUAL(2, ops.size());
 
     auto op1 = std::dynamic_pointer_cast<const OCIO::Op>(ops[1]);
-    OIIO_REQUIRE_ASSERT(op1);
+    OCIO_REQUIRE_ASSERT(op1);
     auto fwdLutData = std::dynamic_pointer_cast<const OCIO::Lut3DOpData>(op1->data());
-    OIIO_REQUIRE_ASSERT(fwdLutData);
+    OCIO_REQUIRE_ASSERT(fwdLutData);
     OCIO::ConstLut3DOpDataRcPtr invLutData = fwdLutData->inverse();
 
     OCIO::Lut3DOpDataRcPtr invFastLutData = MakeFastLut3DFromInverse(invLutData);
 
     // NB: Avoid finalizing the transform since this will reset the bit-depths
     // and prevent checking that the inversion swapped them correctly.
-    OIIO_CHECK_EQUAL(invFastLutData->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL(invFastLutData->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(invFastLutData->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(invFastLutData->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
 
-    OIIO_CHECK_EQUAL(invFastLutData->getArray().getLength(), 48);
+    OCIO_CHECK_EQUAL(invFastLutData->getArray().getLength(), 48);
 }
 
 #endif

--- a/src/OpenColorIO/ops/Matrix/MatrixOpCPU.cpp
+++ b/src/OpenColorIO/ops/Matrix/MatrixOpCPU.cpp
@@ -452,7 +452,7 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 // TODO: syncolor also tests various bit-depths and pixel formats.
 // CPURenderer_cases.cpp_inc - CPURendererMatrix
@@ -464,28 +464,28 @@ namespace OCIO = OCIO_NAMESPACE;
 
 OCIO_NAMESPACE_USING
 
-OIIO_ADD_TEST(MatrixOpCPU, scale_renderer)
+OCIO_ADD_TEST(MatrixOpCPU, scale_renderer)
 {
     ConstMatrixOpDataRcPtr mat(MatrixOpData::CreateDiagonalMatrix(
         OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, 2.0));
 
     OpCPURcPtr op = GetMatrixRenderer(mat);
-    OIIO_CHECK_ASSERT((bool)op);
+    OCIO_CHECK_ASSERT((bool)op);
 
     ScaleRenderer* scaleOp = dynamic_cast<ScaleRenderer*>(op.get());
-    OIIO_CHECK_ASSERT(scaleOp);
+    OCIO_CHECK_ASSERT(scaleOp);
 
     float rgba[4] = { 4.f, 3.f, 2.f, 1.f };
 
     op->apply(rgba, rgba, 1);
 
-    OIIO_CHECK_EQUAL(rgba[0], 8.f);
-    OIIO_CHECK_EQUAL(rgba[1], 6.f);
-    OIIO_CHECK_EQUAL(rgba[2], 4.f);
-    OIIO_CHECK_EQUAL(rgba[3], 2.f);
+    OCIO_CHECK_EQUAL(rgba[0], 8.f);
+    OCIO_CHECK_EQUAL(rgba[1], 6.f);
+    OCIO_CHECK_EQUAL(rgba[2], 4.f);
+    OCIO_CHECK_EQUAL(rgba[3], 2.f);
 }
 
-OIIO_ADD_TEST(MatrixOpCPU, scale_with_offset_renderer)
+OCIO_ADD_TEST(MatrixOpCPU, scale_with_offset_renderer)
 {
     MatrixOpDataRcPtr mat(MatrixOpData::CreateDiagonalMatrix(
         OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, 2.0));
@@ -497,23 +497,23 @@ OIIO_ADD_TEST(MatrixOpCPU, scale_with_offset_renderer)
 
     OCIO::ConstMatrixOpDataRcPtr m = OCIO::DynamicPtrCast<const OCIO::MatrixOpData>(mat);
     OpCPURcPtr op = GetMatrixRenderer(m);
-    OIIO_CHECK_ASSERT((bool)op);
+    OCIO_CHECK_ASSERT((bool)op);
 
     ScaleWithOffsetRenderer* scaleOffOp = dynamic_cast<ScaleWithOffsetRenderer*>(op.get());
-    OIIO_CHECK_ASSERT(scaleOffOp);
+    OCIO_CHECK_ASSERT(scaleOffOp);
 
     float rgba[4] = { 4.f, 3.f, 2.f, 1.f };
 
     op->apply(rgba, rgba, 1);
 
-    OIIO_CHECK_EQUAL(rgba[0], 9.f);
-    OIIO_CHECK_EQUAL(rgba[1], 8.f);
-    OIIO_CHECK_EQUAL(rgba[2], 7.f);
-    OIIO_CHECK_EQUAL(rgba[3], 6.f);
+    OCIO_CHECK_EQUAL(rgba[0], 9.f);
+    OCIO_CHECK_EQUAL(rgba[1], 8.f);
+    OCIO_CHECK_EQUAL(rgba[2], 7.f);
+    OCIO_CHECK_EQUAL(rgba[3], 6.f);
 }
 
 
-OIIO_ADD_TEST(MatrixOpCPU, matrix_with_offset_renderer)
+OCIO_ADD_TEST(MatrixOpCPU, matrix_with_offset_renderer)
 {
     MatrixOpDataRcPtr mat(MatrixOpData::CreateDiagonalMatrix(
         OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, 2.0));
@@ -529,22 +529,22 @@ OIIO_ADD_TEST(MatrixOpCPU, matrix_with_offset_renderer)
 
     OCIO::ConstMatrixOpDataRcPtr m = OCIO::DynamicPtrCast<const OCIO::MatrixOpData>(mat);
     OpCPURcPtr op = GetMatrixRenderer(m);
-    OIIO_CHECK_ASSERT((bool)op);
+    OCIO_CHECK_ASSERT((bool)op);
 
     MatrixWithOffsetRenderer* matOffOp = dynamic_cast<MatrixWithOffsetRenderer*>(op.get());
-    OIIO_CHECK_ASSERT(matOffOp);
+    OCIO_CHECK_ASSERT(matOffOp);
 
     float rgba[4] = { 4.f, 3.f, 2.f, 1.f };
 
     op->apply(rgba, rgba, 1);
 
-    OIIO_CHECK_EQUAL(rgba[0], 9.5f);
-    OIIO_CHECK_EQUAL(rgba[1], 8.f);
-    OIIO_CHECK_EQUAL(rgba[2], 7.f);
-    OIIO_CHECK_EQUAL(rgba[3], 6.f);
+    OCIO_CHECK_EQUAL(rgba[0], 9.5f);
+    OCIO_CHECK_EQUAL(rgba[1], 8.f);
+    OCIO_CHECK_EQUAL(rgba[2], 7.f);
+    OCIO_CHECK_EQUAL(rgba[3], 6.f);
 }
 
-OIIO_ADD_TEST(MatrixOpCPU, matrix_renderer)
+OCIO_ADD_TEST(MatrixOpCPU, matrix_renderer)
 {
     MatrixOpDataRcPtr mat(MatrixOpData::CreateDiagonalMatrix(
         OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, 2.0));
@@ -554,19 +554,19 @@ OIIO_ADD_TEST(MatrixOpCPU, matrix_renderer)
 
     OCIO::ConstMatrixOpDataRcPtr m = OCIO::DynamicPtrCast<const OCIO::MatrixOpData>(mat);
     OpCPURcPtr op = GetMatrixRenderer(m);
-    OIIO_CHECK_ASSERT((bool)op);
+    OCIO_CHECK_ASSERT((bool)op);
 
     MatrixRenderer* matOp = dynamic_cast<MatrixRenderer*>(op.get());
-    OIIO_CHECK_ASSERT(matOp);
+    OCIO_CHECK_ASSERT(matOp);
 
     float rgba[4] = { 4.f, 3.f, 2.f, 1.f };
 
     op->apply(rgba, rgba, 1);
 
-    OIIO_CHECK_EQUAL(rgba[0], 8.5f);
-    OIIO_CHECK_EQUAL(rgba[1], 6.f);
-    OIIO_CHECK_EQUAL(rgba[2], 4.f);
-    OIIO_CHECK_EQUAL(rgba[3], 2.f);
+    OCIO_CHECK_EQUAL(rgba[0], 8.5f);
+    OCIO_CHECK_EQUAL(rgba[1], 6.f);
+    OCIO_CHECK_EQUAL(rgba[2], 4.f);
+    OCIO_CHECK_EQUAL(rgba[3], 2.f);
 }
 
 

--- a/src/OpenColorIO/ops/Matrix/MatrixOpData.cpp
+++ b/src/OpenColorIO/ops/Matrix/MatrixOpData.cpp
@@ -969,109 +969,109 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(MatrixOpData, empty)
+OCIO_ADD_TEST(MatrixOpData, empty)
 {
     OCIO::MatrixOpData m;
-    OIIO_CHECK_ASSERT(m.isNoOp());
-    OIIO_CHECK_ASSERT(m.isUnityDiagonal());
-    OIIO_CHECK_ASSERT(m.isDiagonal());
-    OIIO_CHECK_NO_THROW(m.validate());
-    OIIO_CHECK_EQUAL(m.getType(), OCIO::OpData::MatrixType);
+    OCIO_CHECK_ASSERT(m.isNoOp());
+    OCIO_CHECK_ASSERT(m.isUnityDiagonal());
+    OCIO_CHECK_ASSERT(m.isDiagonal());
+    OCIO_CHECK_NO_THROW(m.validate());
+    OCIO_CHECK_EQUAL(m.getType(), OCIO::OpData::MatrixType);
 
-    OIIO_CHECK_EQUAL(m.getArray().getLength(), 4);
-    OIIO_CHECK_EQUAL(m.getArray().getNumValues(), 16);
-    OIIO_CHECK_EQUAL(m.getArray().getNumColorComponents(), 4);
+    OCIO_CHECK_EQUAL(m.getArray().getLength(), 4);
+    OCIO_CHECK_EQUAL(m.getArray().getNumValues(), 16);
+    OCIO_CHECK_EQUAL(m.getArray().getNumColorComponents(), 4);
 
     m.getArray().resize(3, 3);
 
-    OIIO_CHECK_EQUAL(m.getArray().getNumValues(), 9);
-    OIIO_CHECK_EQUAL(m.getArray().getLength(), 3);
-    OIIO_CHECK_EQUAL(m.getArray().getNumColorComponents(), 3);
-    OIIO_CHECK_NO_THROW(m.validate());
+    OCIO_CHECK_EQUAL(m.getArray().getNumValues(), 9);
+    OCIO_CHECK_EQUAL(m.getArray().getLength(), 3);
+    OCIO_CHECK_EQUAL(m.getArray().getNumColorComponents(), 3);
+    OCIO_CHECK_NO_THROW(m.validate());
 }
 
-OIIO_ADD_TEST(MatrixOpData, accessors)
+OCIO_ADD_TEST(MatrixOpData, accessors)
 {
     OCIO::MatrixOpData m(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_ASSERT(m.isNoOp());
-    OIIO_CHECK_ASSERT(m.isUnityDiagonal());
-    OIIO_CHECK_ASSERT(m.isDiagonal());
-    OIIO_CHECK_ASSERT(m.isIdentity());
-    OIIO_CHECK_NO_THROW(m.validate());
+    OCIO_CHECK_ASSERT(m.isNoOp());
+    OCIO_CHECK_ASSERT(m.isUnityDiagonal());
+    OCIO_CHECK_ASSERT(m.isDiagonal());
+    OCIO_CHECK_ASSERT(m.isIdentity());
+    OCIO_CHECK_NO_THROW(m.validate());
 
     m.setArrayValue(15, 1 + 1e-5f);
 
-    OIIO_CHECK_ASSERT(!m.isNoOp());
-    OIIO_CHECK_ASSERT(!m.isUnityDiagonal());
-    OIIO_CHECK_ASSERT(m.isDiagonal());
-    OIIO_CHECK_ASSERT(!m.isIdentity());
-    OIIO_CHECK_NO_THROW(m.validate());
+    OCIO_CHECK_ASSERT(!m.isNoOp());
+    OCIO_CHECK_ASSERT(!m.isUnityDiagonal());
+    OCIO_CHECK_ASSERT(m.isDiagonal());
+    OCIO_CHECK_ASSERT(!m.isIdentity());
+    OCIO_CHECK_NO_THROW(m.validate());
 
     m.setArrayValue(1, 1e-5f);
     m.setArrayValue(15, 1.0f);
 
-    OIIO_CHECK_ASSERT(!m.isNoOp());
-    OIIO_CHECK_ASSERT(!m.isUnityDiagonal());
-    OIIO_CHECK_ASSERT(!m.isDiagonal());
-    OIIO_CHECK_ASSERT(!m.isIdentity());
-    OIIO_CHECK_NO_THROW(m.validate());
+    OCIO_CHECK_ASSERT(!m.isNoOp());
+    OCIO_CHECK_ASSERT(!m.isUnityDiagonal());
+    OCIO_CHECK_ASSERT(!m.isDiagonal());
+    OCIO_CHECK_ASSERT(!m.isIdentity());
+    OCIO_CHECK_NO_THROW(m.validate());
 }
 
-OIIO_ADD_TEST(MatrixOpData, offsets)
+OCIO_ADD_TEST(MatrixOpData, offsets)
 {
     OCIO::MatrixOpData m(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_ASSERT(m.isNoOp());
-    OIIO_CHECK_ASSERT(m.isUnityDiagonal());
-    OIIO_CHECK_ASSERT(m.isDiagonal());
-    OIIO_CHECK_ASSERT(!m.hasOffsets());
-    OIIO_CHECK_NO_THROW(m.validate());
+    OCIO_CHECK_ASSERT(m.isNoOp());
+    OCIO_CHECK_ASSERT(m.isUnityDiagonal());
+    OCIO_CHECK_ASSERT(m.isDiagonal());
+    OCIO_CHECK_ASSERT(!m.hasOffsets());
+    OCIO_CHECK_NO_THROW(m.validate());
 
     m.setOffsetValue(2, 1.0f);
-    OIIO_CHECK_ASSERT(!m.isNoOp());
-    OIIO_CHECK_ASSERT(m.isUnityDiagonal());
-    OIIO_CHECK_ASSERT(m.isDiagonal());
-    OIIO_CHECK_ASSERT(m.hasOffsets());
-    OIIO_CHECK_NO_THROW(m.validate());
-    OIIO_CHECK_EQUAL(m.getOffsets()[2], 1.0f);
+    OCIO_CHECK_ASSERT(!m.isNoOp());
+    OCIO_CHECK_ASSERT(m.isUnityDiagonal());
+    OCIO_CHECK_ASSERT(m.isDiagonal());
+    OCIO_CHECK_ASSERT(m.hasOffsets());
+    OCIO_CHECK_NO_THROW(m.validate());
+    OCIO_CHECK_EQUAL(m.getOffsets()[2], 1.0f);
 }
 
-OIIO_ADD_TEST(MatrixOpData, offsets4)
+OCIO_ADD_TEST(MatrixOpData, offsets4)
 {
     OCIO::MatrixOpData m(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_ASSERT(m.isNoOp());
-    OIIO_CHECK_ASSERT(m.isUnityDiagonal());
-    OIIO_CHECK_ASSERT(m.isDiagonal());
-    OIIO_CHECK_ASSERT(!m.hasOffsets());
-    OIIO_CHECK_NO_THROW(m.validate());
+    OCIO_CHECK_ASSERT(m.isNoOp());
+    OCIO_CHECK_ASSERT(m.isUnityDiagonal());
+    OCIO_CHECK_ASSERT(m.isDiagonal());
+    OCIO_CHECK_ASSERT(!m.hasOffsets());
+    OCIO_CHECK_NO_THROW(m.validate());
 
     m.setOffsetValue(3, -1e-6f);
-    OIIO_CHECK_ASSERT(!m.isNoOp());
-    OIIO_CHECK_ASSERT(m.isUnityDiagonal());
-    OIIO_CHECK_ASSERT(m.isDiagonal());
-    OIIO_CHECK_ASSERT(m.hasOffsets());
-    OIIO_CHECK_NO_THROW(m.validate());
-    OIIO_CHECK_EQUAL(m.getOffsets()[3], -1e-6f);
+    OCIO_CHECK_ASSERT(!m.isNoOp());
+    OCIO_CHECK_ASSERT(m.isUnityDiagonal());
+    OCIO_CHECK_ASSERT(m.isDiagonal());
+    OCIO_CHECK_ASSERT(m.hasOffsets());
+    OCIO_CHECK_NO_THROW(m.validate());
+    OCIO_CHECK_EQUAL(m.getOffsets()[3], -1e-6f);
 }
 
-OIIO_ADD_TEST(MatrixOpData, diagonal)
+OCIO_ADD_TEST(MatrixOpData, diagonal)
 {
     OCIO::MatrixOpDataRcPtr pM = OCIO::MatrixOpData::CreateDiagonalMatrix(
         OCIO::BIT_DEPTH_UINT8,
         OCIO::BIT_DEPTH_UINT8, 
         0.5);
 
-    OIIO_CHECK_ASSERT(pM->isDiagonal());
-    OIIO_CHECK_ASSERT(!pM->hasOffsets());
-    OIIO_CHECK_NO_THROW(pM->validate());
-    OIIO_CHECK_EQUAL(pM->getArray().getValues()[0], 0.5);
-    OIIO_CHECK_EQUAL(pM->getArray().getValues()[5], 0.5);
-    OIIO_CHECK_EQUAL(pM->getArray().getValues()[10], 0.5);
-    OIIO_CHECK_EQUAL(pM->getArray().getValues()[15], 0.5);
+    OCIO_CHECK_ASSERT(pM->isDiagonal());
+    OCIO_CHECK_ASSERT(!pM->hasOffsets());
+    OCIO_CHECK_NO_THROW(pM->validate());
+    OCIO_CHECK_EQUAL(pM->getArray().getValues()[0], 0.5);
+    OCIO_CHECK_EQUAL(pM->getArray().getValues()[5], 0.5);
+    OCIO_CHECK_EQUAL(pM->getArray().getValues()[10], 0.5);
+    OCIO_CHECK_EQUAL(pM->getArray().getValues()[15], 0.5);
 }
 
-OIIO_ADD_TEST(MatrixOpData, clone)
+OCIO_ADD_TEST(MatrixOpData, clone)
 {
     OCIO::MatrixOpData ref;
     ref.setOffsetValue(2, 1.0f);
@@ -1079,20 +1079,20 @@ OIIO_ADD_TEST(MatrixOpData, clone)
 
     OCIO::MatrixOpDataRcPtr pClone = ref.clone();
 
-    OIIO_CHECK_ASSERT(pClone.get());
-    OIIO_CHECK_ASSERT(!pClone->isNoOp());
-    OIIO_CHECK_ASSERT(!pClone->isUnityDiagonal());
-    OIIO_CHECK_ASSERT(pClone->isDiagonal());
-    OIIO_CHECK_NO_THROW(pClone->validate());
-    OIIO_CHECK_EQUAL(pClone->getType(), OCIO::OpData::MatrixType);
-    OIIO_CHECK_EQUAL(pClone->getOffsets()[0], 0.0f);
-    OIIO_CHECK_EQUAL(pClone->getOffsets()[1], 0.0f);
-    OIIO_CHECK_EQUAL(pClone->getOffsets()[2], 1.0f);
-    OIIO_CHECK_EQUAL(pClone->getOffsets()[3], 0.0f);
-    OIIO_CHECK_ASSERT(pClone->getArray() == ref.getArray());
+    OCIO_CHECK_ASSERT(pClone.get());
+    OCIO_CHECK_ASSERT(!pClone->isNoOp());
+    OCIO_CHECK_ASSERT(!pClone->isUnityDiagonal());
+    OCIO_CHECK_ASSERT(pClone->isDiagonal());
+    OCIO_CHECK_NO_THROW(pClone->validate());
+    OCIO_CHECK_EQUAL(pClone->getType(), OCIO::OpData::MatrixType);
+    OCIO_CHECK_EQUAL(pClone->getOffsets()[0], 0.0f);
+    OCIO_CHECK_EQUAL(pClone->getOffsets()[1], 0.0f);
+    OCIO_CHECK_EQUAL(pClone->getOffsets()[2], 1.0f);
+    OCIO_CHECK_EQUAL(pClone->getOffsets()[3], 0.0f);
+    OCIO_CHECK_ASSERT(pClone->getArray() == ref.getArray());
 }
 
-OIIO_ADD_TEST(MatrixOpData, clone_offsets4)
+OCIO_ADD_TEST(MatrixOpData, clone_offsets4)
 {
     OCIO::MatrixOpData ref;
     ref.setOffsetValue(0, 1.0f);
@@ -1103,34 +1103,34 @@ OIIO_ADD_TEST(MatrixOpData, clone_offsets4)
 
     OCIO::MatrixOpDataRcPtr pClone = ref.clone();
 
-    OIIO_CHECK_ASSERT(pClone.get());
-    OIIO_CHECK_ASSERT(!pClone->isNoOp());
-    OIIO_CHECK_ASSERT(!pClone->isUnityDiagonal());
-    OIIO_CHECK_ASSERT(pClone->isDiagonal());
-    OIIO_CHECK_NO_THROW(pClone->validate());
-    OIIO_CHECK_EQUAL(pClone->getType(), OCIO::OpData::MatrixType);
-    OIIO_CHECK_EQUAL(pClone->getOffsets()[0], 1.0f);
-    OIIO_CHECK_EQUAL(pClone->getOffsets()[1], 2.0f);
-    OIIO_CHECK_EQUAL(pClone->getOffsets()[2], 3.0f);
-    OIIO_CHECK_EQUAL(pClone->getOffsets()[3], 4.0f);
-    OIIO_CHECK_ASSERT(pClone->getArray() == ref.getArray());
+    OCIO_CHECK_ASSERT(pClone.get());
+    OCIO_CHECK_ASSERT(!pClone->isNoOp());
+    OCIO_CHECK_ASSERT(!pClone->isUnityDiagonal());
+    OCIO_CHECK_ASSERT(pClone->isDiagonal());
+    OCIO_CHECK_NO_THROW(pClone->validate());
+    OCIO_CHECK_EQUAL(pClone->getType(), OCIO::OpData::MatrixType);
+    OCIO_CHECK_EQUAL(pClone->getOffsets()[0], 1.0f);
+    OCIO_CHECK_EQUAL(pClone->getOffsets()[1], 2.0f);
+    OCIO_CHECK_EQUAL(pClone->getOffsets()[2], 3.0f);
+    OCIO_CHECK_EQUAL(pClone->getOffsets()[3], 4.0f);
+    OCIO_CHECK_ASSERT(pClone->getArray() == ref.getArray());
 }
 
-OIIO_ADD_TEST(MatrixOpData, diff_bitdepth)
+OCIO_ADD_TEST(MatrixOpData, diff_bitdepth)
 {
     OCIO::MatrixOpData m1(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_ASSERT(m1.isNoOp());
-    OIIO_CHECK_ASSERT(m1.isUnityDiagonal());
-    OIIO_CHECK_ASSERT(m1.isDiagonal());
-    OIIO_CHECK_ASSERT(!m1.hasOffsets());
-    OIIO_CHECK_NO_THROW(m1.validate());
+    OCIO_CHECK_ASSERT(m1.isNoOp());
+    OCIO_CHECK_ASSERT(m1.isUnityDiagonal());
+    OCIO_CHECK_ASSERT(m1.isDiagonal());
+    OCIO_CHECK_ASSERT(!m1.hasOffsets());
+    OCIO_CHECK_NO_THROW(m1.validate());
 
     OCIO::MatrixOpData m2(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT10);
-    OIIO_CHECK_ASSERT(!m2.isNoOp());
-    OIIO_CHECK_ASSERT(!m2.isUnityDiagonal());
-    OIIO_CHECK_ASSERT(m2.isDiagonal());
-    OIIO_CHECK_ASSERT(!m2.hasOffsets());
-    OIIO_CHECK_NO_THROW(m2.validate());
+    OCIO_CHECK_ASSERT(!m2.isNoOp());
+    OCIO_CHECK_ASSERT(!m2.isUnityDiagonal());
+    OCIO_CHECK_ASSERT(m2.isDiagonal());
+    OCIO_CHECK_ASSERT(!m2.hasOffsets());
+    OCIO_CHECK_NO_THROW(m2.validate());
 
     const double coeff
         = (double)OCIO::GetBitDepthMaxValue(m2.getOutputBitDepth())
@@ -1141,74 +1141,74 @@ OIIO_ADD_TEST(MatrixOpData, diff_bitdepth)
     // not using the MatrixOpData algorithm.
     for (unsigned long idx = 0; idx<3; ++idx)
     {
-        OIIO_CHECK_CLOSE(m1.getArray().getValues()[idx * 5] * coeff,
+        OCIO_CHECK_CLOSE(m1.getArray().getValues()[idx * 5] * coeff,
                          m2.getArray().getValues()[idx * 5], error);
     }
 }
 
-OIIO_ADD_TEST(MatrixOpData, test_construct)
+OCIO_ADD_TEST(MatrixOpData, test_construct)
 {
     OCIO::MatrixOpData matOp;
 
-    OIIO_CHECK_EQUAL(matOp.getID(), "");
-    OIIO_CHECK_EQUAL(matOp.getType(), OCIO::OpData::MatrixType);
-    OIIO_CHECK_EQUAL(matOp.getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(matOp.getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_ASSERT(matOp.getDescriptions().empty());
-    OIIO_CHECK_EQUAL(matOp.getOffsets()[0], 0.0f);
-    OIIO_CHECK_EQUAL(matOp.getOffsets()[1], 0.0f);
-    OIIO_CHECK_EQUAL(matOp.getOffsets()[2], 0.0f);
-    OIIO_CHECK_EQUAL(matOp.getOffsets()[3], 0.0f);
-    OIIO_CHECK_EQUAL(matOp.getArray().getLength(), 4);
-    OIIO_CHECK_EQUAL(matOp.getArray().getNumColorComponents(), 4);
-    OIIO_CHECK_EQUAL(matOp.getArray().getNumValues(), 16);
+    OCIO_CHECK_EQUAL(matOp.getID(), "");
+    OCIO_CHECK_EQUAL(matOp.getType(), OCIO::OpData::MatrixType);
+    OCIO_CHECK_EQUAL(matOp.getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(matOp.getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_ASSERT(matOp.getDescriptions().empty());
+    OCIO_CHECK_EQUAL(matOp.getOffsets()[0], 0.0f);
+    OCIO_CHECK_EQUAL(matOp.getOffsets()[1], 0.0f);
+    OCIO_CHECK_EQUAL(matOp.getOffsets()[2], 0.0f);
+    OCIO_CHECK_EQUAL(matOp.getOffsets()[3], 0.0f);
+    OCIO_CHECK_EQUAL(matOp.getArray().getLength(), 4);
+    OCIO_CHECK_EQUAL(matOp.getArray().getNumColorComponents(), 4);
+    OCIO_CHECK_EQUAL(matOp.getArray().getNumValues(), 16);
     const OCIO::ArrayDouble::Values & val = matOp.getArray().getValues();
-    OIIO_CHECK_EQUAL(val.size(), 16);
-    OIIO_CHECK_EQUAL(val[0], 1.0f);
-    OIIO_CHECK_EQUAL(val[1], 0.0f);
-    OIIO_CHECK_EQUAL(val[2], 0.0f);
-    OIIO_CHECK_EQUAL(val[3], 0.0f);
+    OCIO_CHECK_EQUAL(val.size(), 16);
+    OCIO_CHECK_EQUAL(val[0], 1.0f);
+    OCIO_CHECK_EQUAL(val[1], 0.0f);
+    OCIO_CHECK_EQUAL(val[2], 0.0f);
+    OCIO_CHECK_EQUAL(val[3], 0.0f);
 
-    OIIO_CHECK_EQUAL(val[4], 0.0f);
-    OIIO_CHECK_EQUAL(val[5], 1.0f);
-    OIIO_CHECK_EQUAL(val[6], 0.0f);
-    OIIO_CHECK_EQUAL(val[7], 0.0f);
+    OCIO_CHECK_EQUAL(val[4], 0.0f);
+    OCIO_CHECK_EQUAL(val[5], 1.0f);
+    OCIO_CHECK_EQUAL(val[6], 0.0f);
+    OCIO_CHECK_EQUAL(val[7], 0.0f);
 
-    OIIO_CHECK_EQUAL(val[8], 0.0f);
-    OIIO_CHECK_EQUAL(val[9], 0.0f);
-    OIIO_CHECK_EQUAL(val[10], 1.0f);
-    OIIO_CHECK_EQUAL(val[11], 0.0f);
+    OCIO_CHECK_EQUAL(val[8], 0.0f);
+    OCIO_CHECK_EQUAL(val[9], 0.0f);
+    OCIO_CHECK_EQUAL(val[10], 1.0f);
+    OCIO_CHECK_EQUAL(val[11], 0.0f);
 
-    OIIO_CHECK_EQUAL(val[12], 0.0f);
-    OIIO_CHECK_EQUAL(val[13], 0.0f);
-    OIIO_CHECK_EQUAL(val[14], 0.0f);
-    OIIO_CHECK_EQUAL(val[15], 1.0f);
+    OCIO_CHECK_EQUAL(val[12], 0.0f);
+    OCIO_CHECK_EQUAL(val[13], 0.0f);
+    OCIO_CHECK_EQUAL(val[14], 0.0f);
+    OCIO_CHECK_EQUAL(val[15], 1.0f);
 
-    OIIO_CHECK_NO_THROW(matOp.validate());
+    OCIO_CHECK_NO_THROW(matOp.validate());
 
     matOp.getArray().resize(3, 3); // validate() will resize to 4x4
 
-    OIIO_CHECK_EQUAL(matOp.getArray().getNumValues(), 9);
-    OIIO_CHECK_EQUAL(matOp.getArray().getLength(), 3);
-    OIIO_CHECK_EQUAL(matOp.getArray().getNumColorComponents(), 3);
+    OCIO_CHECK_EQUAL(matOp.getArray().getNumValues(), 9);
+    OCIO_CHECK_EQUAL(matOp.getArray().getLength(), 3);
+    OCIO_CHECK_EQUAL(matOp.getArray().getNumColorComponents(), 3);
 
-    OIIO_CHECK_NO_THROW(matOp.validate());
+    OCIO_CHECK_NO_THROW(matOp.validate());
 
-    OIIO_CHECK_EQUAL(matOp.getArray().getNumValues(), 16);
-    OIIO_CHECK_EQUAL(matOp.getArray().getLength(), 4);
-    OIIO_CHECK_EQUAL(matOp.getArray().getNumColorComponents(), 4);
+    OCIO_CHECK_EQUAL(matOp.getArray().getNumValues(), 16);
+    OCIO_CHECK_EQUAL(matOp.getArray().getLength(), 4);
+    OCIO_CHECK_EQUAL(matOp.getArray().getNumColorComponents(), 4);
 
 
     const OCIO::BitDepth bitDepth = OCIO::BIT_DEPTH_UINT8;
 
     OCIO::MatrixOpData m(bitDepth, bitDepth);
-    OIIO_CHECK_NO_THROW(m.validate());
+    OCIO_CHECK_NO_THROW(m.validate());
 
-    OIIO_CHECK_EQUAL(m.getInputBitDepth(), bitDepth);
-    OIIO_CHECK_EQUAL(m.getOutputBitDepth(), bitDepth);
+    OCIO_CHECK_EQUAL(m.getInputBitDepth(), bitDepth);
+    OCIO_CHECK_EQUAL(m.getOutputBitDepth(), bitDepth);
 }
 
-OIIO_ADD_TEST(MatrixOpData, output_depth_scaling)
+OCIO_ADD_TEST(MatrixOpData, output_depth_scaling)
 {
     OCIO::MatrixOpData ref(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT8);
 
@@ -1255,14 +1255,14 @@ OIIO_ADD_TEST(MatrixOpData, output_depth_scaling)
     ref.setOutputBitDepth(newBitdepth);
     // Make sure that the bit-depth was changed from
     // the overriden method.
-    OIIO_CHECK_EQUAL(ref.getOutputBitDepth(), newBitdepth);
+    OCIO_CHECK_EQUAL(ref.getOutputBitDepth(), newBitdepth);
 
     // Check that the scaling between the new coefficients and
     // initial coefficients matches the factor computed above.
     const OCIO::ArrayDouble::Values & newCoeff = ref.getArray().getValues();
 
     // Sanity check first.
-    OIIO_CHECK_EQUAL(initialCoeff.size(), newCoeff.size());
+    OCIO_CHECK_EQUAL(initialCoeff.size(), newCoeff.size());
 
     double expectedValue;
 
@@ -1270,7 +1270,7 @@ OIIO_ADD_TEST(MatrixOpData, output_depth_scaling)
     for (unsigned long i = 0; i < newCoeff.size(); i++)
     {
         expectedValue = initialCoeff[i] * factor;
-        OIIO_CHECK_EQUAL(expectedValue, newCoeff[i]);
+        OCIO_CHECK_EQUAL(expectedValue, newCoeff[i]);
     }
 
     // Offset check.
@@ -1278,11 +1278,11 @@ OIIO_ADD_TEST(MatrixOpData, output_depth_scaling)
     for (unsigned long i = 0; i<dim; i++)
     {
         expectedValue = initialOffset[i] * factor;
-        OIIO_CHECK_EQUAL(expectedValue, ref.getOffsets()[i]);
+        OCIO_CHECK_EQUAL(expectedValue, ref.getOffsets()[i]);
     }
 }
 
-OIIO_ADD_TEST(MatrixOpData, input_depth_scaling)
+OCIO_ADD_TEST(MatrixOpData, input_depth_scaling)
 {
     OCIO::MatrixOpData ref(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT8);
 
@@ -1329,45 +1329,45 @@ OIIO_ADD_TEST(MatrixOpData, input_depth_scaling)
     ref.setInputBitDepth(newBitdepth);
     // Make sure that the bit-depth was changed from the
     // overriden method.
-    OIIO_CHECK_EQUAL(ref.getInputBitDepth(), newBitdepth);
+    OCIO_CHECK_EQUAL(ref.getInputBitDepth(), newBitdepth);
 
     // Check that the scaling between the new coefficients and
     // initial coefficients matches the factor computed above.
     const OCIO::ArrayDouble::Values & newCoeff = ref.getArray().getValues();
 
     // Sanity check first.
-    OIIO_CHECK_EQUAL(initialCoeff.size(), newCoeff.size());
+    OCIO_CHECK_EQUAL(initialCoeff.size(), newCoeff.size());
 
     const double error = 1e-10;
     // Coefficient check.
     for (unsigned long i = 0; i < newCoeff.size(); i++)
     {
-        OIIO_CHECK_CLOSE((initialCoeff[i] * factor), newCoeff[i], error);
+        OCIO_CHECK_CLOSE((initialCoeff[i] * factor), newCoeff[i], error);
     }
 
     // Offset need to be unchanged.
     const unsigned long dim = ref.getArray().getLength();
     for (unsigned long i = 0; i<dim; i++) 
     {
-        OIIO_CHECK_EQUAL(initialOffset[i], ref.getOffsets()[i]);
+        OCIO_CHECK_EQUAL(initialOffset[i], ref.getOffsets()[i]);
     }
 }
 
 // Test that setting bit-depth does not affect Identity status.
-OIIO_ADD_TEST(MatrixOpData, identity)
+OCIO_ADD_TEST(MatrixOpData, identity)
 {
     OCIO::MatrixOpData m1(OCIO::BIT_DEPTH_UINT16, OCIO::BIT_DEPTH_F16);
-    OIIO_CHECK_ASSERT( m1.isIdentity() );  // 16i --> 16f
+    OCIO_CHECK_ASSERT( m1.isIdentity() );  // 16i --> 16f
 
     m1.setInputBitDepth(OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_ASSERT( m1.isIdentity() );  // 32f --> 16f
+    OCIO_CHECK_ASSERT( m1.isIdentity() );  // 32f --> 16f
 
     m1.setOutputBitDepth(OCIO::BIT_DEPTH_UINT16);
-    OIIO_CHECK_ASSERT( m1.isIdentity() );  // 32f --> 16i
+    OCIO_CHECK_ASSERT( m1.isIdentity() );  // 32f --> 16i
 }
 
 // Validate matrix composition.
-OIIO_ADD_TEST(MatrixOpData, composition)
+OCIO_ADD_TEST(MatrixOpData, composition)
 {
     // Create two test ops.
     const float mtxA[] = {  1, 2, 3, 4,
@@ -1403,29 +1403,29 @@ OIIO_ADD_TEST(MatrixOpData, composition)
     OCIO::MatrixOpDataRcPtr result(mA.compose(mBConst));
 
     // Check bit-depths copied correctly.
-    OIIO_CHECK_EQUAL(result->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(result->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
+    OCIO_CHECK_EQUAL(result->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(result->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT10);
 
     const OCIO::ArrayDouble::Values& newCoeff = result->getArray().getValues();
 
     // Sanity check on size.
-    OIIO_CHECK_ASSERT(newCoeff.size() == 16);
+    OCIO_CHECK_ASSERT(newCoeff.size() == 16);
 
     // Coefficient check.
     for (unsigned long i = 0; i < newCoeff.size(); i++)
     {
-        OIIO_CHECK_EQUAL(aim[i], newCoeff[i]);
+        OCIO_CHECK_EQUAL(aim[i], newCoeff[i]);
     }
 
     // Offset check.
     const unsigned long dim = result->getArray().getLength();
     for (unsigned long i = 0; i < dim; i++)
     {
-        OIIO_CHECK_EQUAL(aim_offs[i], result->getOffsets()[i]);
+        OCIO_CHECK_EQUAL(aim_offs[i], result->getOffsets()[i]);
     }
 }
 
-OIIO_ADD_TEST(MatrixOpData, equality)
+OCIO_ADD_TEST(MatrixOpData, equality)
 {
     OCIO::MatrixOpData m1(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT8);
     m1.setArrayValue(0, 2);
@@ -1434,24 +1434,24 @@ OIIO_ADD_TEST(MatrixOpData, equality)
     m2.setID("invalid_u_id_test");
     m2.setArrayValue(0, 2);
 
-    OIIO_CHECK_ASSERT(!(m1 == m2));
+    OCIO_CHECK_ASSERT(!(m1 == m2));
 
     OCIO::MatrixOpData m3(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT8);
     m3.setArrayValue(0, 6);
 
-    OIIO_CHECK_ASSERT(!(m1 == m3));
+    OCIO_CHECK_ASSERT(!(m1 == m3));
 
     OCIO::MatrixOpData m4(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT8);
     m4.setArrayValue(0, 2);
 
-    OIIO_CHECK_ASSERT(m1 == m4);
+    OCIO_CHECK_ASSERT(m1 == m4);
 
     m4.setOffsetValue(3, 1e-5f);
 
-    OIIO_CHECK_ASSERT(!(m1 == m4));
+    OCIO_CHECK_ASSERT(!(m1 == m4));
 }
 
-OIIO_ADD_TEST(MatrixOpData, rgb)
+OCIO_ADD_TEST(MatrixOpData, rgb)
 {
     OCIO::MatrixOpData m(OCIO::BIT_DEPTH_UINT16, OCIO::BIT_DEPTH_UINT16);
 
@@ -1459,28 +1459,28 @@ OIIO_ADD_TEST(MatrixOpData, rgb)
     m.setRGB(rgb);
 
     const OCIO::ArrayDouble::Values & v = m.getArray().getValues();
-    OIIO_CHECK_EQUAL(v[0], rgb[0]);
-    OIIO_CHECK_EQUAL(v[1], rgb[1]);
-    OIIO_CHECK_EQUAL(v[2], rgb[2]);
-    OIIO_CHECK_EQUAL(v[3], 0.0f);
+    OCIO_CHECK_EQUAL(v[0], rgb[0]);
+    OCIO_CHECK_EQUAL(v[1], rgb[1]);
+    OCIO_CHECK_EQUAL(v[2], rgb[2]);
+    OCIO_CHECK_EQUAL(v[3], 0.0f);
 
-    OIIO_CHECK_EQUAL(v[4], rgb[3]);
-    OIIO_CHECK_EQUAL(v[5], rgb[4]);
-    OIIO_CHECK_EQUAL(v[6], rgb[5]);
-    OIIO_CHECK_EQUAL(v[7], 0.0f);
+    OCIO_CHECK_EQUAL(v[4], rgb[3]);
+    OCIO_CHECK_EQUAL(v[5], rgb[4]);
+    OCIO_CHECK_EQUAL(v[6], rgb[5]);
+    OCIO_CHECK_EQUAL(v[7], 0.0f);
 
-    OIIO_CHECK_EQUAL(v[8], rgb[6]);
-    OIIO_CHECK_EQUAL(v[9], rgb[7]);
-    OIIO_CHECK_EQUAL(v[10], rgb[8]);
-    OIIO_CHECK_EQUAL(v[11], 0.0f);
+    OCIO_CHECK_EQUAL(v[8], rgb[6]);
+    OCIO_CHECK_EQUAL(v[9], rgb[7]);
+    OCIO_CHECK_EQUAL(v[10], rgb[8]);
+    OCIO_CHECK_EQUAL(v[11], 0.0f);
 
-    OIIO_CHECK_EQUAL(v[12], 0.0f);
-    OIIO_CHECK_EQUAL(v[13], 0.0f);
-    OIIO_CHECK_EQUAL(v[14], 0.0f);
-    OIIO_CHECK_EQUAL(v[15], 1.0f);
+    OCIO_CHECK_EQUAL(v[12], 0.0f);
+    OCIO_CHECK_EQUAL(v[13], 0.0f);
+    OCIO_CHECK_EQUAL(v[14], 0.0f);
+    OCIO_CHECK_EQUAL(v[15], 1.0f);
 }
 
-OIIO_ADD_TEST(MatrixOpData, rgba)
+OCIO_ADD_TEST(MatrixOpData, rgba)
 {
     OCIO::MatrixOpData m(OCIO::BIT_DEPTH_UINT16, OCIO::BIT_DEPTH_UINT16);
 
@@ -1490,15 +1490,15 @@ OIIO_ADD_TEST(MatrixOpData, rgba)
     const OCIO::ArrayDouble::Values & v = m.getArray().getValues();
     for (unsigned long i = 0; i<16; ++i)
     {
-        OIIO_CHECK_EQUAL(v[i], rgba[i]);
+        OCIO_CHECK_EQUAL(v[i], rgba[i]);
     }
 }
 
-OIIO_ADD_TEST(MatrixOpData, bitdepth_successive_changes)
+OCIO_ADD_TEST(MatrixOpData, bitdepth_successive_changes)
 {
     OCIO::MatrixOpData m1(OCIO::BIT_DEPTH_UINT10, OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_ASSERT(m1.isDiagonal());
+    OCIO_CHECK_ASSERT(m1.isDiagonal());
 
     const float scaleFactor = 
         OCIO::GetBitDepthMaxValue(OCIO::BIT_DEPTH_F32)
@@ -1515,7 +1515,7 @@ OIIO_ADD_TEST(MatrixOpData, bitdepth_successive_changes)
         {
             if (i == j)
             {
-                OIIO_CHECK_CLOSE(m1Coeff[i*dim + j], scaleFactor, error);
+                OCIO_CHECK_CLOSE(m1Coeff[i*dim + j], scaleFactor, error);
             }
         }
     }
@@ -1537,48 +1537,48 @@ OIIO_ADD_TEST(MatrixOpData, bitdepth_successive_changes)
     m2.setInputBitDepth(OCIO::BIT_DEPTH_UINT10);
     m2.setOutputBitDepth(OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_ASSERT(m2.isDiagonal());
+    OCIO_CHECK_ASSERT(m2.isDiagonal());
 
     const OCIO::ArrayDouble::Values & m2Coeff = m2.getArray().getValues();
 
     const size_t m1Size = m1Coeff.size();
     const size_t m2Size = m2Coeff.size();
-    OIIO_CHECK_EQUAL(m1Size, m2Size);
+    OCIO_CHECK_EQUAL(m1Size, m2Size);
 
     for (size_t i = 0; i < m1Size; ++i)
     {
-        OIIO_CHECK_CLOSE(m1Coeff[i], m2Coeff[i], error);
+        OCIO_CHECK_CLOSE(m1Coeff[i], m2Coeff[i], error);
     }
 }
 
-OIIO_ADD_TEST(MatrixOpData, matrixInverse_identity)
+OCIO_ADD_TEST(MatrixOpData, matrixInverse_identity)
 {
     OCIO::MatrixOpData
         refMatrixOp(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_UINT12);
 
-    OIIO_CHECK_ASSERT(refMatrixOp.isDiagonal());
-    OIIO_CHECK_ASSERT(refMatrixOp.isIdentity());
-    OIIO_CHECK_ASSERT(!refMatrixOp.hasOffsets());
+    OCIO_CHECK_ASSERT(refMatrixOp.isDiagonal());
+    OCIO_CHECK_ASSERT(refMatrixOp.isIdentity());
+    OCIO_CHECK_ASSERT(!refMatrixOp.hasOffsets());
 
     // Get inverse of reference matrix operation.
     OCIO::MatrixOpDataRcPtr invMatrixOp;
-    OIIO_CHECK_ASSERT(!invMatrixOp);
-    OIIO_CHECK_NO_THROW(invMatrixOp = refMatrixOp.inverse());
-    OIIO_REQUIRE_ASSERT(invMatrixOp);
+    OCIO_CHECK_ASSERT(!invMatrixOp);
+    OCIO_CHECK_NO_THROW(invMatrixOp = refMatrixOp.inverse());
+    OCIO_REQUIRE_ASSERT(invMatrixOp);
 
     // Inverse op should have its input/output bit-depth inverted.
-    OIIO_CHECK_EQUAL(invMatrixOp->getInputBitDepth(),
+    OCIO_CHECK_EQUAL(invMatrixOp->getInputBitDepth(),
                      refMatrixOp.getOutputBitDepth());
-    OIIO_CHECK_EQUAL(invMatrixOp->getOutputBitDepth(),
+    OCIO_CHECK_EQUAL(invMatrixOp->getOutputBitDepth(),
                      refMatrixOp.getInputBitDepth());
 
     // But still be an identity matrix.
-    OIIO_CHECK_ASSERT(invMatrixOp->isDiagonal());
-    OIIO_CHECK_ASSERT(invMatrixOp->isIdentity());
-    OIIO_CHECK_ASSERT(!invMatrixOp->hasOffsets());
+    OCIO_CHECK_ASSERT(invMatrixOp->isDiagonal());
+    OCIO_CHECK_ASSERT(invMatrixOp->isIdentity());
+    OCIO_CHECK_ASSERT(!invMatrixOp->hasOffsets());
 }
 
-OIIO_ADD_TEST(MatrixOpData, matrixInverse_singular)
+OCIO_ADD_TEST(MatrixOpData, matrixInverse_singular)
 {
     OCIO::MatrixOpData singularMatrixOp(OCIO::BIT_DEPTH_F32,
         OCIO::BIT_DEPTH_UINT12);
@@ -1592,19 +1592,19 @@ OIIO_ADD_TEST(MatrixOpData, matrixInverse_singular)
 
     singularMatrixOp.setRGBA(mat);
 
-    OIIO_CHECK_ASSERT(!singularMatrixOp.isNoOp());
-    OIIO_CHECK_ASSERT(!singularMatrixOp.isUnityDiagonal());
-    OIIO_CHECK_ASSERT(!singularMatrixOp.isDiagonal());
-    OIIO_CHECK_ASSERT(!singularMatrixOp.isIdentity());
-    OIIO_CHECK_ASSERT(!singularMatrixOp.hasOffsets());
+    OCIO_CHECK_ASSERT(!singularMatrixOp.isNoOp());
+    OCIO_CHECK_ASSERT(!singularMatrixOp.isUnityDiagonal());
+    OCIO_CHECK_ASSERT(!singularMatrixOp.isDiagonal());
+    OCIO_CHECK_ASSERT(!singularMatrixOp.isIdentity());
+    OCIO_CHECK_ASSERT(!singularMatrixOp.hasOffsets());
 
     // Get inverse of singular matrix operation.
-    OIIO_CHECK_THROW_WHAT(singularMatrixOp.inverse(),
+    OCIO_CHECK_THROW_WHAT(singularMatrixOp.inverse(),
                           OCIO::Exception,
                           "Singular Matrix can't be inverted");
 }
 
-OIIO_ADD_TEST(MatrixOpData, inverse)
+OCIO_ADD_TEST(MatrixOpData, inverse)
 {
     OCIO::MatrixOpData
         refMatrixOp(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32);
@@ -1621,13 +1621,13 @@ OIIO_ADD_TEST(MatrixOpData, inverse)
 
     // Get inverse of reference matrix operation.
     OCIO::MatrixOpDataRcPtr invMatrixOp;
-    OIIO_CHECK_NO_THROW(invMatrixOp = refMatrixOp.inverse());
-    OIIO_REQUIRE_ASSERT(invMatrixOp);
+    OCIO_CHECK_NO_THROW(invMatrixOp = refMatrixOp.inverse());
+    OCIO_REQUIRE_ASSERT(invMatrixOp);
 
     // Input/output bit-depths swapped.
-    OIIO_CHECK_EQUAL(invMatrixOp->getInputBitDepth(),
+    OCIO_CHECK_EQUAL(invMatrixOp->getInputBitDepth(),
                      refMatrixOp.getOutputBitDepth());
-    OIIO_CHECK_EQUAL(invMatrixOp->getOutputBitDepth(),
+    OCIO_CHECK_EQUAL(invMatrixOp->getOutputBitDepth(),
                      refMatrixOp.getInputBitDepth());
 
     const float expectedMatrix[16] = {
@@ -1646,27 +1646,27 @@ OIIO_ADD_TEST(MatrixOpData, inverse)
     // Check matrix coeffs.
     for (unsigned long i = 0; i < 16; ++i)
     {
-        OIIO_CHECK_CLOSE(invValues[i], expectedMatrix[i], 1e-6f);
+        OCIO_CHECK_CLOSE(invValues[i], expectedMatrix[i], 1e-6f);
     }
 
     // Check matrix offsets.
     for (unsigned long i = 0; i < 4; ++i)
     {
-        OIIO_CHECK_CLOSE(invOffsets[i],expectedOffsets[i], 1e-6f);
+        OCIO_CHECK_CLOSE(invOffsets[i],expectedOffsets[i], 1e-6f);
     }
 }
 
-OIIO_ADD_TEST(MatrixOpData, channel)
+OCIO_ADD_TEST(MatrixOpData, channel)
 {
     OCIO::MatrixOpData refMatrixOp(OCIO::BIT_DEPTH_F32,
                                    OCIO::BIT_DEPTH_UINT12);
 
-    OIIO_CHECK_ASSERT(!refMatrixOp.hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(!refMatrixOp.hasChannelCrosstalk());
 
     const float offsets[4] = { -0.1f, 0.2f, -0.3f, 0.4f };
     refMatrixOp.setRGBAOffsets(offsets);
     // False: with offsets.
-    OIIO_CHECK_ASSERT(!refMatrixOp.hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(!refMatrixOp.hasChannelCrosstalk());
 
     const float matrix[16] = { 0.9f, 0.0f,  0.0f, 0.0f,
                                0.0f, 0.5f,  0.0f, 0.0f,
@@ -1674,7 +1674,7 @@ OIIO_ADD_TEST(MatrixOpData, channel)
                                0.0f, 0.0f,  0.0f, 0.8f };
     refMatrixOp.setRGBA(matrix);
     // False: with diagonal.
-    OIIO_CHECK_ASSERT(!refMatrixOp.hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(!refMatrixOp.hasChannelCrosstalk());
 
     const float matrix2[16] = { 1.0f, 0.0f, 0.0f, 0.0f,
                                 0.0f, 1.0f, 0.0f, 0.0f,
@@ -1682,7 +1682,7 @@ OIIO_ADD_TEST(MatrixOpData, channel)
                                 0.0f, 0.0f, 0.0f, 1.0f };
     refMatrixOp.setRGBA(matrix2);
     // True: with off-diagonal.
-    OIIO_CHECK_ASSERT(refMatrixOp.hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(refMatrixOp.hasChannelCrosstalk());
 }
 
 #endif

--- a/src/OpenColorIO/ops/Matrix/MatrixOps.cpp
+++ b/src/OpenColorIO/ops/Matrix/MatrixOps.cpp
@@ -453,7 +453,7 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 #include "ops/Log/LogOps.h"
 #include "ops/NoOp/NoOps.h"
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
 OCIO_NAMESPACE_USING
@@ -468,26 +468,26 @@ OCIO_NAMESPACE_USING
 // synColorCheckApply_test.cpp - CheckMatrixWith16iRGBAImage
 
 
-OIIO_ADD_TEST(MatrixOffsetOp, scale)
+OCIO_ADD_TEST(MatrixOffsetOp, scale)
 {
     const float error = 1e-8f;
 
     OpRcPtrVec ops;
     const float scale[] = { 1.1f, 1.3f, 0.3f, -1.0f };
-    OIIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
+    OCIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_FORWARD));
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
 
     std::string cacheID = ops[0]->getCacheID();
-    OIIO_REQUIRE_ASSERT(cacheID.empty());
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_REQUIRE_ASSERT(cacheID.empty());
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
 
     cacheID = ops[0]->getCacheID();
-    OIIO_REQUIRE_ASSERT(!cacheID.empty());
+    OCIO_REQUIRE_ASSERT(!cacheID.empty());
 
-    OIIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_CHECK_NO_THROW(ops[1]->finalize());
+    OCIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_INVERSE));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(ops[1]->finalize());
 
     const unsigned long NB_PIXELS = 3;
     const float src[NB_PIXELS*4] = {  0.1004f,  0.2f, 0.3f,   0.4f,
@@ -505,31 +505,31 @@ OIIO_ADD_TEST(MatrixOffsetOp, scale)
 
     for(unsigned long idx=0; idx<(NB_PIXELS*4); ++idx)
     {
-        OIIO_CHECK_CLOSE(dst[idx], tmp[idx], error);
+        OCIO_CHECK_CLOSE(dst[idx], tmp[idx], error);
     }
 
     ops[1]->apply(tmp, NB_PIXELS);
 
     for(unsigned long idx=0; idx<(NB_PIXELS*4); ++idx)
     {
-        OIIO_CHECK_CLOSE(src[idx], tmp[idx], error);
+        OCIO_CHECK_CLOSE(src[idx], tmp[idx], error);
     }
 }
 
-OIIO_ADD_TEST(MatrixOffsetOp, offset)
+OCIO_ADD_TEST(MatrixOffsetOp, offset)
 {
     const float error = 1e-6f;
 
     OpRcPtrVec ops;
     const float offset[] = { 1.1f, -1.3f, 0.3f, -1.0f };
-    OIIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_FORWARD));
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
 
-    OIIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_EQUAL(ops.size(), 2);
-    OIIO_CHECK_NO_THROW(ops[1]->finalize());
+    OCIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(ops[1]->finalize());
 
     const unsigned long NB_PIXELS = 3;
     const float src[NB_PIXELS*4] = {  0.1004f,  0.2f, 0.3f,  0.4f,
@@ -547,18 +547,18 @@ OIIO_ADD_TEST(MatrixOffsetOp, offset)
 
     for(unsigned long idx=0; idx<(NB_PIXELS*4); ++idx)
     {
-        OIIO_CHECK_CLOSE(dst[idx], tmp[idx], error);
+        OCIO_CHECK_CLOSE(dst[idx], tmp[idx], error);
     }
 
     ops[1]->apply(tmp, NB_PIXELS);
 
     for(unsigned long idx=0; idx<(NB_PIXELS*4); ++idx)
     {
-        OIIO_CHECK_CLOSE(src[idx], tmp[idx], error);
+        OCIO_CHECK_CLOSE(src[idx], tmp[idx], error);
     }
 }
 
-OIIO_ADD_TEST(MatrixOffsetOp, matrix)
+OCIO_ADD_TEST(MatrixOffsetOp, matrix)
 {
     const float error = 1e-6f;
 
@@ -568,14 +568,14 @@ OIIO_ADD_TEST(MatrixOffsetOp, matrix)
                                0.3f, 0.4f, 0.5f, 1.6f };
                    
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_CHECK_NO_THROW(CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD));
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
 
-    OIIO_CHECK_NO_THROW(CreateMatrixOp(ops, matrix, TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_CHECK_NO_THROW(ops[1]->finalize());
+    OCIO_CHECK_NO_THROW(CreateMatrixOp(ops, matrix, TRANSFORM_DIR_INVERSE));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(ops[1]->finalize());
 
     const unsigned long NB_PIXELS = 3;
     const float src[NB_PIXELS*4] = {  0.1004f,  0.201f, 0.303f, 0.408f,
@@ -594,7 +594,7 @@ OIIO_ADD_TEST(MatrixOffsetOp, matrix)
 
     for(unsigned long idx=0; idx<(NB_PIXELS*4); ++idx)
     {
-        OIIO_CHECK_ASSERT(OCIO::EqualWithSafeRelError((float)dst[idx],
+        OCIO_CHECK_ASSERT(OCIO::EqualWithSafeRelError((float)dst[idx],
                                                       (float)tmp[idx],
                                                       error, 1.0f));
     }
@@ -603,13 +603,13 @@ OIIO_ADD_TEST(MatrixOffsetOp, matrix)
 
     for(unsigned long idx=0; idx<(NB_PIXELS*4); ++idx)
     {
-        OIIO_CHECK_ASSERT(OCIO::EqualWithSafeRelError((float)src[idx],
+        OCIO_CHECK_ASSERT(OCIO::EqualWithSafeRelError((float)src[idx],
                                                       (float)tmp[idx],
                                                       error, 1.0f));
     }
 }
 
-OIIO_ADD_TEST(MatrixOffsetOp, arbitrary)
+OCIO_ADD_TEST(MatrixOffsetOp, arbitrary)
 {
     const float error = 1e-6f;
 
@@ -621,16 +621,16 @@ OIIO_ADD_TEST(MatrixOffsetOp, arbitrary)
     const float offset[4] = { -0.5f, -0.25f, 0.25f, 0.1f };
 
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateMatrixOffsetOp(ops, matrix, offset,TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateMatrixOffsetOp(ops, matrix, offset, TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_CHECK_NO_THROW(ops[1]->finalize());
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(ops[1]->finalize());
 
     const unsigned long NB_PIXELS = 3;
     const float src[NB_PIXELS*4] = {
@@ -650,7 +650,7 @@ OIIO_ADD_TEST(MatrixOffsetOp, arbitrary)
 
     for(unsigned long idx=0; idx<(NB_PIXELS*4); ++idx)
     {
-        OIIO_CHECK_ASSERT(OCIO::EqualWithSafeRelError((float)dst[idx],
+        OCIO_CHECK_ASSERT(OCIO::EqualWithSafeRelError((float)dst[idx],
                                                       (float)tmp[idx],
                                                       error, 1.0f));
     }
@@ -659,31 +659,31 @@ OIIO_ADD_TEST(MatrixOffsetOp, arbitrary)
 
     for(unsigned long idx=0; idx<(NB_PIXELS*4); ++idx)
     {
-        OIIO_CHECK_ASSERT(OCIO::EqualWithSafeRelError((float)src[idx],
+        OCIO_CHECK_ASSERT(OCIO::EqualWithSafeRelError((float)src[idx],
                                                       (float)tmp[idx],
                                                       error, 1.0f));
     }
 
     std::string opInfo0 = ops[0]->getInfo();
-    OIIO_CHECK_ASSERT(!opInfo0.empty());
+    OCIO_CHECK_ASSERT(!opInfo0.empty());
 
     std::string opInfo1 = ops[1]->getInfo();
-    OIIO_CHECK_EQUAL(opInfo0, opInfo1);
+    OCIO_CHECK_EQUAL(opInfo0, opInfo1);
 
     OpRcPtr clonedOp = ops[1]->clone();
     std::string cacheID = ops[1]->getCacheID();
     std::string cacheIDCloned = clonedOp->getCacheID();
     
-    OIIO_CHECK_ASSERT(cacheIDCloned.empty());
-    OIIO_CHECK_NO_THROW(clonedOp->finalize());
+    OCIO_CHECK_ASSERT(cacheIDCloned.empty());
+    OCIO_CHECK_NO_THROW(clonedOp->finalize());
 
     cacheIDCloned = clonedOp->getCacheID();
 
-    OIIO_CHECK_ASSERT(!cacheIDCloned.empty());
-    OIIO_CHECK_EQUAL(cacheIDCloned, cacheID);
+    OCIO_CHECK_ASSERT(!cacheIDCloned.empty());
+    OCIO_CHECK_EQUAL(cacheIDCloned, cacheID);
 }
 
-OIIO_ADD_TEST(MatrixOffsetOp, create_fit_op)
+OCIO_ADD_TEST(MatrixOffsetOp, create_fit_op)
 {
     const float error = 1e-6f;
 
@@ -693,18 +693,18 @@ OIIO_ADD_TEST(MatrixOffsetOp, create_fit_op)
     const float newmax4[4] = { 1.0f, 6.0f, 9.0f, 20.0f };
 
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateFitOp(ops,
+    OCIO_CHECK_NO_THROW(CreateFitOp(ops,
                                     oldmin4, oldmax4,
                                     newmin4, newmax4, TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
 
-    OIIO_CHECK_NO_THROW(CreateFitOp(ops,
+    OCIO_CHECK_NO_THROW(CreateFitOp(ops,
                                     oldmin4, oldmax4,
                                     newmin4, newmax4, TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_CHECK_NO_THROW(ops[1]->finalize());
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(ops[1]->finalize());
 
     const unsigned long NB_PIXELS = 3;
     const float src[NB_PIXELS * 4] = {  0.1004f, 0.201f, 0.303f, 0.408f,
@@ -722,36 +722,36 @@ OIIO_ADD_TEST(MatrixOffsetOp, create_fit_op)
 
     for (unsigned long idx = 0; idx<(NB_PIXELS * 4); ++idx)
     {
-        OIIO_CHECK_CLOSE(dst[idx], tmp[idx], error);
+        OCIO_CHECK_CLOSE(dst[idx], tmp[idx], error);
     }
 
     ops[1]->apply(tmp, NB_PIXELS);
 
     for (unsigned long idx = 0; idx<(NB_PIXELS * 4); ++idx)
     {
-        OIIO_CHECK_CLOSE(src[idx], tmp[idx], error);
+        OCIO_CHECK_CLOSE(src[idx], tmp[idx], error);
     }
 
 }
 
-OIIO_ADD_TEST(MatrixOffsetOp, create_saturation_op)
+OCIO_ADD_TEST(MatrixOffsetOp, create_saturation_op)
 {
     const float error = 1e-6f;
     const float sat = 0.9f;
     const float lumaCoef3[3] = { 1.0f, 0.5f, 0.1f };
 
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateSaturationOp(ops, sat, lumaCoef3, TRANSFORM_DIR_FORWARD));
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateSaturationOp(ops, sat, lumaCoef3, TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_CHECK_NO_THROW(ops[1]->finalize());
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(ops[1]->finalize());
 
     const unsigned long NB_PIXELS = 3;
     const float src[NB_PIXELS * 4] = { 0.1004f, 0.201f, 0.303f, 0.408f,
@@ -770,18 +770,18 @@ OIIO_ADD_TEST(MatrixOffsetOp, create_saturation_op)
 
     for (unsigned long idx = 0; idx<(NB_PIXELS * 4); ++idx)
     {
-        OIIO_CHECK_CLOSE(dst[idx], tmp[idx], error);
+        OCIO_CHECK_CLOSE(dst[idx], tmp[idx], error);
     }
 
     ops[1]->apply(tmp, NB_PIXELS);
 
     for (unsigned long idx = 0; idx<(NB_PIXELS * 4); ++idx)
     {
-        OIIO_CHECK_CLOSE(src[idx], tmp[idx], error);
+        OCIO_CHECK_CLOSE(src[idx], tmp[idx], error);
     }
 }
 
-OIIO_ADD_TEST(MatrixOffsetOp, create_min_max_op)
+OCIO_ADD_TEST(MatrixOffsetOp, create_min_max_op)
 {
     const float error = 1e-6f;
 
@@ -789,10 +789,10 @@ OIIO_ADD_TEST(MatrixOffsetOp, create_min_max_op)
     const float max3[4] = { 2.0f, 4.0f, 6.0f };
 
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateMinMaxOp(ops, min3, max3, TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_CHECK_NO_THROW(CreateMinMaxOp(ops, min3, max3, TRANSFORM_DIR_FORWARD));
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<MatrixOffsetOp>");
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
 
     const unsigned long NB_PIXELS = 5;
     const float src[NB_PIXELS * 4] = { 1.0f, 2.0f, 3.0f,  1.0f,
@@ -814,12 +814,12 @@ OIIO_ADD_TEST(MatrixOffsetOp, create_min_max_op)
 
     for (unsigned long idx = 0; idx<(NB_PIXELS * 4); ++idx)
     {
-        OIIO_CHECK_CLOSE(dst[idx], tmp[idx], error);
+        OCIO_CHECK_CLOSE(dst[idx], tmp[idx], error);
     }
 
 }
 
-OIIO_ADD_TEST(MatrixOffsetOp, combining)
+OCIO_ADD_TEST(MatrixOffsetOp, combining)
 {
     const float error = 1e-4f;
     const float m1[16] = { 1.1f, 0.2f, 0.3f, 0.4f,
@@ -838,22 +838,22 @@ OIIO_ADD_TEST(MatrixOffsetOp, combining)
     
     {
         OpRcPtrVec ops;
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_NO_THROW(
             CreateMatrixOffsetOp(ops, m1, v1, TRANSFORM_DIR_FORWARD));
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_NO_THROW(
             CreateMatrixOffsetOp(ops, m2, v2, TRANSFORM_DIR_FORWARD));
-        OIIO_REQUIRE_EQUAL(ops.size(), 2);
-        OIIO_CHECK_NO_THROW(ops[0]->finalize());
-        OIIO_CHECK_NO_THROW(ops[1]->finalize());
+        OCIO_REQUIRE_EQUAL(ops.size(), 2);
+        OCIO_CHECK_NO_THROW(ops[0]->finalize());
+        OCIO_CHECK_NO_THROW(ops[1]->finalize());
         
         OpRcPtrVec combined;
         ConstOpRcPtr opc1 = ops[1];
-        OIIO_CHECK_NO_THROW(ops[0]->combineWith(combined, opc1));
-        OIIO_REQUIRE_EQUAL(combined.size(), 1);
-        OIIO_CHECK_NO_THROW(combined[0]->finalize());
+        OCIO_CHECK_NO_THROW(ops[0]->combineWith(combined, opc1));
+        OCIO_REQUIRE_EQUAL(combined.size(), 1);
+        OCIO_CHECK_NO_THROW(combined[0]->finalize());
 
         const std::string cacheIDCombined = combined[0]->getCacheID();
-        OIIO_CHECK_ASSERT(!cacheIDCombined.empty());
+        OCIO_CHECK_ASSERT(!cacheIDCombined.empty());
 
         for(int test=0; test<3; ++test)
         {
@@ -868,27 +868,27 @@ OIIO_ADD_TEST(MatrixOffsetOp, combining)
             
             for(unsigned int i=0; i<4; ++i)
             {
-                OIIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
+                OCIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
             }
         }
 
         // Now try the same thing but use FinalizeOpVec to call combineWith. 
         ops.clear();
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_NO_THROW(
             CreateMatrixOffsetOp(ops, m1, v1, TRANSFORM_DIR_FORWARD));
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_NO_THROW(
             CreateMatrixOffsetOp(ops, m2, v2, TRANSFORM_DIR_FORWARD));
-        OIIO_REQUIRE_EQUAL(ops.size(), 2);
+        OCIO_REQUIRE_EQUAL(ops.size(), 2);
         OpRcPtr op0 = ops[0];
         OpRcPtr op1 = ops[1];
 
-        OIIO_CHECK_NO_THROW(FinalizeOpVec(ops));
-        OIIO_REQUIRE_EQUAL(ops.size(), 1);
+        OCIO_CHECK_NO_THROW(FinalizeOpVec(ops));
+        OCIO_REQUIRE_EQUAL(ops.size(), 1);
 
         const std::string cacheIDOptimized = ops[0]->getCacheID();
-        OIIO_CHECK_ASSERT(!cacheIDOptimized.empty());
+        OCIO_CHECK_ASSERT(!cacheIDOptimized.empty());
 
-        OIIO_CHECK_EQUAL(cacheIDCombined, cacheIDOptimized);
+        OCIO_CHECK_EQUAL(cacheIDCombined, cacheIDOptimized);
 
         op0->finalize();
         op1->finalize();
@@ -906,7 +906,7 @@ OIIO_ADD_TEST(MatrixOffsetOp, combining)
 
             for (unsigned int i = 0; i<4; ++i)
             {
-                OIIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
+                OCIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
             }
         }
     }
@@ -914,19 +914,19 @@ OIIO_ADD_TEST(MatrixOffsetOp, combining)
     
     {
         OpRcPtrVec ops;
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_NO_THROW(
             CreateMatrixOffsetOp(ops, m1, v1, TRANSFORM_DIR_FORWARD));
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_NO_THROW(
             CreateMatrixOffsetOp(ops, m2, v2, TRANSFORM_DIR_INVERSE));
-        OIIO_REQUIRE_EQUAL(ops.size(), 2);
-        OIIO_CHECK_NO_THROW(ops[0]->finalize());
-        OIIO_CHECK_NO_THROW(ops[1]->finalize());
+        OCIO_REQUIRE_EQUAL(ops.size(), 2);
+        OCIO_CHECK_NO_THROW(ops[0]->finalize());
+        OCIO_CHECK_NO_THROW(ops[1]->finalize());
         
         OpRcPtrVec combined;
         ConstOpRcPtr opc1 = ops[1];
-        OIIO_CHECK_NO_THROW(ops[0]->combineWith(combined, opc1));
-        OIIO_REQUIRE_EQUAL(combined.size(), 1);
-        OIIO_CHECK_NO_THROW(combined[0]->finalize());
+        OCIO_CHECK_NO_THROW(ops[0]->combineWith(combined, opc1));
+        OCIO_REQUIRE_EQUAL(combined.size(), 1);
+        OCIO_CHECK_NO_THROW(combined[0]->finalize());
         
         
         for(int test=0; test<3; ++test)
@@ -942,26 +942,26 @@ OIIO_ADD_TEST(MatrixOffsetOp, combining)
             
             for(unsigned int i=0; i<4; ++i)
             {
-                OIIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
+                OCIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
             }
         }
     }
     
     {
         OpRcPtrVec ops;
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_NO_THROW(
             CreateMatrixOffsetOp(ops, m1, v1, TRANSFORM_DIR_INVERSE));
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_NO_THROW(
             CreateMatrixOffsetOp(ops, m2, v2, TRANSFORM_DIR_FORWARD));
-        OIIO_REQUIRE_EQUAL(ops.size(), 2);
-        OIIO_CHECK_NO_THROW(ops[0]->finalize());
-        OIIO_CHECK_NO_THROW(ops[1]->finalize());
+        OCIO_REQUIRE_EQUAL(ops.size(), 2);
+        OCIO_CHECK_NO_THROW(ops[0]->finalize());
+        OCIO_CHECK_NO_THROW(ops[1]->finalize());
         
         OpRcPtrVec combined;
         ConstOpRcPtr opc1 = ops[1];
-        OIIO_CHECK_NO_THROW(ops[0]->combineWith(combined, opc1));
-        OIIO_REQUIRE_EQUAL(combined.size(), 1);
-        OIIO_CHECK_NO_THROW(combined[0]->finalize());
+        OCIO_CHECK_NO_THROW(ops[0]->combineWith(combined, opc1));
+        OCIO_REQUIRE_EQUAL(combined.size(), 1);
+        OCIO_CHECK_NO_THROW(combined[0]->finalize());
         
         for(int test=0; test<3; ++test)
         {
@@ -976,26 +976,26 @@ OIIO_ADD_TEST(MatrixOffsetOp, combining)
             
             for(unsigned int i=0; i<4; ++i)
             {
-                OIIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
+                OCIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
             }
         }
     }
     
     {
         OpRcPtrVec ops;
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_NO_THROW(
             CreateMatrixOffsetOp(ops, m1, v1, TRANSFORM_DIR_INVERSE));
-        OIIO_CHECK_NO_THROW(
+        OCIO_CHECK_NO_THROW(
             CreateMatrixOffsetOp(ops, m2, v2, TRANSFORM_DIR_INVERSE));
-        OIIO_REQUIRE_EQUAL(ops.size(), 2);
-        OIIO_CHECK_NO_THROW(ops[0]->finalize());
-        OIIO_CHECK_NO_THROW(ops[1]->finalize());
+        OCIO_REQUIRE_EQUAL(ops.size(), 2);
+        OCIO_CHECK_NO_THROW(ops[0]->finalize());
+        OCIO_CHECK_NO_THROW(ops[1]->finalize());
         
         OpRcPtrVec combined;
         OCIO::ConstOpRcPtr op1 = ops[1];
-        OIIO_CHECK_NO_THROW(ops[0]->combineWith(combined, op1));
-        OIIO_REQUIRE_EQUAL(combined.size(), 1);
-        OIIO_CHECK_NO_THROW(combined[0]->finalize());
+        OCIO_CHECK_NO_THROW(ops[0]->combineWith(combined, op1));
+        OCIO_REQUIRE_EQUAL(combined.size(), 1);
+        OCIO_CHECK_NO_THROW(combined[0]->finalize());
         
         for(int test=0; test<3; ++test)
         {
@@ -1010,22 +1010,22 @@ OIIO_ADD_TEST(MatrixOffsetOp, combining)
             
             for(unsigned int i=0; i<4; ++i)
             {
-                OIIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
+                OCIO_CHECK_CLOSE(tmp2[i], tmp[i], error);
             }
         }
     }
 }
 
-OIIO_ADD_TEST(MatrixOffsetOp, throw_create)
+OCIO_ADD_TEST(MatrixOffsetOp, throw_create)
 {
     OpRcPtrVec ops;
     const float scale[] = { 1.1f, 1.3f, 0.3f, 1.0f };
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         CreateScaleOp(ops, scale, TRANSFORM_DIR_UNKNOWN),
         OCIO::Exception, "unspecified transform direction");
 
     const float offset[] = { 1.1f, -1.3f, 0.3f, 0.0f };
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         CreateOffsetOp(ops, offset, TRANSFORM_DIR_UNKNOWN),
         OCIO::Exception, "unspecified transform direction");
 
@@ -1034,7 +1034,7 @@ OIIO_ADD_TEST(MatrixOffsetOp, throw_create)
                                0.2f, 0.1f, 1.1f, 0.2f,
                                0.3f, 0.4f, 0.5f, 1.6f };
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         CreateMatrixOp(ops, matrix, TRANSFORM_DIR_UNKNOWN),
         OCIO::Exception, "unspecified transform direction");
 
@@ -1044,161 +1044,161 @@ OIIO_ADD_TEST(MatrixOffsetOp, throw_create)
     const float newmin4[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
     const float newmax4[4] = { 1.0f, 4.0f, 9.0f, 16.0f };
 
-    OIIO_CHECK_THROW_WHAT(CreateFitOp(ops,
+    OCIO_CHECK_THROW_WHAT(CreateFitOp(ops,
         oldmin4, oldmax4,
         newmin4, newmax4, TRANSFORM_DIR_FORWARD),
         OCIO::Exception,
         "Cannot create Fit operator. Max value equals min value");
 }
 
-OIIO_ADD_TEST(MatrixOffsetOp, throw_finalize)
+OCIO_ADD_TEST(MatrixOffsetOp, throw_finalize)
 {
     // Matrix that can't be inverted can't be used in inverse direction.
     OpRcPtrVec ops;
     const float scale[] = { 0.0f, 1.3f, 0.3f, 1.0f };
-    OIIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_INVERSE));
 
-    OIIO_CHECK_THROW_WHAT(ops[0]->finalize(),
+    OCIO_CHECK_THROW_WHAT(ops[0]->finalize(),
         OCIO::Exception, "Singular Matrix can't be inverted");
 }
 
-OIIO_ADD_TEST(MatrixOffsetOp, throw_combine)
+OCIO_ADD_TEST(MatrixOffsetOp, throw_combine)
 {
     OpRcPtrVec ops;
     
     // Combining with different op.
     const float offset[] = { 1.1f, -1.3f, 0.3f, 0.0f };
-    OIIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
+    OCIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateFileNoOp(ops, "NoOp"));
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     OCIO::ConstOpRcPtr op1 = ops[1];
 
     OpRcPtrVec combinedOps;
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         ops[0]->combineWith(combinedOps, op1),
         OCIO::Exception, "can only be combined with other MatrixOffsetOps");
 
     // Combining forward with inverse that can't be inverted.
     ops.clear();
     const float scaleNoInv[] = { 1.1f, 0.0f, 0.3f, 0.0f };
-    OIIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_NO_THROW(CreateScaleOp(ops, scaleNoInv, TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateScaleOp(ops, scaleNoInv, TRANSFORM_DIR_INVERSE));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     op1 = ops[1];
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         ops[0]->combineWith(combinedOps, op1),
         OCIO::Exception, "Singular Matrix can't be inverted");
 
     // Combining inverse that can't be inverted with forward.
     ops.clear();
-    OIIO_CHECK_NO_THROW(CreateScaleOp(ops, scaleNoInv, TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(CreateScaleOp(ops, scaleNoInv, TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_FORWARD));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     op1 = ops[1];
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         ops[0]->combineWith(combinedOps, op1),
         OCIO::Exception, "Singular Matrix can't be inverted");
 
     // Combining inverse with inverse that can't be inverted.
     ops.clear();
-    OIIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_NO_THROW(CreateScaleOp(ops, scaleNoInv, TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_NO_THROW(CreateScaleOp(ops, scaleNoInv, TRANSFORM_DIR_INVERSE));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     op1 = ops[1];
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         ops[0]->combineWith(combinedOps, op1),
         OCIO::Exception, "Singular Matrix can't be inverted");
     
     // Combining inverse that can't be inverted with inverse.
     ops.clear();
-    OIIO_CHECK_NO_THROW(CreateScaleOp(ops, scaleNoInv, TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(CreateScaleOp(ops, scaleNoInv, TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_INVERSE));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     op1 = ops[1];
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         ops[0]->combineWith(combinedOps, op1),
         OCIO::Exception, "Singular Matrix can't be inverted");
 
 }
 
-OIIO_ADD_TEST(MatrixOffsetOp, no_op)
+OCIO_ADD_TEST(MatrixOffsetOp, no_op)
 {
     OpRcPtrVec ops;
     const float offset[] = { 0.0f, 0.0f, 0.0f, 0.0f };
-    OIIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_FORWARD));
 
     // No ops are not created.
-    OIIO_CHECK_EQUAL(ops.size(), 0);
-    OIIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_EQUAL(ops.size(), 0);
 
     const float scale[] = { 1.0f, 1.0f, 1.0f, 1.0f };
-    OIIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 0);
-    OIIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_EQUAL(ops.size(), 0);
 
     const float matrix[16] = { 1.0f, 0.0f, 0.0f, 0.0f,
                                0.0f, 1.0f, 0.0f, 0.0f,
                                0.0f, 0.0f, 1.0f, 0.0f,
                                0.0f, 0.0f, 0.0f, 1.0f };
 
-    OIIO_CHECK_NO_THROW(CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 0);
-    OIIO_CHECK_NO_THROW(CreateMatrixOp(ops, matrix, TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_EQUAL(ops.size(), 0);
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(CreateMatrixOp(ops, matrix, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_NO_THROW(CreateMatrixOp(ops, matrix, TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_NO_THROW(
         CreateMatrixOffsetOp(ops, matrix, offset, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 0);
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_NO_THROW(
         CreateMatrixOffsetOp(ops, matrix, offset, TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_EQUAL(ops.size(), 0);
 
     const float oldmin4[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
     const float oldmax4[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
 
-    OIIO_CHECK_NO_THROW(CreateFitOp(ops,
+    OCIO_CHECK_NO_THROW(CreateFitOp(ops,
         oldmin4, oldmax4,
         oldmin4, oldmax4, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_EQUAL(ops.size(), 0);
 
-    OIIO_CHECK_NO_THROW(CreateFitOp(ops,
+    OCIO_CHECK_NO_THROW(CreateFitOp(ops,
         oldmin4, oldmax4,
         oldmin4, oldmax4, TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_EQUAL(ops.size(), 0);
 
     const float sat = 1.0f;
     const float lumaCoef3[3] = { 1.0f, 1.0f, 1.0f };
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateSaturationOp(ops, sat, lumaCoef3, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_EQUAL(ops.size(), 0);
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateSaturationOp(ops, sat, lumaCoef3, TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_EQUAL(ops.size(), 0);
+    OCIO_CHECK_EQUAL(ops.size(), 0);
 
     // Except if CreateIdentityMatrixOp is used.
-    OIIO_CHECK_NO_THROW(CreateIdentityMatrixOp(ops, TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_ASSERT(ops[0]->isNoOp());
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
-    OIIO_CHECK_ASSERT(ops[0]->isNoOp());
+    OCIO_CHECK_NO_THROW(CreateIdentityMatrixOp(ops, TRANSFORM_DIR_FORWARD));
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_ASSERT(ops[0]->isNoOp());
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_CHECK_ASSERT(ops[0]->isNoOp());
 
-    OIIO_CHECK_NO_THROW(CreateIdentityMatrixOp(ops, TRANSFORM_DIR_INVERSE));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_CHECK_ASSERT(ops[1]->isNoOp());
-    OIIO_CHECK_NO_THROW(ops[1]->finalize());
-    OIIO_CHECK_ASSERT(ops[1]->isNoOp());
+    OCIO_CHECK_NO_THROW(CreateIdentityMatrixOp(ops, TRANSFORM_DIR_INVERSE));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_ASSERT(ops[1]->isNoOp());
+    OCIO_CHECK_NO_THROW(ops[1]->finalize());
+    OCIO_CHECK_ASSERT(ops[1]->isNoOp());
 
 }
 
-OIIO_ADD_TEST(MatrixOffsetOp, is_same_type)
+OCIO_ADD_TEST(MatrixOffsetOp, is_same_type)
 {
     const float sat = 0.9f;
     const float lumaCoef3[3] = { 1.0f, 0.5f, 0.1f };
@@ -1211,90 +1211,90 @@ OIIO_ADD_TEST(MatrixOffsetOp, is_same_type)
 
     // Create saturation, scale and log.
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateSaturationOp(ops, sat, lumaCoef3, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 1);
-    OIIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 2);
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_EQUAL(ops.size(), 1);
+    OCIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(
         CreateLogOp(ops, base, logSlope, logOffset, linSlope, linOffset, TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 3);
+    OCIO_REQUIRE_EQUAL(ops.size(), 3);
     OCIO::ConstOpRcPtr op0 = ops[0];
     OCIO::ConstOpRcPtr op1 = ops[1];
     OCIO::ConstOpRcPtr op2 = ops[2];
 
     // saturation and scale are MatrixOffset operators, log is not.
-    OIIO_CHECK_ASSERT(ops[0]->isSameType(op1));
-    OIIO_CHECK_ASSERT(ops[1]->isSameType(op0));
-    OIIO_CHECK_ASSERT(!ops[0]->isSameType(op2));
-    OIIO_CHECK_ASSERT(!ops[2]->isSameType(op0));
-    OIIO_CHECK_ASSERT(!ops[1]->isSameType(op2));
-    OIIO_CHECK_ASSERT(!ops[2]->isSameType(op1));
+    OCIO_CHECK_ASSERT(ops[0]->isSameType(op1));
+    OCIO_CHECK_ASSERT(ops[1]->isSameType(op0));
+    OCIO_CHECK_ASSERT(!ops[0]->isSameType(op2));
+    OCIO_CHECK_ASSERT(!ops[2]->isSameType(op0));
+    OCIO_CHECK_ASSERT(!ops[1]->isSameType(op2));
+    OCIO_CHECK_ASSERT(!ops[2]->isSameType(op1));
 }
 
-OIIO_ADD_TEST(MatrixOffsetOp, is_inverse)
+OCIO_ADD_TEST(MatrixOffsetOp, is_inverse)
 {
     OpRcPtrVec ops;
     const float offset[] = { 1.1f, -1.3f, 0.3f, 0.0f };
     const float offsetInv[] = { -1.1f, 1.3f, -0.3f, 0.0f };
-    OIIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 1);
-    OIIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_EQUAL(ops.size(), 2);
-    OIIO_CHECK_NO_THROW(CreateOffsetOp(ops, offsetInv, TRANSFORM_DIR_FORWARD));
-    OIIO_CHECK_EQUAL(ops.size(), 3);
+    OCIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_EQUAL(ops.size(), 1);
+    OCIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(CreateOffsetOp(ops, offsetInv, TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_EQUAL(ops.size(), 3);
 
     const double base = 10.0;
     const double logSlope[3] = { 0.18, 0.5, 0.3 };
     const double linSlope[3] = { 2.0, 4.0, 8.0 };
     const double linOffset[3] = { 0.1, 0.1, 0.1 };
     const double logOffset[3] = { 1.0, 1.0, 1.0 };
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateLogOp(ops, base, logSlope, logOffset, linSlope, linOffset, TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 4);
+    OCIO_REQUIRE_EQUAL(ops.size(), 4);
     OCIO::ConstOpRcPtr op0 = ops[0];
     OCIO::ConstOpRcPtr op1 = ops[1];
     OCIO::ConstOpRcPtr op2 = ops[2];
     OCIO::ConstOpRcPtr op3 = ops[3];
 
-    OIIO_CHECK_ASSERT(ops[0]->isInverse(op1));
-    OIIO_CHECK_ASSERT(ops[1]->isInverse(op0));
+    OCIO_CHECK_ASSERT(ops[0]->isInverse(op1));
+    OCIO_CHECK_ASSERT(ops[1]->isInverse(op0));
     
-    OIIO_CHECK_ASSERT(ops[0]->isInverse(op2));
-    OIIO_CHECK_ASSERT(ops[2]->isInverse(op0));
-    OIIO_CHECK_ASSERT(!ops[2]->isInverse(op3));
-    OIIO_CHECK_ASSERT(!ops[3]->isInverse(op2));
+    OCIO_CHECK_ASSERT(ops[0]->isInverse(op2));
+    OCIO_CHECK_ASSERT(ops[2]->isInverse(op0));
+    OCIO_CHECK_ASSERT(!ops[2]->isInverse(op3));
+    OCIO_CHECK_ASSERT(!ops[3]->isInverse(op2));
 }
 
-OIIO_ADD_TEST(MatrixOffsetOp, has_channel_crosstalk)
+OCIO_ADD_TEST(MatrixOffsetOp, has_channel_crosstalk)
 {
     const float scale[] = { 1.1f, 1.3f, 0.3f, 1.0f };
     const float sat = 0.9f;
     const float lumaCoef3[3] = { 1.0f, 0.5f, 0.1f };
 
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(CreateScaleOp(ops, scale, TRANSFORM_DIR_FORWARD));
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_CHECK_NO_THROW(
         CreateSaturationOp(ops, sat, lumaCoef3, TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_CHECK_NO_THROW(ops[1]->finalize());
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(ops[1]->finalize());
 
-    OIIO_CHECK_ASSERT(!ops[0]->hasChannelCrosstalk());
-    OIIO_CHECK_ASSERT(ops[1]->hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(!ops[0]->hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(ops[1]->hasChannelCrosstalk());
 }
 
-OIIO_ADD_TEST(MatrixOffsetOp, removing_red_green)
+OCIO_ADD_TEST(MatrixOffsetOp, removing_red_green)
 {
     MatrixOpDataRcPtr mat = std::make_shared<MatrixOpData>();
     mat->setArrayValue(0, 0.0);
     mat->setArrayValue(5, 0.0);
     OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         CreateMatrixOp(ops, mat, TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
 
     const unsigned long NB_PIXELS = 6;
     const float src[NB_PIXELS * 4] = {
@@ -1312,10 +1312,10 @@ OIIO_ADD_TEST(MatrixOffsetOp, removing_red_green)
 
     for (unsigned long idx = 0; idx<NB_PIXELS; idx+=4)
     {
-        OIIO_CHECK_EQUAL(0.0f, tmp[idx]);
-        OIIO_CHECK_EQUAL(0.0f, tmp[idx+1]);
-        OIIO_CHECK_EQUAL(src[idx+2], tmp[idx+2]);
-        OIIO_CHECK_EQUAL(src[idx+3], tmp[idx+3]);
+        OCIO_CHECK_EQUAL(0.0f, tmp[idx]);
+        OCIO_CHECK_EQUAL(0.0f, tmp[idx+1]);
+        OCIO_CHECK_EQUAL(src[idx+2], tmp[idx+2]);
+        OCIO_CHECK_EQUAL(src[idx+3], tmp[idx+3]);
     }
 }
 

--- a/src/OpenColorIO/ops/Metadata.cpp
+++ b/src/OpenColorIO/ops/Metadata.cpp
@@ -223,9 +223,9 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(Metadata, test_accessors)
+OCIO_ADD_TEST(Metadata, test_accessors)
 {
     OCIO::Metadata info("Info");
 
@@ -234,16 +234,16 @@ OIIO_ADD_TEST(Metadata, test_accessors)
     info.addAttribute(OCIO::Metadata::Attribute("version", "1.0"));
 
     const OCIO::Metadata::Attributes& atts1 = info.getAttributes();
-    OIIO_CHECK_EQUAL(atts1.size(), 1);
-    OIIO_CHECK_EQUAL(atts1[0].first, "version");
-    OIIO_CHECK_EQUAL(atts1[0].second, "1.0");
+    OCIO_CHECK_EQUAL(atts1.size(), 1);
+    OCIO_CHECK_EQUAL(atts1[0].first, "version");
+    OCIO_CHECK_EQUAL(atts1[0].second, "1.0");
 
     info.addAttribute(OCIO::Metadata::Attribute("version", "2.0"));
 
     const OCIO::Metadata::Attributes& atts2 = info.getAttributes();
-    OIIO_CHECK_EQUAL(atts2.size(), 1);
-    OIIO_CHECK_EQUAL(atts2[0].first, "version");
-    OIIO_CHECK_EQUAL(atts2[0].second, "2.0");
+    OCIO_CHECK_EQUAL(atts2.size(), 1);
+    OCIO_CHECK_EQUAL(atts2[0].first, "version");
+    OCIO_CHECK_EQUAL(atts2[0].second, "2.0");
 
     info["Copyright"] = "Copyright 2013 Autodesk";
     info["Release"] = "2015";
@@ -268,19 +268,19 @@ OIIO_ADD_TEST(Metadata, test_accessors)
 
     {
         const OCIO::Metadata cinfo = info;
-        OIIO_CHECK_EQUAL(cinfo["Copyright"].getValue(), "Copyright 2013 Autodesk");
-        OIIO_CHECK_EQUAL(cinfo["Release"].getValue(), "2015");
-        OIIO_CHECK_EQUAL(cinfo["InputColorSpace"]["Description"].getValue(), 
+        OCIO_CHECK_EQUAL(cinfo["Copyright"].getValue(), "Copyright 2013 Autodesk");
+        OCIO_CHECK_EQUAL(cinfo["Release"].getValue(), "2015");
+        OCIO_CHECK_EQUAL(cinfo["InputColorSpace"]["Description"].getValue(), 
                          "Input color space description");
-        OIIO_CHECK_EQUAL(cinfo["InputColorSpace"]["Profile"].getValue(), 
+        OCIO_CHECK_EQUAL(cinfo["InputColorSpace"]["Profile"].getValue(), 
                          "Input color space profile");
-        OIIO_CHECK_EQUAL(cinfo["OutputColorSpace"]["Description"].getValue(), 
+        OCIO_CHECK_EQUAL(cinfo["OutputColorSpace"]["Description"].getValue(), 
                          "Output color space description");
-        OIIO_CHECK_EQUAL(cinfo["OutputColorSpace"]["Profile"].getValue(), 
+        OCIO_CHECK_EQUAL(cinfo["OutputColorSpace"]["Profile"].getValue(), 
                          "Output color space profile");
-        OIIO_CHECK_EQUAL(cinfo["Category"]["Name"].getValue(),
+        OCIO_CHECK_EQUAL(cinfo["Category"]["Name"].getValue(),
                          "Color space category name");
-        OIIO_CHECK_EQUAL(cinfo["Category"]["Importance"].getValue(), "High");
+        OCIO_CHECK_EQUAL(cinfo["Category"]["Importance"].getValue(), "High");
     }
 
     info["Extra"]["Item1"]["Item1a"] = "Extra:Item1:Item1a";
@@ -291,8 +291,8 @@ OIIO_ADD_TEST(Metadata, test_accessors)
 
     {
         const OCIO::Metadata cinfo = info;
-        OIIO_CHECK_ASSERT(!cinfo["Extra"].isLeaf());
-        OIIO_CHECK_ASSERT(cinfo["Extra"].getItems().size() == 2);
+        OCIO_CHECK_ASSERT(!cinfo["Extra"].isLeaf());
+        OCIO_CHECK_ASSERT(cinfo["Extra"].getItems().size() == 2);
     }
 
     // This should clear subelements of 'Extra' and make it a leaf metadata.
@@ -300,8 +300,8 @@ OIIO_ADD_TEST(Metadata, test_accessors)
 
     {
         const OCIO::Metadata& cinfo = info;
-        OIIO_CHECK_ASSERT(cinfo["Extra"].isLeaf());
-        OIIO_CHECK_EQUAL(cinfo["Extra"].getValue(), "Blah");
+        OCIO_CHECK_ASSERT(cinfo["Extra"].isLeaf());
+        OCIO_CHECK_EQUAL(cinfo["Extra"].getValue(), "Blah");
     }
 
     // This should clear the (leaf) value of 'Extra'
@@ -311,9 +311,9 @@ OIIO_ADD_TEST(Metadata, test_accessors)
 
     {
         const OCIO::Metadata& cinfo = info;
-        OIIO_CHECK_ASSERT(!cinfo["Extra"].isLeaf());
-        OIIO_CHECK_EQUAL(cinfo["Extra"].getItems().size(), 1);
-        OIIO_CHECK_EQUAL(cinfo["Extra"]["Item3"].getItems().size(), 3);
+        OCIO_CHECK_ASSERT(!cinfo["Extra"].isLeaf());
+        OCIO_CHECK_EQUAL(cinfo["Extra"].getItems().size(), 1);
+        OCIO_CHECK_EQUAL(cinfo["Extra"]["Item3"].getItems().size(), 3);
     }
 
     // Remove a subelement.
@@ -321,10 +321,10 @@ OIIO_ADD_TEST(Metadata, test_accessors)
 
     {
         const OCIO::Metadata& cinfo = info;
-        OIIO_CHECK_EQUAL(cinfo["Extra"]["Item3"].getItems().size(), 2);
-        OIIO_CHECK_EQUAL(cinfo["Extra"]["Item3"]["Item3a"].getValue(), 
+        OCIO_CHECK_EQUAL(cinfo["Extra"]["Item3"].getItems().size(), 2);
+        OCIO_CHECK_EQUAL(cinfo["Extra"]["Item3"]["Item3a"].getValue(), 
                          "Extra:Item3:Item3a");
-        OIIO_CHECK_EQUAL(cinfo["Extra"]["Item3"]["Item3c"].getValue(),
+        OCIO_CHECK_EQUAL(cinfo["Extra"]["Item3"]["Item3c"].getValue(),
                          "Extra:Item3:Item3c");
     }
 
@@ -334,8 +334,8 @@ OIIO_ADD_TEST(Metadata, test_accessors)
 
     {
         const OCIO::Metadata& cinfo = info;
-        OIIO_CHECK_ASSERT(cinfo["Extra"]["Item3"]["Item3a"].isLeaf());
-        OIIO_CHECK_EQUAL(cinfo["Extra"]["Item3"]["Item3a"].getValue(), "");
+        OCIO_CHECK_ASSERT(cinfo["Extra"]["Item3"]["Item3a"].isLeaf());
+        OCIO_CHECK_EQUAL(cinfo["Extra"]["Item3"]["Item3a"].getValue(), "");
     }
 
     // Clearing a non-leaf metadata.
@@ -344,8 +344,8 @@ OIIO_ADD_TEST(Metadata, test_accessors)
 
     {
         const OCIO::Metadata& cinfo = info;
-        OIIO_CHECK_ASSERT(cinfo["Extra"]["Item3"].isLeaf());
-        OIIO_CHECK_EQUAL(cinfo["Extra"]["Item3"].getValue(), "");
+        OCIO_CHECK_ASSERT(cinfo["Extra"]["Item3"].isLeaf());
+        OCIO_CHECK_EQUAL(cinfo["Extra"]["Item3"].getValue(), "");
     }
 
     // Create a separate metadata structure and use it to replace an element.
@@ -359,28 +359,28 @@ OIIO_ADD_TEST(Metadata, test_accessors)
     info["InputColorSpace"] = newInCS;
     {
         const OCIO::Metadata& cinfo = info;
-        OIIO_CHECK_EQUAL(cinfo["NewInputColorSpace"]["Profile"].getValue(),
+        OCIO_CHECK_EQUAL(cinfo["NewInputColorSpace"]["Profile"].getValue(),
                          "New input color space profile");
-        OIIO_CHECK_EQUAL(cinfo["NewInputColorSpace"]["Description"].getValue(),
+        OCIO_CHECK_EQUAL(cinfo["NewInputColorSpace"]["Description"].getValue(),
                          "New input color space description");
     }
 
     // Check exceptions.
     const OCIO::Metadata& cinfo = info;
 
-    OIIO_CHECK_THROW_WHAT(cinfo["OutputColorSpace"].getValue(), 
+    OCIO_CHECK_THROW_WHAT(cinfo["OutputColorSpace"].getValue(), 
                           OCIO::Exception, 
                           "Metadata should be a leaf 'OutputColorSpace'");
 
-    OIIO_CHECK_THROW_WHAT(cinfo["OutputColorSpace"]["Profile"].getItems(),
+    OCIO_CHECK_THROW_WHAT(cinfo["OutputColorSpace"]["Profile"].getItems(),
                           OCIO::Exception,
                           "Metadata should be a container 'Profile'");
 
-    OIIO_CHECK_THROW_WHAT(cinfo["OutputColorSpace"]["WrongName"],
+    OCIO_CHECK_THROW_WHAT(cinfo["OutputColorSpace"]["WrongName"],
                           OCIO::Exception,
                           "Metadata element not found 'WrongName'");
 
-    OIIO_CHECK_THROW_WHAT(info["OutputColorSpace"].remove("WrongName"),
+    OCIO_CHECK_THROW_WHAT(info["OutputColorSpace"].remove("WrongName"),
                           OCIO::Exception,
                           "Metadata element not found 'WrongName'");
     

--- a/src/OpenColorIO/ops/NoOp/NoOps.cpp
+++ b/src/OpenColorIO/ops/NoOp/NoOps.cpp
@@ -460,7 +460,7 @@ OCIO_NAMESPACE_EXIT
 OCIO_NAMESPACE_USING
 namespace OCIO = OCIO_NAMESPACE;
 
-#include "unittest.h"
+#include "UnitTest.h"
 #include "ops/Lut1D/Lut1DOp.h"
 #include "ops/Matrix/MatrixOps.h"
 
@@ -506,20 +506,20 @@ void CreateGenericLutOp(OpRcPtrVec & ops)
     CreateLut1DOp(ops, lut, INTERP_LINEAR, TRANSFORM_DIR_FORWARD);
 }
 
-OIIO_ADD_TEST(NoOps, PartitionGPUOps)
+OCIO_ADD_TEST(NoOps, PartitionGPUOps)
 {
     {
     OpRcPtrVec ops;
     
     OpRcPtrVec gpuPreOps, gpuLatticeOps, gpuPostOps;
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         PartitionGPUOps(gpuPreOps, gpuLatticeOps, gpuPostOps, ops));
     
-    OIIO_CHECK_EQUAL(gpuPreOps.size(), 0);
-    OIIO_CHECK_EQUAL(gpuLatticeOps.size(), 0);
-    OIIO_CHECK_EQUAL(gpuPostOps.size(), 0);
+    OCIO_CHECK_EQUAL(gpuPreOps.size(), 0);
+    OCIO_CHECK_EQUAL(gpuLatticeOps.size(), 0);
+    OCIO_CHECK_EQUAL(gpuPostOps.size(), 0);
     
-    OIIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
+    OCIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
                                                   gpuLatticeOps,
                                                   gpuPostOps) );
     }
@@ -527,21 +527,21 @@ OIIO_ADD_TEST(NoOps, PartitionGPUOps)
     {
     OpRcPtrVec ops;
     CreateGenericAllocationOp(ops);
-    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops.size(), 1);
 
     OpRcPtrVec gpuPreOps, gpuLatticeOps, gpuPostOps;
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         PartitionGPUOps(gpuPreOps, gpuLatticeOps, gpuPostOps, ops));
     
-    OIIO_REQUIRE_EQUAL(gpuPreOps.size(), 1);
-    OIIO_CHECK_EQUAL(gpuLatticeOps.size(), 0);
-    OIIO_CHECK_EQUAL(gpuPostOps.size(), 0);
+    OCIO_REQUIRE_EQUAL(gpuPreOps.size(), 1);
+    OCIO_CHECK_EQUAL(gpuLatticeOps.size(), 0);
+    OCIO_CHECK_EQUAL(gpuPostOps.size(), 0);
 
     OCIO::ConstOpRcPtr op0 = gpuPreOps[0];
 
-    OIIO_CHECK_EQUAL(ops[0]->isSameType(op0), true);
+    OCIO_CHECK_EQUAL(ops[0]->isSameType(op0), true);
 
-    OIIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
+    OCIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
                                                   gpuLatticeOps,
                                                   gpuPostOps) );
     }
@@ -551,17 +551,17 @@ OIIO_ADD_TEST(NoOps, PartitionGPUOps)
     
     CreateGenericAllocationOp(ops);
     CreateGenericScaleOp(ops);
-    OIIO_CHECK_EQUAL(ops.size(), 2);
+    OCIO_CHECK_EQUAL(ops.size(), 2);
 
     OpRcPtrVec gpuPreOps, gpuLatticeOps, gpuPostOps;
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         PartitionGPUOps(gpuPreOps, gpuLatticeOps, gpuPostOps, ops));
     
-    OIIO_CHECK_EQUAL(gpuPreOps.size(), 2);
-    OIIO_CHECK_EQUAL(gpuLatticeOps.size(), 0);
-    OIIO_CHECK_EQUAL(gpuPostOps.size(), 0);
+    OCIO_CHECK_EQUAL(gpuPreOps.size(), 2);
+    OCIO_CHECK_EQUAL(gpuLatticeOps.size(), 0);
+    OCIO_CHECK_EQUAL(gpuPostOps.size(), 0);
     
-    OIIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
+    OCIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
                                                   gpuLatticeOps,
                                                   gpuPostOps) );
     }
@@ -572,17 +572,17 @@ OIIO_ADD_TEST(NoOps, PartitionGPUOps)
     CreateGenericAllocationOp(ops);
     CreateGenericLutOp(ops);
     CreateGenericScaleOp(ops);
-    OIIO_CHECK_EQUAL(ops.size(), 3);
+    OCIO_CHECK_EQUAL(ops.size(), 3);
 
     OpRcPtrVec gpuPreOps, gpuLatticeOps, gpuPostOps;
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         PartitionGPUOps(gpuPreOps, gpuLatticeOps, gpuPostOps, ops));
     
-    OIIO_CHECK_EQUAL(gpuPreOps.size(), 2);
-    OIIO_CHECK_EQUAL(gpuLatticeOps.size(), 4);
-    OIIO_CHECK_EQUAL(gpuPostOps.size(), 1);
+    OCIO_CHECK_EQUAL(gpuPreOps.size(), 2);
+    OCIO_CHECK_EQUAL(gpuLatticeOps.size(), 4);
+    OCIO_CHECK_EQUAL(gpuPostOps.size(), 1);
     
-    OIIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
+    OCIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
                                                   gpuLatticeOps,
                                                   gpuPostOps) );
     }
@@ -591,17 +591,17 @@ OIIO_ADD_TEST(NoOps, PartitionGPUOps)
     OpRcPtrVec ops;
     
     CreateGenericLutOp(ops);
-    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops.size(), 1);
 
     OpRcPtrVec gpuPreOps, gpuLatticeOps, gpuPostOps;
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         PartitionGPUOps(gpuPreOps, gpuLatticeOps, gpuPostOps, ops));
     
-    OIIO_CHECK_EQUAL(gpuPreOps.size(), 0);
-    OIIO_CHECK_EQUAL(gpuLatticeOps.size(), 1);
-    OIIO_CHECK_EQUAL(gpuPostOps.size(), 0);
+    OCIO_CHECK_EQUAL(gpuPreOps.size(), 0);
+    OCIO_CHECK_EQUAL(gpuLatticeOps.size(), 1);
+    OCIO_CHECK_EQUAL(gpuPostOps.size(), 0);
     
-    OIIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
+    OCIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
                                                   gpuLatticeOps,
                                                   gpuPostOps) );
     }
@@ -615,17 +615,17 @@ OIIO_ADD_TEST(NoOps, PartitionGPUOps)
     CreateGenericLutOp(ops);
     CreateGenericScaleOp(ops);
     CreateGenericAllocationOp(ops);
-    OIIO_CHECK_EQUAL(ops.size(), 6);
+    OCIO_CHECK_EQUAL(ops.size(), 6);
 
     OpRcPtrVec gpuPreOps, gpuLatticeOps, gpuPostOps;
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         PartitionGPUOps(gpuPreOps, gpuLatticeOps, gpuPostOps, ops));
     
-    OIIO_CHECK_EQUAL(gpuPreOps.size(), 0);
-    OIIO_CHECK_EQUAL(gpuLatticeOps.size(), 4);
-    OIIO_CHECK_EQUAL(gpuPostOps.size(), 2);
+    OCIO_CHECK_EQUAL(gpuPreOps.size(), 0);
+    OCIO_CHECK_EQUAL(gpuLatticeOps.size(), 4);
+    OCIO_CHECK_EQUAL(gpuPostOps.size(), 2);
     
-    OIIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
+    OCIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
                                                   gpuLatticeOps,
                                                   gpuPostOps) );
     }
@@ -641,17 +641,17 @@ OIIO_ADD_TEST(NoOps, PartitionGPUOps)
     CreateGenericLutOp(ops);
     CreateGenericScaleOp(ops);
     CreateGenericAllocationOp(ops);
-    OIIO_CHECK_EQUAL(ops.size(), 8);
+    OCIO_CHECK_EQUAL(ops.size(), 8);
 
     OpRcPtrVec gpuPreOps, gpuLatticeOps, gpuPostOps;
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         PartitionGPUOps(gpuPreOps, gpuLatticeOps, gpuPostOps, ops));
     
-    OIIO_CHECK_EQUAL(gpuPreOps.size(), 2);
-    OIIO_CHECK_EQUAL(gpuLatticeOps.size(), 8);
-    OIIO_CHECK_EQUAL(gpuPostOps.size(), 2);
+    OCIO_CHECK_EQUAL(gpuPreOps.size(), 2);
+    OCIO_CHECK_EQUAL(gpuLatticeOps.size(), 8);
+    OCIO_CHECK_EQUAL(gpuPostOps.size(), 2);
     
-    OIIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
+    OCIO_CHECK_NO_THROW( AssertPartitionIntegrity(gpuPreOps,
                                                   gpuLatticeOps,
                                                   gpuPostOps) );
     /*
@@ -665,7 +665,7 @@ OIIO_ADD_TEST(NoOps, PartitionGPUOps)
     }
 } // PartitionGPUOps
 
-OIIO_ADD_TEST(NoOps, Throw)
+OCIO_ADD_TEST(NoOps, Throw)
 {
     // PartitionGPUOps might throw, but could not find how
 
@@ -676,84 +676,84 @@ OIIO_ADD_TEST(NoOps, Throw)
     CreateGenericScaleOp(ops);
 
     OpRcPtrVec gpuPreOps, gpuLatticeOps, gpuPostOps;
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         PartitionGPUOps(gpuPreOps, gpuLatticeOps, gpuPostOps, ops));
 
-    OIIO_CHECK_THROW_WHAT(AssertPartitionIntegrity(
+    OCIO_CHECK_THROW_WHAT(AssertPartitionIntegrity(
         gpuLatticeOps, gpuLatticeOps, gpuPostOps),
         OCIO::Exception, "One gpuPreOps op does not support GPU");
 
-    OIIO_CHECK_THROW_WHAT(AssertPartitionIntegrity(
+    OCIO_CHECK_THROW_WHAT(AssertPartitionIntegrity(
         gpuPreOps, gpuPreOps, gpuPostOps),
         OCIO::Exception, "All gpuLatticeOps ops do support GPU");
 
-    OIIO_CHECK_THROW_WHAT(AssertPartitionIntegrity(
+    OCIO_CHECK_THROW_WHAT(AssertPartitionIntegrity(
         gpuPreOps, gpuLatticeOps, gpuLatticeOps),
         OCIO::Exception, "One gpuPostOps op does not support GPU");
 
 }
 
-OIIO_ADD_TEST(NoOps, AllocationOp)
+OCIO_ADD_TEST(NoOps, AllocationOp)
 {
     OpRcPtrVec ops;
     CreateGenericAllocationOp(ops);
     CreateGenericScaleOp(ops);
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     OCIO::ConstOpRcPtr op0 = ops[0];
     OCIO::ConstOpRcPtr op1 = ops[1];
     OpRcPtr clonedOp = ops[0]->clone();
 
-    OIIO_CHECK_EQUAL(clonedOp->isSameType(op0), true);
-    OIIO_CHECK_EQUAL(clonedOp->isSameType(op1), false);
-    OIIO_CHECK_EQUAL(clonedOp->isInverse(op0), true);
-    OIIO_CHECK_EQUAL(clonedOp->isInverse(op1), false);
+    OCIO_CHECK_EQUAL(clonedOp->isSameType(op0), true);
+    OCIO_CHECK_EQUAL(clonedOp->isSameType(op1), false);
+    OCIO_CHECK_EQUAL(clonedOp->isInverse(op0), true);
+    OCIO_CHECK_EQUAL(clonedOp->isInverse(op1), false);
 
-    OIIO_CHECK_EQUAL(clonedOp->isNoOp(), true);
-    OIIO_CHECK_EQUAL(clonedOp->hasChannelCrosstalk(), false);
-    OIIO_CHECK_EQUAL(clonedOp->supportedByLegacyShader(), true);
+    OCIO_CHECK_EQUAL(clonedOp->isNoOp(), true);
+    OCIO_CHECK_EQUAL(clonedOp->hasChannelCrosstalk(), false);
+    OCIO_CHECK_EQUAL(clonedOp->supportedByLegacyShader(), true);
 }
 
-OIIO_ADD_TEST(NoOps, FileOp)
+OCIO_ADD_TEST(NoOps, FileOp)
 {
     OpRcPtrVec ops;
     CreateFileNoOp(ops,"");
     CreateGenericAllocationOp(ops);
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     OCIO::ConstOpRcPtr op0 = ops[0];
     OCIO::ConstOpRcPtr op1 = ops[1];
     OpRcPtr clonedOp = ops[0]->clone();
 
-    OIIO_CHECK_EQUAL(clonedOp->isSameType(op0), true);
-    OIIO_CHECK_EQUAL(clonedOp->isSameType(op1), false);
-    OIIO_CHECK_EQUAL(clonedOp->isInverse(op0), true);
-    OIIO_CHECK_EQUAL(clonedOp->isInverse(op1), false);
+    OCIO_CHECK_EQUAL(clonedOp->isSameType(op0), true);
+    OCIO_CHECK_EQUAL(clonedOp->isSameType(op1), false);
+    OCIO_CHECK_EQUAL(clonedOp->isInverse(op0), true);
+    OCIO_CHECK_EQUAL(clonedOp->isInverse(op1), false);
 
-    OIIO_CHECK_EQUAL(clonedOp->isNoOp(), true);
-    OIIO_CHECK_EQUAL(clonedOp->hasChannelCrosstalk(), false);
-    OIIO_CHECK_EQUAL(clonedOp->supportedByLegacyShader(), true);
+    OCIO_CHECK_EQUAL(clonedOp->isNoOp(), true);
+    OCIO_CHECK_EQUAL(clonedOp->hasChannelCrosstalk(), false);
+    OCIO_CHECK_EQUAL(clonedOp->supportedByLegacyShader(), true);
 }
 
-OIIO_ADD_TEST(NoOps, LookOp)
+OCIO_ADD_TEST(NoOps, LookOp)
 {
     OpRcPtrVec ops;
     CreateLookNoOp(ops, "");
     CreateGenericAllocationOp(ops);
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     OCIO::ConstOpRcPtr op0 = ops[0];
     OCIO::ConstOpRcPtr op1 = ops[1];
     OpRcPtr clonedOp = ops[0]->clone();
 
-    OIIO_CHECK_EQUAL(clonedOp->isSameType(op0), true);
-    OIIO_CHECK_EQUAL(clonedOp->isSameType(op1), false);
-    OIIO_CHECK_EQUAL(clonedOp->isInverse(op0), true);
-    OIIO_CHECK_EQUAL(clonedOp->isInverse(op1), false);
+    OCIO_CHECK_EQUAL(clonedOp->isSameType(op0), true);
+    OCIO_CHECK_EQUAL(clonedOp->isSameType(op1), false);
+    OCIO_CHECK_EQUAL(clonedOp->isInverse(op0), true);
+    OCIO_CHECK_EQUAL(clonedOp->isInverse(op1), false);
 
-    OIIO_CHECK_EQUAL(clonedOp->isNoOp(), true);
-    OIIO_CHECK_EQUAL(clonedOp->hasChannelCrosstalk(), false);
-    OIIO_CHECK_EQUAL(clonedOp->supportedByLegacyShader(), true);
+    OCIO_CHECK_EQUAL(clonedOp->isNoOp(), true);
+    OCIO_CHECK_EQUAL(clonedOp->hasChannelCrosstalk(), false);
+    OCIO_CHECK_EQUAL(clonedOp->supportedByLegacyShader(), true);
 }
 
 #endif // OCIO_UNIT_TEST

--- a/src/OpenColorIO/ops/Range/RangeOpCPU.cpp
+++ b/src/OpenColorIO/ops/Range/RangeOpCPU.cpp
@@ -380,41 +380,41 @@ namespace OCIO = OCIO_NAMESPACE;
 #include <limits>
 #include "ops/Range/RangeOpData.h"
 #include "pystring/pystring.h"
-#include "unittest.h"
+#include "UnitTest.h"
 
 
 static const float g_error = 1e-7f;
 
 
-OIIO_ADD_TEST(RangeOpCPU, identity)
+OCIO_ADD_TEST(RangeOpCPU, identity)
 {
     OCIO::RangeOpDataRcPtr range = std::make_shared<OCIO::RangeOpData>();
-    OIIO_CHECK_NO_THROW(range->validate());
-    OIIO_CHECK_NO_THROW(range->finalize());
-    OIIO_CHECK_NO_THROW(range->isIdentity());
-    OIIO_CHECK_NO_THROW(range->isNoOp());
+    OCIO_CHECK_NO_THROW(range->validate());
+    OCIO_CHECK_NO_THROW(range->finalize());
+    OCIO_CHECK_NO_THROW(range->isIdentity());
+    OCIO_CHECK_NO_THROW(range->isNoOp());
 
     OCIO::ConstRangeOpDataRcPtr r = range;
-    OIIO_CHECK_THROW_WHAT(OCIO::GetRangeRenderer(r), 
+    OCIO_CHECK_THROW_WHAT(OCIO::GetRangeRenderer(r), 
                           OCIO::Exception, 
                           "No processing as the Range is a NoOp");
 }
 
-OIIO_ADD_TEST(RangeOpCPU, scale_with_low_and_high_clippings)
+OCIO_ADD_TEST(RangeOpCPU, scale_with_low_and_high_clippings)
 {
     OCIO::RangeOpDataRcPtr range 
         = std::make_shared<OCIO::RangeOpData>(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, 
                                               0., 1., 0.5, 1.5);
 
-    OIIO_CHECK_NO_THROW(range->validate());
-    OIIO_CHECK_NO_THROW(range->finalize());
+    OCIO_CHECK_NO_THROW(range->validate());
+    OCIO_CHECK_NO_THROW(range->finalize());
 
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeScaleMinMaxRenderer"));
+    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeScaleMinMaxRenderer"));
 
     const long numPixels = 9;
     const float qnan = std::numeric_limits<float>::quiet_NaN();
@@ -429,70 +429,70 @@ OIIO_ADD_TEST(RangeOpCPU, scale_with_low_and_high_clippings)
                                    -inf,   -inf,  -inf, 0.0f,
                                    0.0f,   0.0f,  0.0f, -inf };
 
-    OIIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
+    OCIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
 
-    OIIO_CHECK_CLOSE(image[0],  0.50f, g_error);
-    OIIO_CHECK_CLOSE(image[1],  0.50f, g_error);
-    OIIO_CHECK_CLOSE(image[2],  1.00f, g_error);
-    OIIO_CHECK_CLOSE(image[3],  0.00f, g_error);
+    OCIO_CHECK_CLOSE(image[0],  0.50f, g_error);
+    OCIO_CHECK_CLOSE(image[1],  0.50f, g_error);
+    OCIO_CHECK_CLOSE(image[2],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[3],  0.00f, g_error);
 
-    OIIO_CHECK_CLOSE(image[4],  1.25f, g_error);
-    OIIO_CHECK_CLOSE(image[5],  1.50f, g_error);
-    OIIO_CHECK_CLOSE(image[6],  1.50f, g_error);
-    OIIO_CHECK_CLOSE(image[7],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[4],  1.25f, g_error);
+    OCIO_CHECK_CLOSE(image[5],  1.50f, g_error);
+    OCIO_CHECK_CLOSE(image[6],  1.50f, g_error);
+    OCIO_CHECK_CLOSE(image[7],  1.00f, g_error);
 
-    OIIO_CHECK_CLOSE(image[8],  1.50f, g_error);
-    OIIO_CHECK_CLOSE(image[9],  1.50f, g_error);
-    OIIO_CHECK_CLOSE(image[10], 1.50f, g_error);
-    OIIO_CHECK_CLOSE(image[11], 0.00f, g_error);
+    OCIO_CHECK_CLOSE(image[8],  1.50f, g_error);
+    OCIO_CHECK_CLOSE(image[9],  1.50f, g_error);
+    OCIO_CHECK_CLOSE(image[10], 1.50f, g_error);
+    OCIO_CHECK_CLOSE(image[11], 0.00f, g_error);
 
-    OIIO_CHECK_EQUAL(image[12], 0.50f);
-    OIIO_CHECK_EQUAL(image[13], 0.50f);
-    OIIO_CHECK_EQUAL(image[14], 0.50f);
-    OIIO_CHECK_EQUAL(image[15], 0.00f);
+    OCIO_CHECK_EQUAL(image[12], 0.50f);
+    OCIO_CHECK_EQUAL(image[13], 0.50f);
+    OCIO_CHECK_EQUAL(image[14], 0.50f);
+    OCIO_CHECK_EQUAL(image[15], 0.00f);
 
-    OIIO_CHECK_EQUAL(image[16], 0.50f);
-    OIIO_CHECK_EQUAL(image[17], 0.50f);
-    OIIO_CHECK_EQUAL(image[18], 0.50f);
-    OIIO_CHECK_ASSERT(OCIO::IsNan(image[19]));
+    OCIO_CHECK_EQUAL(image[16], 0.50f);
+    OCIO_CHECK_EQUAL(image[17], 0.50f);
+    OCIO_CHECK_EQUAL(image[18], 0.50f);
+    OCIO_CHECK_ASSERT(OCIO::IsNan(image[19]));
 
-    OIIO_CHECK_EQUAL(image[20], 1.50f);
-    OIIO_CHECK_EQUAL(image[21], 1.50f);
-    OIIO_CHECK_EQUAL(image[22], 1.50f);
-    OIIO_CHECK_EQUAL(image[23], 0.0f);
+    OCIO_CHECK_EQUAL(image[20], 1.50f);
+    OCIO_CHECK_EQUAL(image[21], 1.50f);
+    OCIO_CHECK_EQUAL(image[22], 1.50f);
+    OCIO_CHECK_EQUAL(image[23], 0.0f);
 
-    OIIO_CHECK_EQUAL(image[24], 0.50f);
-    OIIO_CHECK_EQUAL(image[25], 0.50f);
-    OIIO_CHECK_EQUAL(image[26], 0.50f);
-    OIIO_CHECK_EQUAL(image[27], inf);
+    OCIO_CHECK_EQUAL(image[24], 0.50f);
+    OCIO_CHECK_EQUAL(image[25], 0.50f);
+    OCIO_CHECK_EQUAL(image[26], 0.50f);
+    OCIO_CHECK_EQUAL(image[27], inf);
 
-    OIIO_CHECK_EQUAL(image[28], 0.50f);
-    OIIO_CHECK_EQUAL(image[29], 0.50f);
-    OIIO_CHECK_EQUAL(image[30], 0.50f);
-    OIIO_CHECK_EQUAL(image[31], 0.0f);
+    OCIO_CHECK_EQUAL(image[28], 0.50f);
+    OCIO_CHECK_EQUAL(image[29], 0.50f);
+    OCIO_CHECK_EQUAL(image[30], 0.50f);
+    OCIO_CHECK_EQUAL(image[31], 0.0f);
 
-    OIIO_CHECK_EQUAL(image[32], 0.50f);
-    OIIO_CHECK_EQUAL(image[33], 0.50f);
-    OIIO_CHECK_EQUAL(image[34], 0.50f);
-    OIIO_CHECK_EQUAL(image[35], -inf);
+    OCIO_CHECK_EQUAL(image[32], 0.50f);
+    OCIO_CHECK_EQUAL(image[33], 0.50f);
+    OCIO_CHECK_EQUAL(image[34], 0.50f);
+    OCIO_CHECK_EQUAL(image[35], -inf);
 }
 
-OIIO_ADD_TEST(RangeOpCPU, scale_with_low_clipping)
+OCIO_ADD_TEST(RangeOpCPU, scale_with_low_clipping)
 {
     OCIO::RangeOpDataRcPtr range 
         = std::make_shared<OCIO::RangeOpData>(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, 
                                               0.,  OCIO::RangeOpData::EmptyValue(), 
                                               0.5, OCIO::RangeOpData::EmptyValue());
 
-    OIIO_CHECK_NO_THROW(range->validate());
-    OIIO_CHECK_NO_THROW(range->finalize());
+    OCIO_CHECK_NO_THROW(range->validate());
+    OCIO_CHECK_NO_THROW(range->finalize());
 
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeScaleMinRenderer"));
+    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeScaleMinRenderer"));
 
     const long numPixels = 9;
     const float qnan = std::numeric_limits<float>::quiet_NaN();
@@ -507,70 +507,70 @@ OIIO_ADD_TEST(RangeOpCPU, scale_with_low_clipping)
                                   -inf,   -inf,  -inf, 0.0f,
                                   0.0f,   0.0f,  0.0f, -inf };
 
-    OIIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
+    OCIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
 
-    OIIO_CHECK_CLOSE(image[0],  0.50f, g_error);
-    OIIO_CHECK_CLOSE(image[1],  0.50f, g_error);
-    OIIO_CHECK_CLOSE(image[2],  1.00f, g_error);
-    OIIO_CHECK_CLOSE(image[3],  0.00f, g_error);
+    OCIO_CHECK_CLOSE(image[0],  0.50f, g_error);
+    OCIO_CHECK_CLOSE(image[1],  0.50f, g_error);
+    OCIO_CHECK_CLOSE(image[2],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[3],  0.00f, g_error);
 
-    OIIO_CHECK_CLOSE(image[4],  1.25f, g_error);
-    OIIO_CHECK_CLOSE(image[5],  1.50f, g_error);
-    OIIO_CHECK_CLOSE(image[6],  1.75f, g_error);
-    OIIO_CHECK_CLOSE(image[7],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[4],  1.25f, g_error);
+    OCIO_CHECK_CLOSE(image[5],  1.50f, g_error);
+    OCIO_CHECK_CLOSE(image[6],  1.75f, g_error);
+    OCIO_CHECK_CLOSE(image[7],  1.00f, g_error);
 
-    OIIO_CHECK_CLOSE(image[8],  1.75f, g_error);
-    OIIO_CHECK_CLOSE(image[9],  2.00f, g_error);
-    OIIO_CHECK_CLOSE(image[10], 2.25f, g_error);
-    OIIO_CHECK_CLOSE(image[11], 0.00f, g_error);
+    OCIO_CHECK_CLOSE(image[8],  1.75f, g_error);
+    OCIO_CHECK_CLOSE(image[9],  2.00f, g_error);
+    OCIO_CHECK_CLOSE(image[10], 2.25f, g_error);
+    OCIO_CHECK_CLOSE(image[11], 0.00f, g_error);
 
-    OIIO_CHECK_EQUAL(image[12], 0.50f);
-    OIIO_CHECK_EQUAL(image[13], 0.50f);
-    OIIO_CHECK_EQUAL(image[14], 0.50f);
-    OIIO_CHECK_EQUAL(image[15], 0.00f);
+    OCIO_CHECK_EQUAL(image[12], 0.50f);
+    OCIO_CHECK_EQUAL(image[13], 0.50f);
+    OCIO_CHECK_EQUAL(image[14], 0.50f);
+    OCIO_CHECK_EQUAL(image[15], 0.00f);
 
-    OIIO_CHECK_EQUAL(image[16], 0.50f);
-    OIIO_CHECK_EQUAL(image[17], 0.50f);
-    OIIO_CHECK_EQUAL(image[18], 0.50f);
-    OIIO_CHECK_ASSERT(OCIO::IsNan(image[19]));
+    OCIO_CHECK_EQUAL(image[16], 0.50f);
+    OCIO_CHECK_EQUAL(image[17], 0.50f);
+    OCIO_CHECK_EQUAL(image[18], 0.50f);
+    OCIO_CHECK_ASSERT(OCIO::IsNan(image[19]));
 
-    OIIO_CHECK_EQUAL(image[20], inf);
-    OIIO_CHECK_EQUAL(image[21], inf);
-    OIIO_CHECK_EQUAL(image[22], inf);
-    OIIO_CHECK_EQUAL(image[23], 0.0f);
+    OCIO_CHECK_EQUAL(image[20], inf);
+    OCIO_CHECK_EQUAL(image[21], inf);
+    OCIO_CHECK_EQUAL(image[22], inf);
+    OCIO_CHECK_EQUAL(image[23], 0.0f);
 
-    OIIO_CHECK_EQUAL(image[24], 0.50f);
-    OIIO_CHECK_EQUAL(image[25], 0.50f);
-    OIIO_CHECK_EQUAL(image[26], 0.50f);
-    OIIO_CHECK_EQUAL(image[27], inf);
+    OCIO_CHECK_EQUAL(image[24], 0.50f);
+    OCIO_CHECK_EQUAL(image[25], 0.50f);
+    OCIO_CHECK_EQUAL(image[26], 0.50f);
+    OCIO_CHECK_EQUAL(image[27], inf);
 
-    OIIO_CHECK_EQUAL(image[28], 0.50f);
-    OIIO_CHECK_EQUAL(image[29], 0.50f);
-    OIIO_CHECK_EQUAL(image[30], 0.50f);
-    OIIO_CHECK_EQUAL(image[31], 0.0f);
+    OCIO_CHECK_EQUAL(image[28], 0.50f);
+    OCIO_CHECK_EQUAL(image[29], 0.50f);
+    OCIO_CHECK_EQUAL(image[30], 0.50f);
+    OCIO_CHECK_EQUAL(image[31], 0.0f);
 
-    OIIO_CHECK_EQUAL(image[32], 0.50f);
-    OIIO_CHECK_EQUAL(image[33], 0.50f);
-    OIIO_CHECK_EQUAL(image[34], 0.50f);
-    OIIO_CHECK_EQUAL(image[35], -inf);
+    OCIO_CHECK_EQUAL(image[32], 0.50f);
+    OCIO_CHECK_EQUAL(image[33], 0.50f);
+    OCIO_CHECK_EQUAL(image[34], 0.50f);
+    OCIO_CHECK_EQUAL(image[35], -inf);
 }
 
-OIIO_ADD_TEST(RangeOpCPU, scale_with_high_clipping)
+OCIO_ADD_TEST(RangeOpCPU, scale_with_high_clipping)
 {
     OCIO::RangeOpDataRcPtr range 
         = std::make_shared<OCIO::RangeOpData>(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, 
                                               OCIO::RangeOpData::EmptyValue(), 1., 
                                               OCIO::RangeOpData::EmptyValue(), 1.5);
 
-    OIIO_CHECK_NO_THROW(range->validate());
-    OIIO_CHECK_NO_THROW(range->finalize());
+    OCIO_CHECK_NO_THROW(range->validate());
+    OCIO_CHECK_NO_THROW(range->finalize());
 
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeScaleMaxRenderer"));
+    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeScaleMaxRenderer"));
 
     const long numPixels = 9;
     const float qnan = std::numeric_limits<float>::quiet_NaN();
@@ -585,147 +585,147 @@ OIIO_ADD_TEST(RangeOpCPU, scale_with_high_clipping)
                                    -inf,   -inf,  -inf, 0.0f,
                                    0.0f,   0.0f,  0.0f, -inf };
 
-    OIIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
+    OCIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
 
-    OIIO_CHECK_CLOSE(image[0],  0.00f, g_error);
-    OIIO_CHECK_CLOSE(image[1],  0.25f, g_error);
-    OIIO_CHECK_CLOSE(image[2],  1.00f, g_error);
-    OIIO_CHECK_CLOSE(image[3],  0.00f, g_error);
+    OCIO_CHECK_CLOSE(image[0],  0.00f, g_error);
+    OCIO_CHECK_CLOSE(image[1],  0.25f, g_error);
+    OCIO_CHECK_CLOSE(image[2],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[3],  0.00f, g_error);
 
-    OIIO_CHECK_CLOSE(image[4],  1.25f, g_error);
-    OIIO_CHECK_CLOSE(image[5],  1.50f, g_error);
-    OIIO_CHECK_CLOSE(image[6],  1.50f, g_error);
-    OIIO_CHECK_CLOSE(image[7],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[4],  1.25f, g_error);
+    OCIO_CHECK_CLOSE(image[5],  1.50f, g_error);
+    OCIO_CHECK_CLOSE(image[6],  1.50f, g_error);
+    OCIO_CHECK_CLOSE(image[7],  1.00f, g_error);
 
-    OIIO_CHECK_CLOSE(image[8],  1.50f, g_error);
-    OIIO_CHECK_CLOSE(image[9],  1.50f, g_error);
-    OIIO_CHECK_CLOSE(image[10], 1.50f, g_error);
-    OIIO_CHECK_CLOSE(image[11], 0.00f, g_error);
+    OCIO_CHECK_CLOSE(image[8],  1.50f, g_error);
+    OCIO_CHECK_CLOSE(image[9],  1.50f, g_error);
+    OCIO_CHECK_CLOSE(image[10], 1.50f, g_error);
+    OCIO_CHECK_CLOSE(image[11], 0.00f, g_error);
 
-    OIIO_CHECK_EQUAL(image[12], 1.50f);
-    OIIO_CHECK_EQUAL(image[13], 1.50f);
-    OIIO_CHECK_EQUAL(image[14], 1.50f);
-    OIIO_CHECK_EQUAL(image[15], 0.00f);
+    OCIO_CHECK_EQUAL(image[12], 1.50f);
+    OCIO_CHECK_EQUAL(image[13], 1.50f);
+    OCIO_CHECK_EQUAL(image[14], 1.50f);
+    OCIO_CHECK_EQUAL(image[15], 0.00f);
 
-    OIIO_CHECK_EQUAL(image[16], 0.50f);
-    OIIO_CHECK_EQUAL(image[17], 0.50f);
-    OIIO_CHECK_EQUAL(image[18], 0.50f);
-    OIIO_CHECK_ASSERT(OCIO::IsNan(image[19]));
+    OCIO_CHECK_EQUAL(image[16], 0.50f);
+    OCIO_CHECK_EQUAL(image[17], 0.50f);
+    OCIO_CHECK_EQUAL(image[18], 0.50f);
+    OCIO_CHECK_ASSERT(OCIO::IsNan(image[19]));
 
-    OIIO_CHECK_EQUAL(image[20], 1.50f);
-    OIIO_CHECK_EQUAL(image[21], 1.50f);
-    OIIO_CHECK_EQUAL(image[22], 1.50f);
-    OIIO_CHECK_EQUAL(image[23], 0.0f);
+    OCIO_CHECK_EQUAL(image[20], 1.50f);
+    OCIO_CHECK_EQUAL(image[21], 1.50f);
+    OCIO_CHECK_EQUAL(image[22], 1.50f);
+    OCIO_CHECK_EQUAL(image[23], 0.0f);
 
-    OIIO_CHECK_EQUAL(image[24], 0.50f);
-    OIIO_CHECK_EQUAL(image[25], 0.50f);
-    OIIO_CHECK_EQUAL(image[26], 0.50f);
-    OIIO_CHECK_EQUAL(image[27], inf);
+    OCIO_CHECK_EQUAL(image[24], 0.50f);
+    OCIO_CHECK_EQUAL(image[25], 0.50f);
+    OCIO_CHECK_EQUAL(image[26], 0.50f);
+    OCIO_CHECK_EQUAL(image[27], inf);
 
-    OIIO_CHECK_EQUAL(image[28], -inf);
-    OIIO_CHECK_EQUAL(image[29], -inf);
-    OIIO_CHECK_EQUAL(image[30], -inf);
-    OIIO_CHECK_EQUAL(image[31], 0.0f);
+    OCIO_CHECK_EQUAL(image[28], -inf);
+    OCIO_CHECK_EQUAL(image[29], -inf);
+    OCIO_CHECK_EQUAL(image[30], -inf);
+    OCIO_CHECK_EQUAL(image[31], 0.0f);
 
-    OIIO_CHECK_EQUAL(image[32], 0.50f);
-    OIIO_CHECK_EQUAL(image[33], 0.50f);
-    OIIO_CHECK_EQUAL(image[34], 0.50f);
-    OIIO_CHECK_EQUAL(image[35], -inf);
+    OCIO_CHECK_EQUAL(image[32], 0.50f);
+    OCIO_CHECK_EQUAL(image[33], 0.50f);
+    OCIO_CHECK_EQUAL(image[34], 0.50f);
+    OCIO_CHECK_EQUAL(image[35], -inf);
 }
 
-OIIO_ADD_TEST(RangeOpCPU, scale_with_low_and_high_clippings_2)
+OCIO_ADD_TEST(RangeOpCPU, scale_with_low_and_high_clippings_2)
 {
     OCIO::RangeOpDataRcPtr range 
         = std::make_shared<OCIO::RangeOpData>(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, 
                                               0., 1., 0., 1.5);
 
-    OIIO_CHECK_NO_THROW(range->validate());
-    OIIO_CHECK_NO_THROW(range->finalize());
+    OCIO_CHECK_NO_THROW(range->validate());
+    OCIO_CHECK_NO_THROW(range->finalize());
 
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeScaleMinMaxRenderer"));
+    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeScaleMinMaxRenderer"));
 
     const long numPixels = 3;
     float image[4*numPixels] = { -0.50f, -0.25f, 0.50f, 0.0f,
                                   0.75f,  1.00f, 1.25f, 1.0f,
                                   1.25f,  1.50f, 1.75f, 0.0f };
 
-    OIIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
+    OCIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
 
-    OIIO_CHECK_CLOSE(image[0],  0.000f, g_error);
-    OIIO_CHECK_CLOSE(image[1],  0.000f, g_error);
-    OIIO_CHECK_CLOSE(image[2],  0.750f, g_error);
-    OIIO_CHECK_CLOSE(image[3],  0.000f, g_error);
+    OCIO_CHECK_CLOSE(image[0],  0.000f, g_error);
+    OCIO_CHECK_CLOSE(image[1],  0.000f, g_error);
+    OCIO_CHECK_CLOSE(image[2],  0.750f, g_error);
+    OCIO_CHECK_CLOSE(image[3],  0.000f, g_error);
 
-    OIIO_CHECK_CLOSE(image[4],  1.125f, g_error);
-    OIIO_CHECK_CLOSE(image[5],  1.500f, g_error);
-    OIIO_CHECK_CLOSE(image[6],  1.500f, g_error);
-    OIIO_CHECK_CLOSE(image[7],  1.000f, g_error);
+    OCIO_CHECK_CLOSE(image[4],  1.125f, g_error);
+    OCIO_CHECK_CLOSE(image[5],  1.500f, g_error);
+    OCIO_CHECK_CLOSE(image[6],  1.500f, g_error);
+    OCIO_CHECK_CLOSE(image[7],  1.000f, g_error);
 
-    OIIO_CHECK_CLOSE(image[8],  1.500f, g_error);
-    OIIO_CHECK_CLOSE(image[9],  1.500f, g_error);
-    OIIO_CHECK_CLOSE(image[10], 1.500f, g_error);
-    OIIO_CHECK_CLOSE(image[11], 0.000f, g_error);
+    OCIO_CHECK_CLOSE(image[8],  1.500f, g_error);
+    OCIO_CHECK_CLOSE(image[9],  1.500f, g_error);
+    OCIO_CHECK_CLOSE(image[10], 1.500f, g_error);
+    OCIO_CHECK_CLOSE(image[11], 0.000f, g_error);
 }
 
-OIIO_ADD_TEST(RangeOpCPU, offset_with_low_and_high_clippings)
+OCIO_ADD_TEST(RangeOpCPU, offset_with_low_and_high_clippings)
 {
     OCIO::RangeOpDataRcPtr range 
         = std::make_shared<OCIO::RangeOpData>(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, 
                                               0., 1., 1., 2.);
 
-    OIIO_CHECK_NO_THROW(range->validate());
-    OIIO_CHECK_NO_THROW(range->finalize());
+    OCIO_CHECK_NO_THROW(range->validate());
+    OCIO_CHECK_NO_THROW(range->finalize());
 
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeScaleMinMaxRenderer"));
+    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeScaleMinMaxRenderer"));
 
     const long numPixels = 3;
     float image[4*numPixels] = { -0.50f, -0.25f, 0.50f, 0.0f,
                                   0.75f,  1.00f, 1.25f, 1.0f,
                                   1.25f,  1.50f, 1.75f, 0.0f };
 
-    OIIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
+    OCIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
 
-    OIIO_CHECK_CLOSE(image[0],  1.00f, g_error);
-    OIIO_CHECK_CLOSE(image[1],  1.00f, g_error);
-    OIIO_CHECK_CLOSE(image[2],  1.50f, g_error);
-    OIIO_CHECK_CLOSE(image[3],  0.00f, g_error);
+    OCIO_CHECK_CLOSE(image[0],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[1],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[2],  1.50f, g_error);
+    OCIO_CHECK_CLOSE(image[3],  0.00f, g_error);
 
-    OIIO_CHECK_CLOSE(image[4],  1.75f, g_error);
-    OIIO_CHECK_CLOSE(image[5],  2.00f, g_error);
-    OIIO_CHECK_CLOSE(image[6],  2.00f, g_error);
-    OIIO_CHECK_CLOSE(image[7],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[4],  1.75f, g_error);
+    OCIO_CHECK_CLOSE(image[5],  2.00f, g_error);
+    OCIO_CHECK_CLOSE(image[6],  2.00f, g_error);
+    OCIO_CHECK_CLOSE(image[7],  1.00f, g_error);
 
-    OIIO_CHECK_CLOSE(image[8],  2.00f, g_error);
-    OIIO_CHECK_CLOSE(image[9],  2.00f, g_error);
-    OIIO_CHECK_CLOSE(image[10], 2.00f, g_error);
-    OIIO_CHECK_CLOSE(image[11], 0.00f, g_error);
+    OCIO_CHECK_CLOSE(image[8],  2.00f, g_error);
+    OCIO_CHECK_CLOSE(image[9],  2.00f, g_error);
+    OCIO_CHECK_CLOSE(image[10], 2.00f, g_error);
+    OCIO_CHECK_CLOSE(image[11], 0.00f, g_error);
 }
 
-OIIO_ADD_TEST(RangeOpCPU, low_and_high_clippings)
+OCIO_ADD_TEST(RangeOpCPU, low_and_high_clippings)
 {
     OCIO::RangeOpDataRcPtr range 
         = std::make_shared<OCIO::RangeOpData>(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, 
                                               1., 2., 1., 2.);
 
-    OIIO_CHECK_NO_THROW(range->validate());
-    OIIO_CHECK_NO_THROW(range->finalize());
+    OCIO_CHECK_NO_THROW(range->validate());
+    OCIO_CHECK_NO_THROW(range->finalize());
 
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeMinMaxRenderer"));
+    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeMinMaxRenderer"));
 
     const long numPixels = 4;
     float image[4*numPixels] = { -0.50f, -0.25f, 0.50f, 0.0f,
@@ -733,107 +733,107 @@ OIIO_ADD_TEST(RangeOpCPU, low_and_high_clippings)
                                   1.25f,  1.50f, 1.75f, 0.0f,
                                   2.00f,  2.50f, 2.75f, 1.0f };
 
-    OIIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
+    OCIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
 
-    OIIO_CHECK_CLOSE(image[0],  1.00f, g_error);
-    OIIO_CHECK_CLOSE(image[1],  1.00f, g_error);
-    OIIO_CHECK_CLOSE(image[2],  1.00f, g_error);
-    OIIO_CHECK_CLOSE(image[3],  0.00f, g_error);
+    OCIO_CHECK_CLOSE(image[0],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[1],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[2],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[3],  0.00f, g_error);
 
-    OIIO_CHECK_CLOSE(image[4],  1.00f, g_error);
-    OIIO_CHECK_CLOSE(image[5],  1.00f, g_error);
-    OIIO_CHECK_CLOSE(image[6],  1.25f, g_error);
-    OIIO_CHECK_CLOSE(image[7],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[4],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[5],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[6],  1.25f, g_error);
+    OCIO_CHECK_CLOSE(image[7],  1.00f, g_error);
 
-    OIIO_CHECK_CLOSE(image[8],  1.25f, g_error);
-    OIIO_CHECK_CLOSE(image[9],  1.50f, g_error);
-    OIIO_CHECK_CLOSE(image[10], 1.75f, g_error);
-    OIIO_CHECK_CLOSE(image[11], 0.00f, g_error);
+    OCIO_CHECK_CLOSE(image[8],  1.25f, g_error);
+    OCIO_CHECK_CLOSE(image[9],  1.50f, g_error);
+    OCIO_CHECK_CLOSE(image[10], 1.75f, g_error);
+    OCIO_CHECK_CLOSE(image[11], 0.00f, g_error);
 
-    OIIO_CHECK_CLOSE(image[12], 2.00f, g_error);
-    OIIO_CHECK_CLOSE(image[13], 2.00f, g_error);
-    OIIO_CHECK_CLOSE(image[14], 2.00f, g_error);
-    OIIO_CHECK_CLOSE(image[15], 1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[12], 2.00f, g_error);
+    OCIO_CHECK_CLOSE(image[13], 2.00f, g_error);
+    OCIO_CHECK_CLOSE(image[14], 2.00f, g_error);
+    OCIO_CHECK_CLOSE(image[15], 1.00f, g_error);
 }
 
-OIIO_ADD_TEST(RangeOpCPU, low_clipping)
+OCIO_ADD_TEST(RangeOpCPU, low_clipping)
 {
     OCIO::RangeOpDataRcPtr range 
         = std::make_shared<OCIO::RangeOpData>(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, 
                                               -0.1, OCIO::RangeOpData::EmptyValue(), 
                                               -0.1, OCIO::RangeOpData::EmptyValue());
 
-    OIIO_CHECK_NO_THROW(range->validate());
-    OIIO_CHECK_NO_THROW(range->finalize());
+    OCIO_CHECK_NO_THROW(range->validate());
+    OCIO_CHECK_NO_THROW(range->finalize());
 
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeMinRenderer"));
+    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeMinRenderer"));
 
     const long numPixels = 3;
     float image[4*numPixels] = { -0.50f, -0.25f, 0.50f, 0.0f,
                                   0.75f,  1.00f, 1.25f, 1.0f,
                                   1.25f,  1.50f, 1.75f, 0.0f };
 
-    OIIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
+    OCIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
 
-    OIIO_CHECK_CLOSE(image[0], -0.10f, g_error);
-    OIIO_CHECK_CLOSE(image[1], -0.10f, g_error);
-    OIIO_CHECK_CLOSE(image[2],  0.50f, g_error);
-    OIIO_CHECK_CLOSE(image[3],  0.00f, g_error);
+    OCIO_CHECK_CLOSE(image[0], -0.10f, g_error);
+    OCIO_CHECK_CLOSE(image[1], -0.10f, g_error);
+    OCIO_CHECK_CLOSE(image[2],  0.50f, g_error);
+    OCIO_CHECK_CLOSE(image[3],  0.00f, g_error);
 
-    OIIO_CHECK_CLOSE(image[4],  0.75f, g_error);
-    OIIO_CHECK_CLOSE(image[5],  1.00f, g_error);
-    OIIO_CHECK_CLOSE(image[6],  1.25f, g_error);
-    OIIO_CHECK_CLOSE(image[7],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[4],  0.75f, g_error);
+    OCIO_CHECK_CLOSE(image[5],  1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[6],  1.25f, g_error);
+    OCIO_CHECK_CLOSE(image[7],  1.00f, g_error);
 
-    OIIO_CHECK_CLOSE(image[8],  1.25f, g_error);
-    OIIO_CHECK_CLOSE(image[9],  1.50f, g_error);
-    OIIO_CHECK_CLOSE(image[10], 1.75f, g_error);
-    OIIO_CHECK_CLOSE(image[11], 0.00f, g_error);
+    OCIO_CHECK_CLOSE(image[8],  1.25f, g_error);
+    OCIO_CHECK_CLOSE(image[9],  1.50f, g_error);
+    OCIO_CHECK_CLOSE(image[10], 1.75f, g_error);
+    OCIO_CHECK_CLOSE(image[11], 0.00f, g_error);
 }
 
-OIIO_ADD_TEST(RangeOpCPU, high_clipping)
+OCIO_ADD_TEST(RangeOpCPU, high_clipping)
 {
     OCIO::RangeOpDataRcPtr range 
         = std::make_shared<OCIO::RangeOpData>(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32, 
                                               OCIO::RangeOpData::EmptyValue(), 1.1, 
                                               OCIO::RangeOpData::EmptyValue(), 1.1);
 
-    OIIO_CHECK_NO_THROW(range->validate());
-    OIIO_CHECK_NO_THROW(range->finalize());
+    OCIO_CHECK_NO_THROW(range->validate());
+    OCIO_CHECK_NO_THROW(range->finalize());
 
     OCIO::ConstRangeOpDataRcPtr r = range;
     OCIO::OpCPURcPtr op = OCIO::GetRangeRenderer(r);
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OIIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeMaxRenderer"));
+    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeMaxRenderer"));
 
     const long numPixels = 3;
     float image[4*numPixels] = { -0.50f, -0.25f, 0.50f, 0.0f,
                                   0.75f,  1.00f, 1.25f, 1.0f,
                                   1.25f,  1.50f, 1.75f, 0.0f };
 
-    OIIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
+    OCIO_CHECK_NO_THROW(op->apply(&image[0], &image[0], numPixels));
 
-    OIIO_CHECK_CLOSE(image[0],  -0.50f, g_error);
-    OIIO_CHECK_CLOSE(image[1],  -0.25f, g_error);
-    OIIO_CHECK_CLOSE(image[2],   0.50f, g_error);
-    OIIO_CHECK_CLOSE(image[3],   0.00f, g_error);
+    OCIO_CHECK_CLOSE(image[0],  -0.50f, g_error);
+    OCIO_CHECK_CLOSE(image[1],  -0.25f, g_error);
+    OCIO_CHECK_CLOSE(image[2],   0.50f, g_error);
+    OCIO_CHECK_CLOSE(image[3],   0.00f, g_error);
 
-    OIIO_CHECK_CLOSE(image[4],   0.75f, g_error);
-    OIIO_CHECK_CLOSE(image[5],   1.00f, g_error);
-    OIIO_CHECK_CLOSE(image[6],   1.10f, g_error);
-    OIIO_CHECK_CLOSE(image[7],   1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[4],   0.75f, g_error);
+    OCIO_CHECK_CLOSE(image[5],   1.00f, g_error);
+    OCIO_CHECK_CLOSE(image[6],   1.10f, g_error);
+    OCIO_CHECK_CLOSE(image[7],   1.00f, g_error);
 
-    OIIO_CHECK_CLOSE(image[8],   1.10f, g_error);
-    OIIO_CHECK_CLOSE(image[9],   1.10f, g_error);
-    OIIO_CHECK_CLOSE(image[10],  1.10f, g_error);
-    OIIO_CHECK_CLOSE(image[11],  0.00f, g_error);
+    OCIO_CHECK_CLOSE(image[8],   1.10f, g_error);
+    OCIO_CHECK_CLOSE(image[9],   1.10f, g_error);
+    OCIO_CHECK_CLOSE(image[10],  1.10f, g_error);
+    OCIO_CHECK_CLOSE(image[11],  0.00f, g_error);
 }
 
 

--- a/src/OpenColorIO/ops/Range/RangeOpCPU.cpp
+++ b/src/OpenColorIO/ops/Range/RangeOpCPU.cpp
@@ -414,7 +414,7 @@ OCIO_ADD_TEST(RangeOpCPU, scale_with_low_and_high_clippings)
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeScaleMinMaxRenderer"));
+    OCIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeScaleMinMaxRenderer"));
 
     const long numPixels = 9;
     const float qnan = std::numeric_limits<float>::quiet_NaN();
@@ -492,7 +492,7 @@ OCIO_ADD_TEST(RangeOpCPU, scale_with_low_clipping)
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeScaleMinRenderer"));
+    OCIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeScaleMinRenderer"));
 
     const long numPixels = 9;
     const float qnan = std::numeric_limits<float>::quiet_NaN();
@@ -570,7 +570,7 @@ OCIO_ADD_TEST(RangeOpCPU, scale_with_high_clipping)
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeScaleMaxRenderer"));
+    OCIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeScaleMaxRenderer"));
 
     const long numPixels = 9;
     const float qnan = std::numeric_limits<float>::quiet_NaN();
@@ -647,7 +647,7 @@ OCIO_ADD_TEST(RangeOpCPU, scale_with_low_and_high_clippings_2)
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeScaleMinMaxRenderer"));
+    OCIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeScaleMinMaxRenderer"));
 
     const long numPixels = 3;
     float image[4*numPixels] = { -0.50f, -0.25f, 0.50f, 0.0f,
@@ -686,7 +686,7 @@ OCIO_ADD_TEST(RangeOpCPU, offset_with_low_and_high_clippings)
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeScaleMinMaxRenderer"));
+    OCIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeScaleMinMaxRenderer"));
 
     const long numPixels = 3;
     float image[4*numPixels] = { -0.50f, -0.25f, 0.50f, 0.0f,
@@ -725,7 +725,7 @@ OCIO_ADD_TEST(RangeOpCPU, low_and_high_clippings)
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeMinMaxRenderer"));
+    OCIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeMinMaxRenderer"));
 
     const long numPixels = 4;
     float image[4*numPixels] = { -0.50f, -0.25f, 0.50f, 0.0f,
@@ -771,7 +771,7 @@ OCIO_ADD_TEST(RangeOpCPU, low_clipping)
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeMinRenderer"));
+    OCIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeMinRenderer"));
 
     const long numPixels = 3;
     float image[4*numPixels] = { -0.50f, -0.25f, 0.50f, 0.0f,
@@ -811,7 +811,7 @@ OCIO_ADD_TEST(RangeOpCPU, high_clipping)
 
     const OCIO::OpCPU & c = *op;
     const std::string typeName(typeid(c).name());
-    OCIO_CHECK_NE(-1, pystring::find(typeName, "RangeMaxRenderer"));
+    OCIO_CHECK_NE(-1, OCIO::pystring::find(typeName, "RangeMaxRenderer"));
 
     const long numPixels = 3;
     float image[4*numPixels] = { -0.50f, -0.25f, 0.50f, 0.0f,

--- a/src/OpenColorIO/ops/Range/RangeOpData.cpp
+++ b/src/OpenColorIO/ops/Range/RangeOpData.cpp
@@ -760,18 +760,18 @@ OCIO_NAMESPACE_EXIT
 
 namespace OCIO = OCIO_NAMESPACE;
 
-#include "unittest.h"
+#include "UnitTest.h"
 
 
-OIIO_ADD_TEST(RangeOpData, accessors)
+OCIO_ADD_TEST(RangeOpData, accessors)
 {
     {
     OCIO::RangeOpData r;
     
-    OIIO_CHECK_ASSERT(OCIO::IsNan((float)r.getMinInValue()));
-    OIIO_CHECK_ASSERT(OCIO::IsNan((float)r.getMaxInValue()));
-    OIIO_CHECK_ASSERT(OCIO::IsNan((float)r.getMinOutValue()));
-    OIIO_CHECK_ASSERT(OCIO::IsNan((float)r.getMaxOutValue()));
+    OCIO_CHECK_ASSERT(OCIO::IsNan((float)r.getMinInValue()));
+    OCIO_CHECK_ASSERT(OCIO::IsNan((float)r.getMaxInValue()));
+    OCIO_CHECK_ASSERT(OCIO::IsNan((float)r.getMinOutValue()));
+    OCIO_CHECK_ASSERT(OCIO::IsNan((float)r.getMaxOutValue()));
 
     double minVal = 1.0;
     double maxVal = 10.0;
@@ -780,12 +780,12 @@ OIIO_ADD_TEST(RangeOpData, accessors)
     r.setMinOutValue(2.0*minVal);
     r.setMaxOutValue(2.0*maxVal);
 
-    OIIO_CHECK_EQUAL(r.getMinInValue(), minVal);
-    OIIO_CHECK_EQUAL(r.getMaxInValue(), maxVal);
-    OIIO_CHECK_EQUAL(r.getMinOutValue(), 2.0*minVal);
-    OIIO_CHECK_EQUAL(r.getMaxOutValue(), 2.0*maxVal);
+    OCIO_CHECK_EQUAL(r.getMinInValue(), minVal);
+    OCIO_CHECK_EQUAL(r.getMaxInValue(), maxVal);
+    OCIO_CHECK_EQUAL(r.getMinOutValue(), 2.0*minVal);
+    OCIO_CHECK_EQUAL(r.getMaxOutValue(), 2.0*maxVal);
 
-    OIIO_CHECK_EQUAL(r.getType(), OCIO::OpData::RangeType);
+    OCIO_CHECK_EQUAL(r.getType(), OCIO::OpData::RangeType);
     }
 
     {
@@ -794,33 +794,33 @@ OIIO_ADD_TEST(RangeOpData, accessors)
     OCIO::RangeOpData range(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32,
                             0.0f, 1.0f, 0.5f, 1.5f);
 
-    OIIO_CHECK_EQUAL(range.getMinInValue(), 0.);
-    OIIO_CHECK_EQUAL(range.getMaxInValue(), 1.);
-    OIIO_CHECK_EQUAL(range.getMinOutValue(), 0.5);
-    OIIO_CHECK_EQUAL(range.getMaxOutValue(), 1.5);
+    OCIO_CHECK_EQUAL(range.getMinInValue(), 0.);
+    OCIO_CHECK_EQUAL(range.getMaxInValue(), 1.);
+    OCIO_CHECK_EQUAL(range.getMinOutValue(), 0.5);
+    OCIO_CHECK_EQUAL(range.getMaxOutValue(), 1.5);
 
-    OIIO_CHECK_NO_THROW(range.setMinInValue(-0.05432));
-    OIIO_CHECK_NO_THROW(range.validate());
-    OIIO_CHECK_EQUAL(range.getMinInValue(), -0.05432);
+    OCIO_CHECK_NO_THROW(range.setMinInValue(-0.05432));
+    OCIO_CHECK_NO_THROW(range.validate());
+    OCIO_CHECK_EQUAL(range.getMinInValue(), -0.05432);
 
-    OIIO_CHECK_NO_THROW(range.setMaxInValue(1.05432));
-    OIIO_CHECK_NO_THROW(range.validate());
-    OIIO_CHECK_EQUAL(range.getMaxInValue(), 1.05432);
+    OCIO_CHECK_NO_THROW(range.setMaxInValue(1.05432));
+    OCIO_CHECK_NO_THROW(range.validate());
+    OCIO_CHECK_EQUAL(range.getMaxInValue(), 1.05432);
 
-    OIIO_CHECK_NO_THROW(range.setMinOutValue(0.05432));
-    OIIO_CHECK_NO_THROW(range.validate());
-    OIIO_CHECK_EQUAL(range.getMinOutValue(), 0.05432);
+    OCIO_CHECK_NO_THROW(range.setMinOutValue(0.05432));
+    OCIO_CHECK_NO_THROW(range.validate());
+    OCIO_CHECK_EQUAL(range.getMinOutValue(), 0.05432);
 
-    OIIO_CHECK_NO_THROW(range.setMaxOutValue(2.05432));
-    OIIO_CHECK_NO_THROW(range.validate());
-    OIIO_CHECK_EQUAL(range.getMaxOutValue(), 2.05432);
+    OCIO_CHECK_NO_THROW(range.setMaxOutValue(2.05432));
+    OCIO_CHECK_NO_THROW(range.validate());
+    OCIO_CHECK_EQUAL(range.getMaxOutValue(), 2.05432);
 
-    OIIO_CHECK_CLOSE(range.getScale(), 1.804012123, g_error);
-    OIIO_CHECK_CLOSE(range.getOffset(), 0.1523139385, g_error);
+    OCIO_CHECK_CLOSE(range.getScale(), 1.804012123, g_error);
+    OCIO_CHECK_CLOSE(range.getOffset(), 0.1523139385, g_error);
     }
 }
 
-OIIO_ADD_TEST(RangeOpData, validation)
+OCIO_ADD_TEST(RangeOpData, validation)
 {
     OCIO::RangeOpData r;
 
@@ -829,46 +829,46 @@ OIIO_ADD_TEST(RangeOpData, validation)
     // leave min output empty
     r.setMaxOutValue(2.);
 
-    OIIO_CHECK_THROW_WHAT(r.validate(), 
+    OCIO_CHECK_THROW_WHAT(r.validate(), 
                           OCIO::Exception, 
                           "must be both set or both missing");
 }
 
-OIIO_ADD_TEST(RangeOpData, set_bit_depth)
+OCIO_ADD_TEST(RangeOpData, set_bit_depth)
 {
     OCIO::RangeOpData r1(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_F16,
                          16., 235., -0.5, 2. );
 
     OCIO::BitDepth newBitdepth = OCIO::BIT_DEPTH_UINT10;
     r1.setOutputBitDepth(newBitdepth);
-    OIIO_CHECK_EQUAL(r1.getOutputBitDepth(), newBitdepth);
-    OIIO_CHECK_EQUAL((float)r1.getMinInValue(), 16.f);
-    OIIO_CHECK_EQUAL((float)r1.getMaxInValue(), 235.f);
-    OIIO_CHECK_EQUAL((float)r1.getMinOutValue(), -0.5f * 1023.f);
-    OIIO_CHECK_EQUAL((float)r1.getMaxOutValue(), 2.f * 1023.f);
+    OCIO_CHECK_EQUAL(r1.getOutputBitDepth(), newBitdepth);
+    OCIO_CHECK_EQUAL((float)r1.getMinInValue(), 16.f);
+    OCIO_CHECK_EQUAL((float)r1.getMaxInValue(), 235.f);
+    OCIO_CHECK_EQUAL((float)r1.getMinOutValue(), -0.5f * 1023.f);
+    OCIO_CHECK_EQUAL((float)r1.getMaxOutValue(), 2.f * 1023.f);
 
     newBitdepth = OCIO::BIT_DEPTH_F32;
     r1.setOutputBitDepth(newBitdepth);
-    OIIO_CHECK_EQUAL(r1.getOutputBitDepth(), newBitdepth);
-    OIIO_CHECK_EQUAL((float)r1.getMinOutValue(), -0.5f);
-    OIIO_CHECK_EQUAL((float)r1.getMaxOutValue(), 2.f);
+    OCIO_CHECK_EQUAL(r1.getOutputBitDepth(), newBitdepth);
+    OCIO_CHECK_EQUAL((float)r1.getMinOutValue(), -0.5f);
+    OCIO_CHECK_EQUAL((float)r1.getMaxOutValue(), 2.f);
 
     OCIO::RangeOpData r2(OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_UINT10, 
                          -0.5, 2.0, 0., 1023. );
 
     newBitdepth = OCIO::BIT_DEPTH_UINT10;
     r2.setInputBitDepth(newBitdepth);
-    OIIO_CHECK_EQUAL(r2.getInputBitDepth(), newBitdepth);
-    OIIO_CHECK_EQUAL((float)r2.getMinInValue(), -0.5f * 1023.f);
-    OIIO_CHECK_EQUAL((float)r2.getMaxInValue(), 2.f * 1023.f);
-    OIIO_CHECK_EQUAL((float)r2.getMinOutValue(), 0.f);
-    OIIO_CHECK_EQUAL((float)r2.getMaxOutValue(), 1023.f);
+    OCIO_CHECK_EQUAL(r2.getInputBitDepth(), newBitdepth);
+    OCIO_CHECK_EQUAL((float)r2.getMinInValue(), -0.5f * 1023.f);
+    OCIO_CHECK_EQUAL((float)r2.getMaxInValue(), 2.f * 1023.f);
+    OCIO_CHECK_EQUAL((float)r2.getMinOutValue(), 0.f);
+    OCIO_CHECK_EQUAL((float)r2.getMaxOutValue(), 1023.f);
 
     newBitdepth = OCIO::BIT_DEPTH_F16;
     r2.setInputBitDepth(newBitdepth);
-    OIIO_CHECK_EQUAL(r2.getInputBitDepth(), newBitdepth);
-    OIIO_CHECK_EQUAL((float)r2.getMinInValue(), -0.5f);
-    OIIO_CHECK_EQUAL((float)r2.getMaxInValue(), 2.f);
+    OCIO_CHECK_EQUAL(r2.getInputBitDepth(), newBitdepth);
+    OCIO_CHECK_EQUAL((float)r2.getMinInValue(), -0.5f);
+    OCIO_CHECK_EQUAL((float)r2.getMaxInValue(), 2.f);
 
     OCIO::RangeOpData r3;
     r3.setInputBitDepth(OCIO::BIT_DEPTH_F16);
@@ -881,117 +881,117 @@ OIIO_ADD_TEST(RangeOpData, set_bit_depth)
 
     r3.validate();
 
-    OIIO_CHECK_ASSERT(r3.minClips());  // since it's float --> int
-    OIIO_CHECK_ASSERT(r3.maxClips());
-    OIIO_CHECK_EQUAL(r3.getScale(), 1023.f);
-    OIIO_CHECK_EQUAL(r3.getOffset(), -1023.f);
+    OCIO_CHECK_ASSERT(r3.minClips());  // since it's float --> int
+    OCIO_CHECK_ASSERT(r3.maxClips());
+    OCIO_CHECK_EQUAL(r3.getScale(), 1023.f);
+    OCIO_CHECK_EQUAL(r3.getOffset(), -1023.f);
     newBitdepth = OCIO::BIT_DEPTH_UINT10;
     r3.setInputBitDepth(newBitdepth);
-    OIIO_CHECK_EQUAL(r3.getInputBitDepth(), newBitdepth);
-    OIIO_CHECK_ASSERT(r3.minIsEmpty());
-    OIIO_CHECK_EQUAL(r3.getScale(), 1.f);
-    OIIO_CHECK_EQUAL(r3.getOffset(), -1023.f);
-    OIIO_CHECK_EQUAL((float)r3.getMaxInValue(), 2.f * 1023.f);
-    OIIO_CHECK_ASSERT(r3.minClips());  // due to negative offset
-    OIIO_CHECK_ASSERT(!r3.maxClips()); // not needed since domain max is in range
+    OCIO_CHECK_EQUAL(r3.getInputBitDepth(), newBitdepth);
+    OCIO_CHECK_ASSERT(r3.minIsEmpty());
+    OCIO_CHECK_EQUAL(r3.getScale(), 1.f);
+    OCIO_CHECK_EQUAL(r3.getOffset(), -1023.f);
+    OCIO_CHECK_EQUAL((float)r3.getMaxInValue(), 2.f * 1023.f);
+    OCIO_CHECK_ASSERT(r3.minClips());  // due to negative offset
+    OCIO_CHECK_ASSERT(!r3.maxClips()); // not needed since domain max is in range
 }
 
-OIIO_ADD_TEST(RangeOpData, clamp_identity )
+OCIO_ADD_TEST(RangeOpData, clamp_identity )
 {
     OCIO::RangeOpData r1(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_F16, 
                          0., 255., 0., 1. );
-    OIIO_CHECK_ASSERT( r1.clampsToLutDomain() );
-    OIIO_CHECK_ASSERT( r1.isClampIdentity() );
-    OIIO_CHECK_ASSERT( ! r1.isClampNegs() );
+    OCIO_CHECK_ASSERT( r1.clampsToLutDomain() );
+    OCIO_CHECK_ASSERT( r1.isClampIdentity() );
+    OCIO_CHECK_ASSERT( ! r1.isClampNegs() );
 
     OCIO::RangeOpData r2(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_F16,
                          16., 300., -0.5, 2. );
-    OIIO_CHECK_ASSERT( ! r2.clampsToLutDomain() );
-    OIIO_CHECK_ASSERT( ! r2.isClampIdentity() );
-    OIIO_CHECK_ASSERT( ! r2.isClampNegs() );
+    OCIO_CHECK_ASSERT( ! r2.clampsToLutDomain() );
+    OCIO_CHECK_ASSERT( ! r2.isClampIdentity() );
+    OCIO_CHECK_ASSERT( ! r2.isClampNegs() );
 
     OCIO::RangeOpData r3(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_F16,
                          -16., 300., -0.5, 2. );
-    OIIO_CHECK_ASSERT( ! r3.clampsToLutDomain() );
-    OIIO_CHECK_ASSERT( ! r3.isClampIdentity() );
-    OIIO_CHECK_ASSERT( ! r3.isClampNegs() );
+    OCIO_CHECK_ASSERT( ! r3.clampsToLutDomain() );
+    OCIO_CHECK_ASSERT( ! r3.isClampIdentity() );
+    OCIO_CHECK_ASSERT( ! r3.isClampNegs() );
 
     OCIO::RangeOpData r4(OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_UINT8,
                          0., 1., 8., 255. );
-    OIIO_CHECK_ASSERT( r4.clampsToLutDomain() );
-    OIIO_CHECK_ASSERT( ! r4.isClampIdentity() );
-    OIIO_CHECK_ASSERT( ! r4.isClampNegs() );
+    OCIO_CHECK_ASSERT( r4.clampsToLutDomain() );
+    OCIO_CHECK_ASSERT( ! r4.isClampIdentity() );
+    OCIO_CHECK_ASSERT( ! r4.isClampNegs() );
 
     OCIO::RangeOpData r5(OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_UINT8, 
                          0.1, 1., -8., 255. );
-    OIIO_CHECK_ASSERT( r5.clampsToLutDomain() );
-    OIIO_CHECK_ASSERT( ! r5.isClampIdentity() );
-    OIIO_CHECK_ASSERT( ! r5.isClampNegs() );
+    OCIO_CHECK_ASSERT( r5.clampsToLutDomain() );
+    OCIO_CHECK_ASSERT( ! r5.isClampIdentity() );
+    OCIO_CHECK_ASSERT( ! r5.isClampNegs() );
 
     OCIO::RangeOpData r6(OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_UINT8, 
                          -0.1, 1.1, -255. * 0.1, 255. * 1.1 );
-    OIIO_CHECK_ASSERT( ! r6.clampsToLutDomain() );
-    OIIO_CHECK_ASSERT( r6.isClampIdentity() );
-    OIIO_CHECK_ASSERT( ! r6.isClampNegs() );
+    OCIO_CHECK_ASSERT( ! r6.clampsToLutDomain() );
+    OCIO_CHECK_ASSERT( r6.isClampIdentity() );
+    OCIO_CHECK_ASSERT( ! r6.isClampNegs() );
 
     OCIO::RangeOpData r7(OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_UINT8, 
                          0., OCIO::RangeOpData::EmptyValue(), 
                          0., OCIO::RangeOpData::EmptyValue());
-    OIIO_CHECK_ASSERT( ! r7.clampsToLutDomain() );
-    OIIO_CHECK_ASSERT( r7.isClampIdentity() );
-    OIIO_CHECK_ASSERT( r7.isClampNegs() );
+    OCIO_CHECK_ASSERT( ! r7.clampsToLutDomain() );
+    OCIO_CHECK_ASSERT( r7.isClampIdentity() );
+    OCIO_CHECK_ASSERT( r7.isClampNegs() );
 
     OCIO::RangeOpData r8(OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_F32, 
                          OCIO::RangeOpData::EmptyValue(), 1., 
                          OCIO::RangeOpData::EmptyValue(), 1. );
-    OIIO_CHECK_ASSERT( ! r8.clampsToLutDomain() );
-    OIIO_CHECK_ASSERT( r8.isClampIdentity() );
-    OIIO_CHECK_ASSERT( ! r8.isClampNegs() );
+    OCIO_CHECK_ASSERT( ! r8.clampsToLutDomain() );
+    OCIO_CHECK_ASSERT( r8.isClampIdentity() );
+    OCIO_CHECK_ASSERT( ! r8.isClampNegs() );
 }
 
-OIIO_ADD_TEST(RangeOpData, identity)
+OCIO_ADD_TEST(RangeOpData, identity)
 {
     OCIO::RangeOpData r4(OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_F16,
                          OCIO::RangeOpData::EmptyValue(), 
                          OCIO::RangeOpData::EmptyValue(), 
                          OCIO::RangeOpData::EmptyValue(), 
                          OCIO::RangeOpData::EmptyValue() );
-    OIIO_CHECK_ASSERT(r4.isIdentity());
-    OIIO_CHECK_ASSERT(r4.isNoOp());
-    OIIO_CHECK_ASSERT(!r4.hasChannelCrosstalk());
-    OIIO_CHECK_ASSERT(!r4.minClips());
-    OIIO_CHECK_ASSERT(!r4.maxClips());
-    OIIO_CHECK_ASSERT(!r4.scales(false));
-    OIIO_CHECK_ASSERT(r4.minIsEmpty());
-    OIIO_CHECK_ASSERT(r4.maxIsEmpty());
+    OCIO_CHECK_ASSERT(r4.isIdentity());
+    OCIO_CHECK_ASSERT(r4.isNoOp());
+    OCIO_CHECK_ASSERT(!r4.hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(!r4.minClips());
+    OCIO_CHECK_ASSERT(!r4.maxClips());
+    OCIO_CHECK_ASSERT(!r4.scales(false));
+    OCIO_CHECK_ASSERT(r4.minIsEmpty());
+    OCIO_CHECK_ASSERT(r4.maxIsEmpty());
 
     OCIO::RangeOpData r5(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT10,
                          0., 255., 0., 1023. );
-    OIIO_CHECK_ASSERT(!r5.wouldClip(0.));
-    OIIO_CHECK_ASSERT(!r5.wouldClip(255.));
-    OIIO_CHECK_ASSERT(!r5.scales(true));
-    OIIO_CHECK_ASSERT(!r5.isIdentity());
-    OIIO_CHECK_ASSERT(!r5.hasChannelCrosstalk());
-    OIIO_CHECK_ASSERT(!r5.isNoOp());
-    OIIO_CHECK_ASSERT(!r5.minClips());
-    OIIO_CHECK_ASSERT(!r5.maxClips());
-    OIIO_CHECK_ASSERT(r5.scales(false));
-    OIIO_CHECK_ASSERT(!r5.minIsEmpty());
-    OIIO_CHECK_ASSERT(!r5.maxIsEmpty());
+    OCIO_CHECK_ASSERT(!r5.wouldClip(0.));
+    OCIO_CHECK_ASSERT(!r5.wouldClip(255.));
+    OCIO_CHECK_ASSERT(!r5.scales(true));
+    OCIO_CHECK_ASSERT(!r5.isIdentity());
+    OCIO_CHECK_ASSERT(!r5.hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(!r5.isNoOp());
+    OCIO_CHECK_ASSERT(!r5.minClips());
+    OCIO_CHECK_ASSERT(!r5.maxClips());
+    OCIO_CHECK_ASSERT(r5.scales(false));
+    OCIO_CHECK_ASSERT(!r5.minIsEmpty());
+    OCIO_CHECK_ASSERT(!r5.maxIsEmpty());
 
     OCIO::RangeOpData r6(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT16,
                          0., 255., -1., 65540. );
-    OIIO_CHECK_ASSERT(!r6.isIdentity());
-    OIIO_CHECK_ASSERT(!r6.isNoOp());
-    OIIO_CHECK_ASSERT(!r6.hasChannelCrosstalk());
-    OIIO_CHECK_ASSERT(r6.minClips());
-    OIIO_CHECK_ASSERT(r6.maxClips());
-    OIIO_CHECK_EQUAL(r6.getLowBound(), 0.f);  // check tightening of bound
-    OIIO_CHECK_EQUAL(r6.getHighBound(), 65535.f);
-    OIIO_CHECK_ASSERT(r6.scales(true));
+    OCIO_CHECK_ASSERT(!r6.isIdentity());
+    OCIO_CHECK_ASSERT(!r6.isNoOp());
+    OCIO_CHECK_ASSERT(!r6.hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(r6.minClips());
+    OCIO_CHECK_ASSERT(r6.maxClips());
+    OCIO_CHECK_EQUAL(r6.getLowBound(), 0.f);  // check tightening of bound
+    OCIO_CHECK_EQUAL(r6.getHighBound(), 65535.f);
+    OCIO_CHECK_ASSERT(r6.scales(true));
 }
 
-OIIO_ADD_TEST(RangeOpData, equality)
+OCIO_ADD_TEST(RangeOpData, equality)
 {
     OCIO::RangeOpData r1(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT16,
                          0., 255., -1., 65540. );
@@ -999,22 +999,22 @@ OIIO_ADD_TEST(RangeOpData, equality)
     OCIO::RangeOpData r2(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT16,
                          0.123, 255., -1., 65540. );
 
-    OIIO_CHECK_ASSERT(!(r1 == r2));
+    OCIO_CHECK_ASSERT(!(r1 == r2));
 
     OCIO::RangeOpData r3(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT16,
                          0., 252., -1., 65540. );
 
-    OIIO_CHECK_ASSERT(!(r1 == r3));
+    OCIO_CHECK_ASSERT(!(r1 == r3));
 
     OCIO::RangeOpData r4(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT16,
                          0., 255., -12., 65540. );
 
-    OIIO_CHECK_ASSERT(!(r1 == r4));
+    OCIO_CHECK_ASSERT(!(r1 == r4));
 
     OCIO::RangeOpData r5(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT16,
                          0., 255., -1., 65540. );
 
-    OIIO_CHECK_ASSERT(r5 == r1);
+    OCIO_CHECK_ASSERT(r5 == r1);
 
     OCIO::RangeOpData r6(OCIO::BIT_DEPTH_F16, OCIO::BIT_DEPTH_F16,
                          OCIO::RangeOpData::EmptyValue(),
@@ -1028,18 +1028,18 @@ OIIO_ADD_TEST(RangeOpData, equality)
                          OCIO::RangeOpData::EmptyValue(),
                          OCIO::RangeOpData::EmptyValue() );
 
-    OIIO_CHECK_ASSERT(r6 == r7);
+    OCIO_CHECK_ASSERT(r6 == r7);
 }
 
-OIIO_ADD_TEST(RangeOpData, faulty)
+OCIO_ADD_TEST(RangeOpData, faulty)
 {
     {
         OCIO::RangeOpData range(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32,
                                 0.0f, 1.0f, 0.5f, 1.5f);
-        OIIO_CHECK_NO_THROW(range.validate());
+        OCIO_CHECK_NO_THROW(range.validate());
 
-        OIIO_CHECK_NO_THROW(range.unsetMinInValue()); 
-        OIIO_CHECK_THROW_WHAT(range.validate(), 
+        OCIO_CHECK_NO_THROW(range.unsetMinInValue()); 
+        OCIO_CHECK_THROW_WHAT(range.validate(), 
                               OCIO::Exception,
                               "In and out minimum limits must be both set or both missing");
     }
@@ -1047,20 +1047,20 @@ OIIO_ADD_TEST(RangeOpData, faulty)
     {
         OCIO::RangeOpData range(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32,
                                 0.0f, 1.0f, 0.5f, 1.5f);
-        OIIO_CHECK_NO_THROW(range.validate());
+        OCIO_CHECK_NO_THROW(range.validate());
 
-        OIIO_CHECK_NO_THROW(range.unsetMinInValue()); 
-        OIIO_CHECK_NO_THROW(range.unsetMinOutValue()); 
-        OIIO_CHECK_NO_THROW(range.validate());
+        OCIO_CHECK_NO_THROW(range.unsetMinInValue()); 
+        OCIO_CHECK_NO_THROW(range.unsetMinOutValue()); 
+        OCIO_CHECK_NO_THROW(range.validate());
     }
 
     {
         OCIO::RangeOpData range(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32,
                                 0.0f, 1.0f, 0.5f, 1.5f);
-        OIIO_CHECK_NO_THROW(range.validate());
+        OCIO_CHECK_NO_THROW(range.validate());
 
-        OIIO_CHECK_NO_THROW(range.unsetMaxInValue()); 
-        OIIO_CHECK_THROW_WHAT(range.validate(), 
+        OCIO_CHECK_NO_THROW(range.unsetMaxInValue()); 
+        OCIO_CHECK_THROW_WHAT(range.validate(), 
                               OCIO::Exception,
                               "In and out maximum limits must be both set or both missing");
     }
@@ -1068,20 +1068,20 @@ OIIO_ADD_TEST(RangeOpData, faulty)
     {
         OCIO::RangeOpData range(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32,
                                 0.0f, 1.0f, 0.5f, 1.5f);
-        OIIO_CHECK_NO_THROW(range.validate());
+        OCIO_CHECK_NO_THROW(range.validate());
 
-        OIIO_CHECK_NO_THROW(range.unsetMaxInValue()); 
-        OIIO_CHECK_NO_THROW(range.unsetMaxOutValue()); 
-        OIIO_CHECK_NO_THROW(range.validate());
+        OCIO_CHECK_NO_THROW(range.unsetMaxInValue()); 
+        OCIO_CHECK_NO_THROW(range.unsetMaxOutValue()); 
+        OCIO_CHECK_NO_THROW(range.validate());
     }
 
     {
         OCIO::RangeOpData range(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32,
                                 0.0f, 1.0f, 0.5f, 1.5f);
-        OIIO_CHECK_NO_THROW(range.validate());
+        OCIO_CHECK_NO_THROW(range.validate());
 
-        OIIO_CHECK_NO_THROW(range.setMaxInValue(-125.)); 
-        OIIO_CHECK_THROW_WHAT(range.validate(), 
+        OCIO_CHECK_NO_THROW(range.setMaxInValue(-125.)); 
+        OCIO_CHECK_THROW_WHAT(range.validate(), 
                               OCIO::Exception,
                               "Range maximum input value is less than minimum input value");
     }
@@ -1089,10 +1089,10 @@ OIIO_ADD_TEST(RangeOpData, faulty)
     {
         OCIO::RangeOpData range(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32,
                                 0.0f, 1.0f, 0.5f, 1.5f);
-        OIIO_CHECK_NO_THROW(range.validate());
+        OCIO_CHECK_NO_THROW(range.validate());
 
-        OIIO_CHECK_NO_THROW(range.setMaxOutValue(-125.)); 
-        OIIO_CHECK_THROW_WHAT(range.validate(), 
+        OCIO_CHECK_NO_THROW(range.setMaxOutValue(-125.)); 
+        OCIO_CHECK_THROW_WHAT(range.validate(), 
                               OCIO::Exception,
                               "Range maximum output value is less than minimum output value");
     }
@@ -1112,26 +1112,26 @@ namespace
         OCIO::RangeOpDataRcPtr invOp = refOp.inverse();
 
         // Inverse op should have its input/output bitdepth swapped.
-        OIIO_CHECK_EQUAL(invOp->getInputBitDepth(), out);
-        OIIO_CHECK_EQUAL(invOp->getOutputBitDepth(), in);
+        OCIO_CHECK_EQUAL(invOp->getInputBitDepth(), out);
+        OCIO_CHECK_EQUAL(invOp->getOutputBitDepth(), in);
 
         // The min/max values should be swapped.
         if (OCIO::IsNan(revMinIn))
-            OIIO_CHECK_ASSERT(OCIO::IsNan(invOp->getMinInValue()));
+            OCIO_CHECK_ASSERT(OCIO::IsNan(invOp->getMinInValue()));
         else
-            OIIO_CHECK_EQUAL(invOp->getMinInValue(), revMinIn);
+            OCIO_CHECK_EQUAL(invOp->getMinInValue(), revMinIn);
         if (OCIO::IsNan(revMaxIn))
-            OIIO_CHECK_ASSERT(OCIO::IsNan(invOp->getMaxInValue()));
+            OCIO_CHECK_ASSERT(OCIO::IsNan(invOp->getMaxInValue()));
         else
-            OIIO_CHECK_EQUAL(invOp->getMaxInValue(), revMaxIn);
+            OCIO_CHECK_EQUAL(invOp->getMaxInValue(), revMaxIn);
         if (OCIO::IsNan(revMinOut))
-            OIIO_CHECK_ASSERT(OCIO::IsNan(invOp->getMinOutValue()));
+            OCIO_CHECK_ASSERT(OCIO::IsNan(invOp->getMinOutValue()));
         else
-            OIIO_CHECK_EQUAL(invOp->getMinOutValue(), revMinOut);
+            OCIO_CHECK_EQUAL(invOp->getMinOutValue(), revMinOut);
         if (OCIO::IsNan(revMaxOut))
-            OIIO_CHECK_ASSERT(OCIO::IsNan(invOp->getMaxOutValue()));
+            OCIO_CHECK_ASSERT(OCIO::IsNan(invOp->getMaxOutValue()));
         else
-            OIIO_CHECK_EQUAL(invOp->getMaxOutValue(), revMaxOut);
+            OCIO_CHECK_EQUAL(invOp->getMaxOutValue(), revMaxOut);
 
         // Check that the computation would be correct.
         // (Doing this in lieu of renderer testing.)
@@ -1144,17 +1144,17 @@ namespace
         // Want in == (in * fwdScale + fwdOffset) * revScale + revOffset
         // in == in * fwdScale * revScale + fwdOffset * revScale + revOffset
         // in == in * 1. + 0.
-        OIIO_CHECK_ASSERT(!OCIO::FloatsDiffer( 1.0f, fwdScale * revScale, 10, false));
+        OCIO_CHECK_ASSERT(!OCIO::FloatsDiffer( 1.0f, fwdScale * revScale, 10, false));
 
-        //OIIO_CHECK_ASSERT(!OCIO::floatsDiffer(
+        //OCIO_CHECK_ASSERT(!OCIO::floatsDiffer(
         //     0.0f, fwdOffset * revScale + revOffset, 100000, false));
         // The above is correct but we lose too much precision in the subtraction
         // so rearrange the compare as follows to allow a tighter tolerance.
-        OIIO_CHECK_ASSERT(!OCIO::FloatsDiffer(fwdOffset * revScale, -revOffset, 500, false));
+        OCIO_CHECK_ASSERT(!OCIO::FloatsDiffer(fwdOffset * revScale, -revOffset, 500, false));
     }
 }
 
-OIIO_ADD_TEST(RangeOpData, inverse)
+OCIO_ADD_TEST(RangeOpData, inverse)
 {
     checkInverse(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_UINT12,
                  OCIO::RangeOpData::EmptyValue(), OCIO::RangeOpData::EmptyValue(), 
@@ -1177,31 +1177,31 @@ OIIO_ADD_TEST(RangeOpData, inverse)
                  32., 235., 64., 940.);
 }
 
-OIIO_ADD_TEST(RangeOpData, computed_identifier)
+OCIO_ADD_TEST(RangeOpData, computed_identifier)
 {
     std::string id1, id2;
 
     OCIO::RangeOpData range(OCIO::BIT_DEPTH_F32, OCIO::BIT_DEPTH_F32,
                             0.0f, 1.0f, 0.5f, 1.5f);
-    OIIO_CHECK_NO_THROW( range.finalize() );
-    OIIO_CHECK_NO_THROW( id1 = range.getCacheID() );
+    OCIO_CHECK_NO_THROW( range.finalize() );
+    OCIO_CHECK_NO_THROW( id1 = range.getCacheID() );
 
-    OIIO_CHECK_NO_THROW( range.unsetMaxInValue() ); 
-    OIIO_CHECK_NO_THROW( range.unsetMaxOutValue() ); 
-    OIIO_CHECK_NO_THROW( range.finalize() );
-    OIIO_CHECK_NO_THROW( id2 = range.getCacheID() );
+    OCIO_CHECK_NO_THROW( range.unsetMaxInValue() ); 
+    OCIO_CHECK_NO_THROW( range.unsetMaxOutValue() ); 
+    OCIO_CHECK_NO_THROW( range.finalize() );
+    OCIO_CHECK_NO_THROW( id2 = range.getCacheID() );
 
-    OIIO_CHECK_ASSERT( id1 != id2 );
+    OCIO_CHECK_ASSERT( id1 != id2 );
 
-    OIIO_CHECK_NO_THROW( range.unsetMinInValue() ); 
-    OIIO_CHECK_NO_THROW( range.unsetMinOutValue() ); 
-    OIIO_CHECK_NO_THROW( range.finalize() );
-    OIIO_CHECK_NO_THROW( id1 = range.getCacheID() );
+    OCIO_CHECK_NO_THROW( range.unsetMinInValue() ); 
+    OCIO_CHECK_NO_THROW( range.unsetMinOutValue() ); 
+    OCIO_CHECK_NO_THROW( range.finalize() );
+    OCIO_CHECK_NO_THROW( id1 = range.getCacheID() );
 
-    OIIO_CHECK_ASSERT( id1 != id2 );
+    OCIO_CHECK_ASSERT( id1 != id2 );
 
-    OIIO_CHECK_NO_THROW( id2 = range.getCacheID() );
-    OIIO_CHECK_ASSERT( id1 == id2 );
+    OCIO_CHECK_NO_THROW( id2 = range.getCacheID() );
+    OCIO_CHECK_ASSERT( id1 == id2 );
 }
 
 #endif

--- a/src/OpenColorIO/ops/Range/RangeOps.cpp
+++ b/src/OpenColorIO/ops/Range/RangeOps.cpp
@@ -281,131 +281,131 @@ OCIO_NAMESPACE_EXIT
 namespace OCIO = OCIO_NAMESPACE;
 
 #include "ops/Matrix/MatrixOps.h"
-#include "unittest.h"
+#include "UnitTest.h"
 
 
 OCIO_NAMESPACE_USING
 
 const float g_error = 1e-7f;
 
-OIIO_ADD_TEST(RangeOps, apply_arbitrary)
+OCIO_ADD_TEST(RangeOps, apply_arbitrary)
 {
     OCIO::RangeOp r(-0.101, 0.95, 0.194, 1.001, OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_NO_THROW(r.finalize());
+    OCIO_CHECK_NO_THROW(r.finalize());
 
     float image[4*3] = { -0.50f,  0.25f, 0.50f, 0.0f,
                           0.75f,  1.00f, 1.25f, 1.0f,
                           1.25f,  1.50f, 1.75f, 0.0f };
 
-    OIIO_CHECK_NO_THROW(r.apply(&image[0], 3));
+    OCIO_CHECK_NO_THROW(r.apply(&image[0], 3));
 
-    OIIO_CHECK_CLOSE(image[0],  0.194f,        g_error);
-    OIIO_CHECK_CLOSE(image[1],  0.4635119438f, g_error);
-    OIIO_CHECK_CLOSE(image[2],  0.6554719806f, g_error);
-    OIIO_CHECK_CLOSE(image[3],  0.0f,          g_error);
-    OIIO_CHECK_CLOSE(image[4],  0.8474320173f, g_error);
-    OIIO_CHECK_CLOSE(image[5],  1.001f,        g_error);
-    OIIO_CHECK_CLOSE(image[6],  1.001f,        g_error);
-    OIIO_CHECK_CLOSE(image[7],  1.0f,          g_error);
-    OIIO_CHECK_CLOSE(image[8],  1.001f,        g_error);
-    OIIO_CHECK_CLOSE(image[9],  1.001f,        g_error);
-    OIIO_CHECK_CLOSE(image[10], 1.001f,        g_error);
-    OIIO_CHECK_CLOSE(image[11], 0.0f,          g_error);
+    OCIO_CHECK_CLOSE(image[0],  0.194f,        g_error);
+    OCIO_CHECK_CLOSE(image[1],  0.4635119438f, g_error);
+    OCIO_CHECK_CLOSE(image[2],  0.6554719806f, g_error);
+    OCIO_CHECK_CLOSE(image[3],  0.0f,          g_error);
+    OCIO_CHECK_CLOSE(image[4],  0.8474320173f, g_error);
+    OCIO_CHECK_CLOSE(image[5],  1.001f,        g_error);
+    OCIO_CHECK_CLOSE(image[6],  1.001f,        g_error);
+    OCIO_CHECK_CLOSE(image[7],  1.0f,          g_error);
+    OCIO_CHECK_CLOSE(image[8],  1.001f,        g_error);
+    OCIO_CHECK_CLOSE(image[9],  1.001f,        g_error);
+    OCIO_CHECK_CLOSE(image[10], 1.001f,        g_error);
+    OCIO_CHECK_CLOSE(image[11], 0.0f,          g_error);
 }
 
-OIIO_ADD_TEST(RangeOps, combining)
+OCIO_ADD_TEST(RangeOps, combining)
 {
     OCIO::OpRcPtrVec ops;
 
     OCIO::CreateRangeOp(ops, 0., 0.5, 0.5, 1.0);
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
     OCIO::CreateRangeOp(ops, 0., 1., 0.5, 1.5);
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_CHECK_NO_THROW(ops[1]->finalize());
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(ops[1]->finalize());
 
     OCIO::ConstOpRcPtr op1 = ops[1];
 
     // TODO: implement Range combine
-    OIIO_CHECK_THROW_WHAT(ops[0]->combineWith(ops, op1), 
+    OCIO_CHECK_THROW_WHAT(ops[0]->combineWith(ops, op1), 
                           OCIO::Exception, "TODO: Range can't be combined");
-    OIIO_CHECK_EQUAL(ops.size(), 2);
+    OCIO_CHECK_EQUAL(ops.size(), 2);
 
 }
 
-OIIO_ADD_TEST(RangeOps, combining_with_inverse)
+OCIO_ADD_TEST(RangeOps, combining_with_inverse)
 {
     OCIO::OpRcPtrVec ops;
 
     OCIO::CreateRangeOp(ops, 0., 1., 0.5, 1.5);
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_CHECK_NO_THROW(ops[0]->finalize());
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_NO_THROW(ops[0]->finalize());
     OCIO::CreateRangeOp(ops, 0., 1., 0.5, 1.5, OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_CHECK_NO_THROW(ops[1]->finalize());
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_CHECK_NO_THROW(ops[1]->finalize());
 
     OCIO::ConstOpRcPtr op1 = ops[1];
 
     // TODO: implement Range combine
-    OIIO_CHECK_THROW_WHAT(ops[0]->combineWith(ops, op1), 
+    OCIO_CHECK_THROW_WHAT(ops[0]->combineWith(ops, op1), 
                           OCIO::Exception, "TODO: Range can't be combined");
-    OIIO_CHECK_EQUAL(ops.size(), 2);
+    OCIO_CHECK_EQUAL(ops.size(), 2);
 
 }
 
-OIIO_ADD_TEST(RangeOps, is_inverse)
+OCIO_ADD_TEST(RangeOps, is_inverse)
 {
     OCIO::OpRcPtrVec ops;
 
     OCIO::CreateRangeOp(ops, 0., 0.5, 0.5, 1.);
-    OIIO_CHECK_EQUAL(ops.size(), 1);
+    OCIO_CHECK_EQUAL(ops.size(), 1);
     // Skip finalize so that inverse direction is kept
     OCIO::CreateRangeOp(ops, 0., 0.5, 0.5, 1., OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(ops.size(), 2);
+    OCIO_CHECK_EQUAL(ops.size(), 2);
 
     const float offset[] = { 1.1f, -1.3f, 0.3f, 0.0f };
-    OIIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 3);
+    OCIO_CHECK_NO_THROW(CreateOffsetOp(ops, offset, OCIO::TRANSFORM_DIR_FORWARD));
+    OCIO_REQUIRE_EQUAL(ops.size(), 3);
     OCIO::ConstOpRcPtr op0 = ops[0];
     OCIO::ConstOpRcPtr op1 = ops[1];
     OCIO::ConstOpRcPtr op2 = ops[2];
 
-    OIIO_CHECK_ASSERT(ops[0]->isSameType(op1));
-    OIIO_CHECK_ASSERT(!ops[0]->isSameType(op2));
+    OCIO_CHECK_ASSERT(ops[0]->isSameType(op1));
+    OCIO_CHECK_ASSERT(!ops[0]->isSameType(op2));
 
-    OIIO_CHECK_ASSERT(!ops[0]->isInverse(op2));
-    OIIO_CHECK_ASSERT(!ops[0]->isInverse(op0));
+    OCIO_CHECK_ASSERT(!ops[0]->isInverse(op2));
+    OCIO_CHECK_ASSERT(!ops[0]->isInverse(op0));
 
     // Inverse based on Op direction
 
-    OIIO_CHECK_ASSERT(ops[0]->isInverse(op1));
+    OCIO_CHECK_ASSERT(ops[0]->isInverse(op1));
 
     OCIO::CreateRangeOp(ops, 0.000002, 0.5, 0.5, 1., OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_REQUIRE_EQUAL(ops.size(), 4);
+    OCIO_REQUIRE_EQUAL(ops.size(), 4);
     OCIO::ConstOpRcPtr op3 = ops[3];
 
-    OIIO_CHECK_ASSERT(!ops[0]->isInverse(op3));
-    OIIO_CHECK_ASSERT(!ops[2]->isInverse(op3));
+    OCIO_CHECK_ASSERT(!ops[0]->isInverse(op3));
+    OCIO_CHECK_ASSERT(!ops[2]->isInverse(op3));
 
     OCIO::CreateRangeOp(ops, 0.000002, 0.5, 0.5, 1.);
-    OIIO_REQUIRE_EQUAL(ops.size(), 5);
+    OCIO_REQUIRE_EQUAL(ops.size(), 5);
     OCIO::ConstOpRcPtr op4 = ops[4];
 
-    OIIO_CHECK_ASSERT(!ops[0]->isInverse(op4));
-    OIIO_CHECK_ASSERT(!ops[2]->isInverse(op4));
-    OIIO_CHECK_ASSERT(ops[3]->isInverse(op4));
+    OCIO_CHECK_ASSERT(!ops[0]->isInverse(op4));
+    OCIO_CHECK_ASSERT(!ops[2]->isInverse(op4));
+    OCIO_CHECK_ASSERT(ops[3]->isInverse(op4));
 
     OCIO::CreateRangeOp(ops, 0.5, 1., 0.000002, 0.5, OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_REQUIRE_EQUAL(ops.size(), 6);
+    OCIO_REQUIRE_EQUAL(ops.size(), 6);
     OCIO::ConstOpRcPtr op5 = ops[5];
 
-    OIIO_CHECK_ASSERT(!ops[0]->isInverse(op5));
-    OIIO_CHECK_ASSERT(!ops[2]->isInverse(op5));
-    OIIO_CHECK_ASSERT(ops[3]->isInverse(op5));
-    OIIO_CHECK_ASSERT(!ops[4]->isInverse(op5));
+    OCIO_CHECK_ASSERT(!ops[0]->isInverse(op5));
+    OCIO_CHECK_ASSERT(!ops[2]->isInverse(op5));
+    OCIO_CHECK_ASSERT(ops[3]->isInverse(op5));
+    OCIO_CHECK_ASSERT(!ops[4]->isInverse(op5));
 }
 
-OIIO_ADD_TEST(RangeOps, computed_identifier)
+OCIO_ADD_TEST(RangeOps, computed_identifier)
 {
     OCIO::OpRcPtrVec ops;
 
@@ -415,22 +415,22 @@ OIIO_ADD_TEST(RangeOps, computed_identifier)
     OCIO::CreateRangeOp(ops, 0.1, 1., 0.3, 1.9, OCIO::TRANSFORM_DIR_INVERSE);
     for(OCIO::OpRcPtrVec::reference op : ops) { op->finalize(); }
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 4);
+    OCIO_REQUIRE_EQUAL(ops.size(), 4);
 
-    OIIO_CHECK_ASSERT(ops[0]->getCacheID() == ops[1]->getCacheID());
-    OIIO_CHECK_ASSERT(ops[0]->getCacheID() != ops[2]->getCacheID());
-    OIIO_CHECK_ASSERT(ops[1]->getCacheID() != ops[2]->getCacheID());
-    OIIO_CHECK_ASSERT(ops[2]->getCacheID() != ops[3]->getCacheID());
+    OCIO_CHECK_ASSERT(ops[0]->getCacheID() == ops[1]->getCacheID());
+    OCIO_CHECK_ASSERT(ops[0]->getCacheID() != ops[2]->getCacheID());
+    OCIO_CHECK_ASSERT(ops[1]->getCacheID() != ops[2]->getCacheID());
+    OCIO_CHECK_ASSERT(ops[2]->getCacheID() != ops[3]->getCacheID());
 
     OCIO::CreateRangeOp(ops, 0.1, 1., 0.3, 1.90001);
     for(OCIO::OpRcPtrVec::reference op : ops) { op->finalize(); }
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 5);
-    OIIO_CHECK_ASSERT(ops[2]->getCacheID() != ops[4]->getCacheID());
-    OIIO_CHECK_ASSERT(ops[3]->getCacheID() != ops[4]->getCacheID());
+    OCIO_REQUIRE_EQUAL(ops.size(), 5);
+    OCIO_CHECK_ASSERT(ops[2]->getCacheID() != ops[4]->getCacheID());
+    OCIO_CHECK_ASSERT(ops[3]->getCacheID() != ops[4]->getCacheID());
 }
 
-OIIO_ADD_TEST(RangeOps, bit_depth)
+OCIO_ADD_TEST(RangeOps, bit_depth)
 {
     // Test bit depths.
 
@@ -438,23 +438,23 @@ OIIO_ADD_TEST(RangeOps, bit_depth)
         = std::make_shared<OCIO::RangeOpData>(OCIO::BIT_DEPTH_UINT8, OCIO::BIT_DEPTH_UINT16,
                                               0., 255., -1., 65540.);
 
-    OIIO_CHECK_EQUAL(range->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(range->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT16);
+    OCIO_CHECK_EQUAL(range->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(range->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT16);
 
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(OCIO::CreateRangeOp(ops, range, OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_CHECK_NO_THROW(OCIO::CreateRangeOp(ops, range, OCIO::TRANSFORM_DIR_FORWARD));
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
 
-    OIIO_CHECK_EQUAL(ops[0]->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT16);
+    OCIO_CHECK_EQUAL(ops[0]->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ops[0]->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT16);
 
     // Test bit depths after a clone.
 
     OCIO::ConstOpRcPtr o = ops[0]->clone();
-    OIIO_CHECK_EQUAL(o->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(o->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT16);
+    OCIO_CHECK_EQUAL(o->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(o->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT16);
 
     OCIO::ConstRangeOpDataRcPtr r = DynamicPtrCast<const OCIO::RangeOpData>(o->data());
-    OIIO_CHECK_EQUAL(r->getMinOutValue(), -1.);
+    OCIO_CHECK_EQUAL(r->getMinOutValue(), -1.);
 }
 #endif

--- a/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpCPU.cpp
+++ b/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpCPU.cpp
@@ -806,7 +806,7 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 namespace
 {
@@ -875,7 +875,7 @@ static constexpr float inf = std::numeric_limits<float>::infinity();
 
 }
 
-OIIO_ADD_TEST(ExposureContrastRenderer, video)
+OCIO_ADD_TEST(ExposureContrastRenderer, video)
 {
     //
     // Video case, no scaling
@@ -897,26 +897,26 @@ OIIO_ADD_TEST(ExposureContrastRenderer, video)
 
     OCIO::ConstExposureContrastOpDataRcPtr const_ec = ec;
     OCIO::OpCPURcPtr renderer = OCIO::GetExposureContrastCPURenderer(const_ec);
-    OIIO_CHECK_ASSERT(OCIO::DynamicPtrCast<OCIO::ECVideoRenderer>(renderer));
+    OCIO_CHECK_ASSERT(OCIO::DynamicPtrCast<OCIO::ECVideoRenderer>(renderer));
     std::vector<float> rgba = rgbaImage;
 
     renderer->apply(rgba.data(), rgba.data(), 4);
 
-    OIIO_CHECK_EQUAL(rgba[0], videoECVal(rgbaImage[0], const_ec));
-    OIIO_CHECK_EQUAL(rgba[1], videoECVal(rgbaImage[1], const_ec));
-    OIIO_CHECK_EQUAL(rgba[2], videoECVal(rgbaImage[2], const_ec));
-    OIIO_CHECK_EQUAL(rgba[3], rgbaImage[3]);
-    OIIO_CHECK_EQUAL(rgba[4], videoECVal(rgbaImage[4], const_ec));
-    OIIO_CHECK_EQUAL(rgba[5], videoECVal(rgbaImage[5], const_ec));
-    OIIO_CHECK_EQUAL(rgba[6], videoECVal(rgbaImage[6], const_ec));
-    OIIO_CHECK_EQUAL(rgba[7], rgbaImage[7]);
+    OCIO_CHECK_EQUAL(rgba[0], videoECVal(rgbaImage[0], const_ec));
+    OCIO_CHECK_EQUAL(rgba[1], videoECVal(rgbaImage[1], const_ec));
+    OCIO_CHECK_EQUAL(rgba[2], videoECVal(rgbaImage[2], const_ec));
+    OCIO_CHECK_EQUAL(rgba[3], rgbaImage[3]);
+    OCIO_CHECK_EQUAL(rgba[4], videoECVal(rgbaImage[4], const_ec));
+    OCIO_CHECK_EQUAL(rgba[5], videoECVal(rgbaImage[5], const_ec));
+    OCIO_CHECK_EQUAL(rgba[6], videoECVal(rgbaImage[6], const_ec));
+    OCIO_CHECK_EQUAL(rgba[7], rgbaImage[7]);
 
-    OIIO_CHECK_ASSERT(std::isnan(rgba[8]));
-    OIIO_CHECK_ASSERT(std::isnan(rgba[9]));
-    OIIO_CHECK_ASSERT(std::isnan(rgba[10]));
-    OIIO_CHECK_EQUAL(rgba[12], videoECVal(rgbaImage[12], const_ec));
-    OIIO_CHECK_EQUAL(rgba[13], videoECVal(rgbaImage[13], const_ec));
-    OIIO_CHECK_EQUAL(rgba[14], videoECVal(rgbaImage[14], const_ec));
+    OCIO_CHECK_ASSERT(std::isnan(rgba[8]));
+    OCIO_CHECK_ASSERT(std::isnan(rgba[9]));
+    OCIO_CHECK_ASSERT(std::isnan(rgba[10]));
+    OCIO_CHECK_EQUAL(rgba[12], videoECVal(rgbaImage[12], const_ec));
+    OCIO_CHECK_EQUAL(rgba[13], videoECVal(rgbaImage[13], const_ec));
+    OCIO_CHECK_EQUAL(rgba[14], videoECVal(rgbaImage[14], const_ec));
 
     // Re-test with different E/C values.
     //
@@ -932,24 +932,24 @@ OIIO_ADD_TEST(ExposureContrastRenderer, video)
 
     // As the ssePower is an approximation, strict equality is not possible.
     const float error = 1e-5f;
-    OIIO_CHECK_CLOSE(rgba[0], videoECVal(rgbaImage[0], const_ec), error);
-    OIIO_CHECK_CLOSE(rgba[1], videoECVal(rgbaImage[1], const_ec), error);
-    OIIO_CHECK_CLOSE(rgba[2], videoECVal(rgbaImage[2], const_ec), error);
-    OIIO_CHECK_EQUAL(rgba[3], rgbaImage[3]);
-    OIIO_CHECK_CLOSE(rgba[4], videoECVal(rgbaImage[4], const_ec), error);
-    OIIO_CHECK_CLOSE(rgba[5], videoECVal(rgbaImage[5], const_ec), error);
-    OIIO_CHECK_CLOSE(rgba[6], videoECVal(rgbaImage[6], const_ec), error);
-    OIIO_CHECK_EQUAL(rgba[7], rgbaImage[7]);
+    OCIO_CHECK_CLOSE(rgba[0], videoECVal(rgbaImage[0], const_ec), error);
+    OCIO_CHECK_CLOSE(rgba[1], videoECVal(rgbaImage[1], const_ec), error);
+    OCIO_CHECK_CLOSE(rgba[2], videoECVal(rgbaImage[2], const_ec), error);
+    OCIO_CHECK_EQUAL(rgba[3], rgbaImage[3]);
+    OCIO_CHECK_CLOSE(rgba[4], videoECVal(rgbaImage[4], const_ec), error);
+    OCIO_CHECK_CLOSE(rgba[5], videoECVal(rgbaImage[5], const_ec), error);
+    OCIO_CHECK_CLOSE(rgba[6], videoECVal(rgbaImage[6], const_ec), error);
+    OCIO_CHECK_EQUAL(rgba[7], rgbaImage[7]);
 
-    OIIO_CHECK_CLOSE(rgba[8], videoECVal(rgbaImage[8], const_ec), error);
-    OIIO_CHECK_CLOSE(rgba[9], videoECVal(rgbaImage[9], const_ec), error);
-    OIIO_CHECK_CLOSE(rgba[10], videoECVal(rgbaImage[10], const_ec), error);
-    OIIO_CHECK_EQUAL(rgba[12], videoECVal(rgbaImage[12], const_ec));
-    OIIO_CHECK_EQUAL(rgba[13], videoECVal(rgbaImage[13], const_ec));
-    OIIO_CHECK_EQUAL(rgba[14], videoECVal(rgbaImage[14], const_ec));
+    OCIO_CHECK_CLOSE(rgba[8], videoECVal(rgbaImage[8], const_ec), error);
+    OCIO_CHECK_CLOSE(rgba[9], videoECVal(rgbaImage[9], const_ec), error);
+    OCIO_CHECK_CLOSE(rgba[10], videoECVal(rgbaImage[10], const_ec), error);
+    OCIO_CHECK_EQUAL(rgba[12], videoECVal(rgbaImage[12], const_ec));
+    OCIO_CHECK_EQUAL(rgba[13], videoECVal(rgbaImage[13], const_ec));
+    OCIO_CHECK_EQUAL(rgba[14], videoECVal(rgbaImage[14], const_ec));
 }
 
-OIIO_ADD_TEST(ExposureContrastRenderer, log)
+OCIO_ADD_TEST(ExposureContrastRenderer, log)
 {
     //
     // Log case, no scaling
@@ -972,7 +972,7 @@ OIIO_ADD_TEST(ExposureContrastRenderer, log)
 
     OCIO::ConstExposureContrastOpDataRcPtr const_ec = ec;
     OCIO::OpCPURcPtr renderer = OCIO::GetExposureContrastCPURenderer(const_ec);
-    OIIO_CHECK_ASSERT(OCIO::DynamicPtrCast<OCIO::ECLogarithmicRenderer>(renderer));
+    OCIO_CHECK_ASSERT(OCIO::DynamicPtrCast<OCIO::ECLogarithmicRenderer>(renderer));
 
     std::vector<float> rgba = rgbaImage;
 
@@ -981,21 +981,21 @@ OIIO_ADD_TEST(ExposureContrastRenderer, log)
     const float inMax = OCIO::GetBitDepthMaxValue(OCIO::BIT_DEPTH_F32);
     const float outMax = OCIO::GetBitDepthMaxValue(OCIO::BIT_DEPTH_F32);
 
-    OIIO_CHECK_EQUAL(rgba[0], logECVal(rgbaImage[0], const_ec, inMax, outMax));
-    OIIO_CHECK_EQUAL(rgba[1], logECVal(rgbaImage[1], const_ec, inMax, outMax));
-    OIIO_CHECK_EQUAL(rgba[2], logECVal(rgbaImage[2], const_ec, inMax, outMax));
-    OIIO_CHECK_EQUAL(rgba[3], rgbaImage[3] * outMax / inMax);
-    OIIO_CHECK_EQUAL(rgba[4], logECVal(rgbaImage[4], const_ec, inMax, outMax));
-    OIIO_CHECK_EQUAL(rgba[5], logECVal(rgbaImage[5], const_ec, inMax, outMax));
-    OIIO_CHECK_EQUAL(rgba[6], logECVal(rgbaImage[6], const_ec, inMax, outMax));
-    OIIO_CHECK_EQUAL(rgba[7], rgbaImage[7] * outMax / inMax);
+    OCIO_CHECK_EQUAL(rgba[0], logECVal(rgbaImage[0], const_ec, inMax, outMax));
+    OCIO_CHECK_EQUAL(rgba[1], logECVal(rgbaImage[1], const_ec, inMax, outMax));
+    OCIO_CHECK_EQUAL(rgba[2], logECVal(rgbaImage[2], const_ec, inMax, outMax));
+    OCIO_CHECK_EQUAL(rgba[3], rgbaImage[3] * outMax / inMax);
+    OCIO_CHECK_EQUAL(rgba[4], logECVal(rgbaImage[4], const_ec, inMax, outMax));
+    OCIO_CHECK_EQUAL(rgba[5], logECVal(rgbaImage[5], const_ec, inMax, outMax));
+    OCIO_CHECK_EQUAL(rgba[6], logECVal(rgbaImage[6], const_ec, inMax, outMax));
+    OCIO_CHECK_EQUAL(rgba[7], rgbaImage[7] * outMax / inMax);
 
-    OIIO_CHECK_ASSERT(std::isnan(rgba[8]));
-    OIIO_CHECK_ASSERT(std::isnan(rgba[9]));
-    OIIO_CHECK_ASSERT(std::isnan(rgba[10]));
-    OIIO_CHECK_EQUAL(rgba[12], logECVal(rgbaImage[12], const_ec));
-    OIIO_CHECK_EQUAL(rgba[13], logECVal(rgbaImage[13], const_ec));
-    OIIO_CHECK_EQUAL(rgba[14], logECVal(rgbaImage[14], const_ec));
+    OCIO_CHECK_ASSERT(std::isnan(rgba[8]));
+    OCIO_CHECK_ASSERT(std::isnan(rgba[9]));
+    OCIO_CHECK_ASSERT(std::isnan(rgba[10]));
+    OCIO_CHECK_EQUAL(rgba[12], logECVal(rgbaImage[12], const_ec));
+    OCIO_CHECK_EQUAL(rgba[13], logECVal(rgbaImage[13], const_ec));
+    OCIO_CHECK_EQUAL(rgba[14], logECVal(rgbaImage[14], const_ec));
 
     // Re-test with differenc E/C values.
     //
@@ -1006,24 +1006,24 @@ OIIO_ADD_TEST(ExposureContrastRenderer, log)
     rgba = rgbaImage;
     renderer->apply(rgba.data(), rgba.data(), 4);
 
-    OIIO_CHECK_EQUAL(rgba[0], logECVal(rgbaImage[0], const_ec, inMax, outMax));
-    OIIO_CHECK_EQUAL(rgba[1], logECVal(rgbaImage[1], const_ec, inMax, outMax));
-    OIIO_CHECK_EQUAL(rgba[2], logECVal(rgbaImage[2], const_ec, inMax, outMax));
-    OIIO_CHECK_EQUAL(rgba[3], rgbaImage[3] * outMax / inMax);
-    OIIO_CHECK_EQUAL(rgba[4], logECVal(rgbaImage[4], const_ec, inMax, outMax));
-    OIIO_CHECK_EQUAL(rgba[5], logECVal(rgbaImage[5], const_ec, inMax, outMax));
-    OIIO_CHECK_EQUAL(rgba[6], logECVal(rgbaImage[6], const_ec, inMax, outMax));
-    OIIO_CHECK_EQUAL(rgba[7], rgbaImage[7] * outMax / inMax);
+    OCIO_CHECK_EQUAL(rgba[0], logECVal(rgbaImage[0], const_ec, inMax, outMax));
+    OCIO_CHECK_EQUAL(rgba[1], logECVal(rgbaImage[1], const_ec, inMax, outMax));
+    OCIO_CHECK_EQUAL(rgba[2], logECVal(rgbaImage[2], const_ec, inMax, outMax));
+    OCIO_CHECK_EQUAL(rgba[3], rgbaImage[3] * outMax / inMax);
+    OCIO_CHECK_EQUAL(rgba[4], logECVal(rgbaImage[4], const_ec, inMax, outMax));
+    OCIO_CHECK_EQUAL(rgba[5], logECVal(rgbaImage[5], const_ec, inMax, outMax));
+    OCIO_CHECK_EQUAL(rgba[6], logECVal(rgbaImage[6], const_ec, inMax, outMax));
+    OCIO_CHECK_EQUAL(rgba[7], rgbaImage[7] * outMax / inMax);
 
-    OIIO_CHECK_ASSERT(std::isnan(rgba[8]));
-    OIIO_CHECK_ASSERT(std::isnan(rgba[9]));
-    OIIO_CHECK_ASSERT(std::isnan(rgba[10]));
-    OIIO_CHECK_EQUAL(rgba[12], logECVal(rgbaImage[12], const_ec));
-    OIIO_CHECK_EQUAL(rgba[13], logECVal(rgbaImage[13], const_ec));
-    OIIO_CHECK_EQUAL(rgba[14], logECVal(rgbaImage[14], const_ec));
+    OCIO_CHECK_ASSERT(std::isnan(rgba[8]));
+    OCIO_CHECK_ASSERT(std::isnan(rgba[9]));
+    OCIO_CHECK_ASSERT(std::isnan(rgba[10]));
+    OCIO_CHECK_EQUAL(rgba[12], logECVal(rgbaImage[12], const_ec));
+    OCIO_CHECK_EQUAL(rgba[13], logECVal(rgbaImage[13], const_ec));
+    OCIO_CHECK_EQUAL(rgba[14], logECVal(rgbaImage[14], const_ec));
 }
 
-OIIO_ADD_TEST(ExposureContrastRenderer, linear)
+OCIO_ADD_TEST(ExposureContrastRenderer, linear)
 {
     //
     // Linear case, no scaling
@@ -1044,27 +1044,27 @@ OIIO_ADD_TEST(ExposureContrastRenderer, linear)
 
     OCIO::ConstExposureContrastOpDataRcPtr const_ec = ec;
     OCIO::OpCPURcPtr renderer = OCIO::GetExposureContrastCPURenderer(const_ec);
-    OIIO_CHECK_ASSERT(OCIO::DynamicPtrCast<OCIO::ECLinearRenderer>(renderer));
+    OCIO_CHECK_ASSERT(OCIO::DynamicPtrCast<OCIO::ECLinearRenderer>(renderer));
 
     std::vector<float> rgba = rgbaImage;
 
     renderer->apply(rgba.data(), rgba.data(), 4);
 
-    OIIO_CHECK_EQUAL(rgba[0], linECVal(rgbaImage[0], const_ec));
-    OIIO_CHECK_EQUAL(rgba[1], linECVal(rgbaImage[1], const_ec));
-    OIIO_CHECK_EQUAL(rgba[2], linECVal(rgbaImage[2], const_ec));
-    OIIO_CHECK_EQUAL(rgba[3], rgbaImage[3]);
-    OIIO_CHECK_EQUAL(rgba[4], linECVal(rgbaImage[4], const_ec));
-    OIIO_CHECK_EQUAL(rgba[5], linECVal(rgbaImage[5], const_ec));
-    OIIO_CHECK_EQUAL(rgba[6], linECVal(rgbaImage[6], const_ec));
-    OIIO_CHECK_EQUAL(rgba[7], rgbaImage[7]);
+    OCIO_CHECK_EQUAL(rgba[0], linECVal(rgbaImage[0], const_ec));
+    OCIO_CHECK_EQUAL(rgba[1], linECVal(rgbaImage[1], const_ec));
+    OCIO_CHECK_EQUAL(rgba[2], linECVal(rgbaImage[2], const_ec));
+    OCIO_CHECK_EQUAL(rgba[3], rgbaImage[3]);
+    OCIO_CHECK_EQUAL(rgba[4], linECVal(rgbaImage[4], const_ec));
+    OCIO_CHECK_EQUAL(rgba[5], linECVal(rgbaImage[5], const_ec));
+    OCIO_CHECK_EQUAL(rgba[6], linECVal(rgbaImage[6], const_ec));
+    OCIO_CHECK_EQUAL(rgba[7], rgbaImage[7]);
 
-    OIIO_CHECK_ASSERT(std::isnan(rgba[8]));
-    OIIO_CHECK_ASSERT(std::isnan(rgba[9]));
-    OIIO_CHECK_ASSERT(std::isnan(rgba[10]));
-    OIIO_CHECK_EQUAL(rgba[12], linECVal(rgbaImage[12], const_ec));
-    OIIO_CHECK_EQUAL(rgba[13], linECVal(rgbaImage[13], const_ec));
-    OIIO_CHECK_EQUAL(rgba[14], linECVal(rgbaImage[14], const_ec));
+    OCIO_CHECK_ASSERT(std::isnan(rgba[8]));
+    OCIO_CHECK_ASSERT(std::isnan(rgba[9]));
+    OCIO_CHECK_ASSERT(std::isnan(rgba[10]));
+    OCIO_CHECK_EQUAL(rgba[12], linECVal(rgbaImage[12], const_ec));
+    OCIO_CHECK_EQUAL(rgba[13], linECVal(rgbaImage[13], const_ec));
+    OCIO_CHECK_EQUAL(rgba[14], linECVal(rgbaImage[14], const_ec));
 
     // Re-test with different E/C values.
     //
@@ -1078,21 +1078,21 @@ OIIO_ADD_TEST(ExposureContrastRenderer, linear)
     // As the ssePower is an approximation, strict equality is not possible.
     const float error = 5e-5f;
 
-    OIIO_CHECK_CLOSE(rgba[0], linECVal(rgbaImage[0], const_ec), error);
-    OIIO_CHECK_CLOSE(rgba[1], linECVal(rgbaImage[1], const_ec), error);
-    OIIO_CHECK_CLOSE(rgba[2], linECVal(rgbaImage[2], const_ec), error);
-    OIIO_CHECK_EQUAL(rgba[3], rgbaImage[3]);
-    OIIO_CHECK_CLOSE(rgba[4], linECVal(rgbaImage[4], const_ec), error);
-    OIIO_CHECK_CLOSE(rgba[5], linECVal(rgbaImage[5], const_ec), error);
-    OIIO_CHECK_CLOSE(rgba[6], linECVal(rgbaImage[6], const_ec), error);
-    OIIO_CHECK_EQUAL(rgba[7], rgbaImage[7]);
+    OCIO_CHECK_CLOSE(rgba[0], linECVal(rgbaImage[0], const_ec), error);
+    OCIO_CHECK_CLOSE(rgba[1], linECVal(rgbaImage[1], const_ec), error);
+    OCIO_CHECK_CLOSE(rgba[2], linECVal(rgbaImage[2], const_ec), error);
+    OCIO_CHECK_EQUAL(rgba[3], rgbaImage[3]);
+    OCIO_CHECK_CLOSE(rgba[4], linECVal(rgbaImage[4], const_ec), error);
+    OCIO_CHECK_CLOSE(rgba[5], linECVal(rgbaImage[5], const_ec), error);
+    OCIO_CHECK_CLOSE(rgba[6], linECVal(rgbaImage[6], const_ec), error);
+    OCIO_CHECK_EQUAL(rgba[7], rgbaImage[7]);
 
-    OIIO_CHECK_CLOSE(rgba[8], linECVal(rgbaImage[8], const_ec), error);
-    OIIO_CHECK_CLOSE(rgba[9], linECVal(rgbaImage[9], const_ec), error);
-    OIIO_CHECK_CLOSE(rgba[10], linECVal(rgbaImage[10], const_ec), error);
-    OIIO_CHECK_EQUAL(rgba[12], linECVal(rgbaImage[12], const_ec));
-    OIIO_CHECK_EQUAL(rgba[13], linECVal(rgbaImage[13], const_ec));
-    OIIO_CHECK_EQUAL(rgba[14], linECVal(rgbaImage[14], const_ec));
+    OCIO_CHECK_CLOSE(rgba[8], linECVal(rgbaImage[8], const_ec), error);
+    OCIO_CHECK_CLOSE(rgba[9], linECVal(rgbaImage[9], const_ec), error);
+    OCIO_CHECK_CLOSE(rgba[10], linECVal(rgbaImage[10], const_ec), error);
+    OCIO_CHECK_EQUAL(rgba[12], linECVal(rgbaImage[12], const_ec));
+    OCIO_CHECK_EQUAL(rgba[13], linECVal(rgbaImage[13], const_ec));
+    OCIO_CHECK_EQUAL(rgba[14], linECVal(rgbaImage[14], const_ec));
 }
 
 namespace
@@ -1126,18 +1126,18 @@ void TestECInverse(OCIO::ExposureContrastOpData::Style style)
     // As the ssePower is an approximation, strict equality is not possible.
     const float error = 1e-5f;
 
-    OIIO_CHECK_CLOSE(rgba[0], rgbaImage[0], error);
-    OIIO_CHECK_CLOSE(rgba[1], rgbaImage[1], error);
-    OIIO_CHECK_CLOSE(rgba[2], rgbaImage[2], error);
-    OIIO_CHECK_EQUAL(rgba[3], rgbaImage[3]);
-    OIIO_CHECK_CLOSE(rgba[4], rgbaImage[4], error);
-    OIIO_CHECK_CLOSE(rgba[5], rgbaImage[5], error);
-    OIIO_CHECK_CLOSE(rgba[6], rgbaImage[6], error);
-    OIIO_CHECK_EQUAL(rgba[7], rgbaImage[7]);
+    OCIO_CHECK_CLOSE(rgba[0], rgbaImage[0], error);
+    OCIO_CHECK_CLOSE(rgba[1], rgbaImage[1], error);
+    OCIO_CHECK_CLOSE(rgba[2], rgbaImage[2], error);
+    OCIO_CHECK_EQUAL(rgba[3], rgbaImage[3]);
+    OCIO_CHECK_CLOSE(rgba[4], rgbaImage[4], error);
+    OCIO_CHECK_CLOSE(rgba[5], rgbaImage[5], error);
+    OCIO_CHECK_CLOSE(rgba[6], rgbaImage[6], error);
+    OCIO_CHECK_EQUAL(rgba[7], rgbaImage[7]);
 }
 }
 
-OIIO_ADD_TEST(ExposureContrastRenderer, inverse)
+OCIO_ADD_TEST(ExposureContrastRenderer, inverse)
 {
     TestECInverse(OCIO::ExposureContrastOpData::STYLE_LOGARITHMIC);
     TestECInverse(OCIO::ExposureContrastOpData::STYLE_LINEAR);
@@ -1181,17 +1181,17 @@ void TestLogParamForStyle(OCIO::ExposureContrastOpData::Style style, bool hasEff
         {
             if (!hasEffect || i%4 == 3) // EC does not affect alpha
             {
-                OIIO_CHECK_EQUAL(rgba[i], rgbaRef[i]);
+                OCIO_CHECK_EQUAL(rgba[i], rgbaRef[i]);
             }
             else
             {
-                OIIO_CHECK_NE(rgba[i], rgbaRef[i]);
+                OCIO_CHECK_NE(rgba[i], rgbaRef[i]);
             }
         }
     }
 }
 
-OIIO_ADD_TEST(ExposureContrastRenderer, log_params)
+OCIO_ADD_TEST(ExposureContrastRenderer, log_params)
 {
     TestLogParamForStyle(OCIO::ExposureContrastOpData::STYLE_VIDEO, false);
     TestLogParamForStyle(OCIO::ExposureContrastOpData::STYLE_VIDEO_REV, false);

--- a/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpData.cpp
+++ b/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOpData.cpp
@@ -389,125 +389,126 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(ExposureContrastOpData, style)
+OCIO_ADD_TEST(ExposureContrastOpData, style)
 {
-    OCIO::ExposureContrastOpData::Style style;
+    OCIO::ExposureContrastOpData::Style style = 
+        OCIO::ExposureContrastOpData::STYLE_LOGARITHMIC_REV;
     const auto & ConvertToStyle =
         OCIO::ExposureContrastOpData::ConvertStringToStyle;
-    OIIO_CHECK_NO_THROW(style =
+    OCIO_CHECK_NO_THROW(style =
         ConvertToStyle(OCIO::EC_STYLE_LINEAR));
-    OIIO_CHECK_EQUAL(style, OCIO::ExposureContrastOpData::STYLE_LINEAR);
-    OIIO_CHECK_NO_THROW(style =
+    OCIO_CHECK_EQUAL(style, OCIO::ExposureContrastOpData::STYLE_LINEAR);
+    OCIO_CHECK_NO_THROW(style =
         ConvertToStyle(OCIO::EC_STYLE_LINEAR_REV));
-    OIIO_CHECK_EQUAL(style, OCIO::ExposureContrastOpData::STYLE_LINEAR_REV);
-    OIIO_CHECK_NO_THROW(style =
+    OCIO_CHECK_EQUAL(style, OCIO::ExposureContrastOpData::STYLE_LINEAR_REV);
+    OCIO_CHECK_NO_THROW(style =
         ConvertToStyle(OCIO::EC_STYLE_VIDEO));
-    OIIO_CHECK_EQUAL(style, OCIO::ExposureContrastOpData::STYLE_VIDEO);
-    OIIO_CHECK_NO_THROW(style =
+    OCIO_CHECK_EQUAL(style, OCIO::ExposureContrastOpData::STYLE_VIDEO);
+    OCIO_CHECK_NO_THROW(style =
         ConvertToStyle(OCIO::EC_STYLE_VIDEO_REV));
-    OIIO_CHECK_EQUAL(style, OCIO::ExposureContrastOpData::STYLE_VIDEO_REV);
-    OIIO_CHECK_NO_THROW(style =
+    OCIO_CHECK_EQUAL(style, OCIO::ExposureContrastOpData::STYLE_VIDEO_REV);
+    OCIO_CHECK_NO_THROW(style =
         ConvertToStyle(OCIO::EC_STYLE_LOGARITHMIC));
-    OIIO_CHECK_EQUAL(style, OCIO::ExposureContrastOpData::STYLE_LOGARITHMIC);
-    OIIO_CHECK_NO_THROW(style =
+    OCIO_CHECK_EQUAL(style, OCIO::ExposureContrastOpData::STYLE_LOGARITHMIC);
+    OCIO_CHECK_NO_THROW(style =
         ConvertToStyle(OCIO::EC_STYLE_LOGARITHMIC_REV));
-    OIIO_CHECK_EQUAL(style, OCIO::ExposureContrastOpData::STYLE_LOGARITHMIC_REV);
+    OCIO_CHECK_EQUAL(style, OCIO::ExposureContrastOpData::STYLE_LOGARITHMIC_REV);
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         ConvertToStyle("Unknown exposure contrast style"),
         OCIO::Exception, "Unknown exposure contrast style");
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         ConvertToStyle(nullptr),
         OCIO::Exception, "Missing exposure contrast style");
 
     const auto & ConvertToString =
         OCIO::ExposureContrastOpData::ConvertStyleToString;
     std::string styleName;
-    OIIO_CHECK_NO_THROW(styleName =
+    OCIO_CHECK_NO_THROW(styleName =
         ConvertToString(OCIO::ExposureContrastOpData::STYLE_LINEAR));
-    OIIO_CHECK_EQUAL(styleName, OCIO::EC_STYLE_LINEAR);
-    OIIO_CHECK_NO_THROW(styleName =
+    OCIO_CHECK_EQUAL(styleName, OCIO::EC_STYLE_LINEAR);
+    OCIO_CHECK_NO_THROW(styleName =
         ConvertToString(OCIO::ExposureContrastOpData::STYLE_LINEAR_REV));
-    OIIO_CHECK_EQUAL(styleName, OCIO::EC_STYLE_LINEAR_REV);
-    OIIO_CHECK_NO_THROW(styleName =
+    OCIO_CHECK_EQUAL(styleName, OCIO::EC_STYLE_LINEAR_REV);
+    OCIO_CHECK_NO_THROW(styleName =
         ConvertToString(OCIO::ExposureContrastOpData::STYLE_VIDEO));
-    OIIO_CHECK_EQUAL(styleName, OCIO::EC_STYLE_VIDEO);
-    OIIO_CHECK_NO_THROW(styleName =
+    OCIO_CHECK_EQUAL(styleName, OCIO::EC_STYLE_VIDEO);
+    OCIO_CHECK_NO_THROW(styleName =
         ConvertToString(OCIO::ExposureContrastOpData::STYLE_VIDEO_REV));
-    OIIO_CHECK_EQUAL(styleName, OCIO::EC_STYLE_VIDEO_REV);
-    OIIO_CHECK_NO_THROW(styleName =
+    OCIO_CHECK_EQUAL(styleName, OCIO::EC_STYLE_VIDEO_REV);
+    OCIO_CHECK_NO_THROW(styleName =
         ConvertToString(OCIO::ExposureContrastOpData::STYLE_LOGARITHMIC));
-    OIIO_CHECK_EQUAL(styleName, OCIO::EC_STYLE_LOGARITHMIC);
-    OIIO_CHECK_NO_THROW(styleName =
+    OCIO_CHECK_EQUAL(styleName, OCIO::EC_STYLE_LOGARITHMIC);
+    OCIO_CHECK_NO_THROW(styleName =
         ConvertToString(OCIO::ExposureContrastOpData::STYLE_LOGARITHMIC_REV));
-    OIIO_CHECK_EQUAL(styleName, OCIO::EC_STYLE_LOGARITHMIC_REV);
+    OCIO_CHECK_EQUAL(styleName, OCIO::EC_STYLE_LOGARITHMIC_REV);
 
-    OIIO_CHECK_THROW_WHAT(
+    OCIO_CHECK_THROW_WHAT(
         ConvertToString((OCIO::ExposureContrastOpData::Style)-1),
         OCIO::Exception, "Unknown exposure contrast style");
 }
 
-OIIO_ADD_TEST(ExposureContrastOpData, accessors)
+OCIO_ADD_TEST(ExposureContrastOpData, accessors)
 {
     OCIO::ExposureContrastOpData ec0;
-    OIIO_CHECK_EQUAL(ec0.getType(), OCIO::OpData::ExposureContrastType);
-    OIIO_CHECK_EQUAL(ec0.getStyle(), OCIO::ExposureContrastOpData::STYLE_LINEAR);
+    OCIO_CHECK_EQUAL(ec0.getType(), OCIO::OpData::ExposureContrastType);
+    OCIO_CHECK_EQUAL(ec0.getStyle(), OCIO::ExposureContrastOpData::STYLE_LINEAR);
 
-    OIIO_CHECK_EQUAL(ec0.getExposure(), 0.0);
-    OIIO_CHECK_EQUAL(ec0.getContrast(), 1.0);
-    OIIO_CHECK_EQUAL(ec0.getGamma(), 1.0);
-    OIIO_CHECK_EQUAL(ec0.getPivot(), 0.18);
-    OIIO_CHECK_EQUAL(ec0.getLogExposureStep(), 0.088);
-    OIIO_CHECK_EQUAL(ec0.getLogMidGray(), 0.435);
+    OCIO_CHECK_EQUAL(ec0.getExposure(), 0.0);
+    OCIO_CHECK_EQUAL(ec0.getContrast(), 1.0);
+    OCIO_CHECK_EQUAL(ec0.getGamma(), 1.0);
+    OCIO_CHECK_EQUAL(ec0.getPivot(), 0.18);
+    OCIO_CHECK_EQUAL(ec0.getLogExposureStep(), 0.088);
+    OCIO_CHECK_EQUAL(ec0.getLogMidGray(), 0.435);
 
-    OIIO_CHECK_ASSERT(ec0.isIdentity());
-    OIIO_CHECK_ASSERT(ec0.isNoOp());
-    OIIO_CHECK_ASSERT(!ec0.hasChannelCrosstalk());
-    OIIO_CHECK_NO_THROW(ec0.validate());
+    OCIO_CHECK_ASSERT(ec0.isIdentity());
+    OCIO_CHECK_ASSERT(ec0.isNoOp());
+    OCIO_CHECK_ASSERT(!ec0.hasChannelCrosstalk());
+    OCIO_CHECK_NO_THROW(ec0.validate());
     ec0.finalize();
     const std::string cacheID(ec0.getCacheID());
     const std::string expected("linear E: 0 C: 1 G: 1 P: 0.18 LES: 0.088 LMG: 0.435");
-    OIIO_CHECK_ASSERT(OCIO::Platform::Strcasecmp(cacheID.c_str(),
+    OCIO_CHECK_ASSERT(OCIO::Platform::Strcasecmp(cacheID.c_str(),
                                                  expected.c_str()) == 0);
 
     ec0.setExposure(0.1);
-    OIIO_CHECK_ASSERT(!ec0.isIdentity());
-    OIIO_CHECK_ASSERT(!ec0.isNoOp());
-    OIIO_CHECK_ASSERT(!ec0.hasChannelCrosstalk());
+    OCIO_CHECK_ASSERT(!ec0.isIdentity());
+    OCIO_CHECK_ASSERT(!ec0.isNoOp());
+    OCIO_CHECK_ASSERT(!ec0.hasChannelCrosstalk());
     ec0.finalize();
-    OIIO_CHECK_ASSERT(cacheID != std::string(ec0.getCacheID()));
+    OCIO_CHECK_ASSERT(cacheID != std::string(ec0.getCacheID()));
 
     OCIO::ExposureContrastOpData ec(OCIO::BIT_DEPTH_UINT8,
                                     OCIO::BIT_DEPTH_F16,
                                     OCIO::ExposureContrastOpData::STYLE_VIDEO);
-    OIIO_CHECK_EQUAL(ec.getType(), OCIO::OpData::ExposureContrastType);
-    OIIO_CHECK_EQUAL(ec.getStyle(), OCIO::ExposureContrastOpData::STYLE_VIDEO);
+    OCIO_CHECK_EQUAL(ec.getType(), OCIO::OpData::ExposureContrastType);
+    OCIO_CHECK_EQUAL(ec.getStyle(), OCIO::ExposureContrastOpData::STYLE_VIDEO);
 
-    OIIO_CHECK_EQUAL(ec.getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(ec.getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
+    OCIO_CHECK_EQUAL(ec.getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(ec.getOutputBitDepth(), OCIO::BIT_DEPTH_F16);
 
-    OIIO_CHECK_EQUAL(ec.getExposure(), 0.0);
-    OIIO_CHECK_EQUAL(ec.getContrast(), 1.0);
-    OIIO_CHECK_EQUAL(ec.getGamma(), 1.0);
-    OIIO_CHECK_EQUAL(ec.getPivot(), 0.18);
-    OIIO_CHECK_EQUAL(ec.getLogExposureStep(), 0.088);
-    OIIO_CHECK_EQUAL(ec.getLogMidGray(), 0.435);
+    OCIO_CHECK_EQUAL(ec.getExposure(), 0.0);
+    OCIO_CHECK_EQUAL(ec.getContrast(), 1.0);
+    OCIO_CHECK_EQUAL(ec.getGamma(), 1.0);
+    OCIO_CHECK_EQUAL(ec.getPivot(), 0.18);
+    OCIO_CHECK_EQUAL(ec.getLogExposureStep(), 0.088);
+    OCIO_CHECK_EQUAL(ec.getLogMidGray(), 0.435);
 
-    OIIO_CHECK_ASSERT(ec.isNoOp());
+    OCIO_CHECK_ASSERT(ec.isNoOp());
 
-    OIIO_CHECK_ASSERT(!ec.getExposureProperty()->isDynamic());
-    OIIO_CHECK_ASSERT(!ec.getContrastProperty()->isDynamic());
-    OIIO_CHECK_ASSERT(!ec.getGammaProperty()->isDynamic());
-    OIIO_CHECK_ASSERT(!ec.isDynamic());
+    OCIO_CHECK_ASSERT(!ec.getExposureProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(!ec.getContrastProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(!ec.getGammaProperty()->isDynamic());
+    OCIO_CHECK_ASSERT(!ec.isDynamic());
 
     // Never treated as NoOp when dynamic.
     ec.getExposureProperty()->makeDynamic();
-    OIIO_CHECK_ASSERT(!ec.isNoOp());
-    OIIO_CHECK_ASSERT(ec.isDynamic());
-    OIIO_CHECK_ASSERT(ec.hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
+    OCIO_CHECK_ASSERT(!ec.isNoOp());
+    OCIO_CHECK_ASSERT(ec.isDynamic());
+    OCIO_CHECK_ASSERT(ec.hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
 
     ec.setExposure(0.1);
     ec.setContrast(0.8);
@@ -516,44 +517,44 @@ OIIO_ADD_TEST(ExposureContrastOpData, accessors)
     ec.setLogExposureStep(0.07);
     ec.setLogMidGray(0.5);
 
-    OIIO_CHECK_EQUAL(ec.getExposure(), 0.1);
-    OIIO_CHECK_EQUAL(ec.getContrast(), 0.8);
-    OIIO_CHECK_EQUAL(ec.getGamma(), 1.1);
-    OIIO_CHECK_EQUAL(ec.getPivot(), 0.2);
-    OIIO_CHECK_EQUAL(ec.getLogExposureStep(), 0.07);
-    OIIO_CHECK_EQUAL(ec.getLogMidGray(), 0.5);
+    OCIO_CHECK_EQUAL(ec.getExposure(), 0.1);
+    OCIO_CHECK_EQUAL(ec.getContrast(), 0.8);
+    OCIO_CHECK_EQUAL(ec.getGamma(), 1.1);
+    OCIO_CHECK_EQUAL(ec.getPivot(), 0.2);
+    OCIO_CHECK_EQUAL(ec.getLogExposureStep(), 0.07);
+    OCIO_CHECK_EQUAL(ec.getLogMidGray(), 0.5);
 
     OCIO::DynamicPropertyRcPtr dpExp;
     OCIO::DynamicPropertyRcPtr dpContrast;
     OCIO::DynamicPropertyRcPtr dpGamma;
 
     // Property must be set as dynamic to accept a dynamic value.
-    OIIO_CHECK_ASSERT(!ec.hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST));
-    OIIO_CHECK_ASSERT(!ec.hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_GAMMA));
-    OIIO_CHECK_THROW_WHAT(ec.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST),
+    OCIO_CHECK_ASSERT(!ec.hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST));
+    OCIO_CHECK_ASSERT(!ec.hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_GAMMA));
+    OCIO_CHECK_THROW_WHAT(ec.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST),
                           OCIO::Exception,
                           "not dynamic")
 
-    OIIO_CHECK_NO_THROW(dpExp = ec.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
-    OIIO_CHECK_EQUAL(dpExp->getDoubleValue(), 0.1);
-    OIIO_CHECK_ASSERT(!ec.hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST));
-    OIIO_CHECK_ASSERT(!ec.hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_GAMMA));
+    OCIO_CHECK_NO_THROW(dpExp = ec.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
+    OCIO_CHECK_EQUAL(dpExp->getDoubleValue(), 0.1);
+    OCIO_CHECK_ASSERT(!ec.hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST));
+    OCIO_CHECK_ASSERT(!ec.hasDynamicProperty(OCIO::DYNAMIC_PROPERTY_GAMMA));
     dpExp->setValue(1.5);
-    OIIO_CHECK_EQUAL(ec.getExposure(), 1.5);
+    OCIO_CHECK_EQUAL(ec.getExposure(), 1.5);
     dpExp->setValue(0.7);
-    OIIO_CHECK_EQUAL(ec.getExposure(), 0.7);
+    OCIO_CHECK_EQUAL(ec.getExposure(), 0.7);
 
     ec.getContrastProperty()->makeDynamic();
     ec.getGammaProperty()->makeDynamic();
-    OIIO_CHECK_NO_THROW(dpContrast = ec.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST));
-    OIIO_CHECK_NO_THROW(dpGamma = ec.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_GAMMA));
+    OCIO_CHECK_NO_THROW(dpContrast = ec.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST));
+    OCIO_CHECK_NO_THROW(dpGamma = ec.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_GAMMA));
     dpContrast->setValue(1.42);
     dpGamma->setValue(0.88);
-    OIIO_CHECK_EQUAL(ec.getContrast(), 1.42);
-    OIIO_CHECK_EQUAL(ec.getGamma(), 0.88);
+    OCIO_CHECK_EQUAL(ec.getContrast(), 1.42);
+    OCIO_CHECK_EQUAL(ec.getGamma(), 0.88);
 }
 
-OIIO_ADD_TEST(ExposureContrastOpData, clone)
+OCIO_ADD_TEST(ExposureContrastOpData, clone)
 {
     OCIO::ExposureContrastOpData ec;
     ec.setExposure(-1.4);
@@ -564,34 +565,34 @@ OIIO_ADD_TEST(ExposureContrastOpData, clone)
     ec.getExposureProperty()->makeDynamic();
     OCIO::DynamicPropertyRcPtr dpExp;
 
-    OIIO_CHECK_NO_THROW(dpExp = ec.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
-    OIIO_CHECK_EQUAL(dpExp->getDoubleValue(), -1.4);
+    OCIO_CHECK_NO_THROW(dpExp = ec.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
+    OCIO_CHECK_EQUAL(dpExp->getDoubleValue(), -1.4);
     dpExp->setValue(1.5);
     OCIO::ExposureContrastOpDataRcPtr ecCloned = ec.clone();
-    OIIO_REQUIRE_ASSERT(ecCloned);
+    OCIO_REQUIRE_ASSERT(ecCloned);
 
-    OIIO_CHECK_EQUAL(ec.getExposure(), ecCloned->getExposure());
-    OIIO_CHECK_EQUAL(ec.getContrast(), ecCloned->getContrast());
-    OIIO_CHECK_EQUAL(ec.getGamma(), ecCloned->getGamma());
-    OIIO_CHECK_EQUAL(ec.getPivot(), ecCloned->getPivot());
-    OIIO_CHECK_EQUAL(ec.getLogExposureStep(), ecCloned->getLogExposureStep());
-    OIIO_CHECK_EQUAL(ec.getLogMidGray(), ecCloned->getLogMidGray());
+    OCIO_CHECK_EQUAL(ec.getExposure(), ecCloned->getExposure());
+    OCIO_CHECK_EQUAL(ec.getContrast(), ecCloned->getContrast());
+    OCIO_CHECK_EQUAL(ec.getGamma(), ecCloned->getGamma());
+    OCIO_CHECK_EQUAL(ec.getPivot(), ecCloned->getPivot());
+    OCIO_CHECK_EQUAL(ec.getLogExposureStep(), ecCloned->getLogExposureStep());
+    OCIO_CHECK_EQUAL(ec.getLogMidGray(), ecCloned->getLogMidGray());
 
-    OIIO_CHECK_EQUAL(ec.getExposureProperty()->isDynamic(),
+    OCIO_CHECK_EQUAL(ec.getExposureProperty()->isDynamic(),
                      ecCloned->getExposureProperty()->isDynamic());
-    OIIO_CHECK_EQUAL(ec.getContrastProperty()->isDynamic(),
+    OCIO_CHECK_EQUAL(ec.getContrastProperty()->isDynamic(),
                      ecCloned->getContrastProperty()->isDynamic());
-    OIIO_CHECK_EQUAL(ec.getGammaProperty()->isDynamic(),
+    OCIO_CHECK_EQUAL(ec.getGammaProperty()->isDynamic(),
                      ecCloned->getGammaProperty()->isDynamic());
 
     // Clone makes a copy of the dynamic property rather than sharing the original.
     dpExp->setValue(0.21);
-    OIIO_CHECK_NE(ec.getExposure(), ecCloned->getExposure());
-    OIIO_CHECK_EQUAL(ec.getExposure(), 0.21);
-    OIIO_CHECK_EQUAL(ecCloned->getExposure(), 1.5);
+    OCIO_CHECK_NE(ec.getExposure(), ecCloned->getExposure());
+    OCIO_CHECK_EQUAL(ec.getExposure(), 0.21);
+    OCIO_CHECK_EQUAL(ecCloned->getExposure(), 1.5);
 }
 
-OIIO_ADD_TEST(ExposureContrastOpData, inverse)
+OCIO_ADD_TEST(ExposureContrastOpData, inverse)
 {
     OCIO::ExposureContrastOpData ec(OCIO::BIT_DEPTH_UINT8,
                                     OCIO::BIT_DEPTH_F16,
@@ -604,87 +605,87 @@ OIIO_ADD_TEST(ExposureContrastOpData, inverse)
     ec.getExposureProperty()->makeDynamic();
     OCIO::DynamicPropertyRcPtr dpExp;
 
-    OIIO_CHECK_NO_THROW(dpExp = ec.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
+    OCIO_CHECK_NO_THROW(dpExp = ec.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
     dpExp->setValue(1.5);
     OCIO::ExposureContrastOpDataRcPtr ecInv = ec.inverse();
-    OIIO_REQUIRE_ASSERT(ecInv);
+    OCIO_REQUIRE_ASSERT(ecInv);
 
     OCIO::ConstExposureContrastOpDataRcPtr ecInvConst = ecInv;
-    OIIO_CHECK_ASSERT(ec.isInverse(ecInvConst));
+    OCIO_CHECK_ASSERT(ec.isInverse(ecInvConst));
 
-    OIIO_CHECK_EQUAL(ecInv->getOutputBitDepth(), ec.getInputBitDepth());
-    OIIO_CHECK_EQUAL(ecInv->getInputBitDepth(), ec.getOutputBitDepth());
+    OCIO_CHECK_EQUAL(ecInv->getOutputBitDepth(), ec.getInputBitDepth());
+    OCIO_CHECK_EQUAL(ecInv->getInputBitDepth(), ec.getOutputBitDepth());
 
-    OIIO_CHECK_EQUAL(ecInv->getStyle(),
+    OCIO_CHECK_EQUAL(ecInv->getStyle(),
                      OCIO::ExposureContrastOpData::STYLE_VIDEO_REV);
 
-    OIIO_CHECK_EQUAL(ec.getExposure(), ecInv->getExposure());
-    OIIO_CHECK_EQUAL(ec.getContrast(), ecInv->getContrast());
-    OIIO_CHECK_EQUAL(ec.getGamma(), ecInv->getGamma());
-    OIIO_CHECK_EQUAL(ec.getPivot(), ecInv->getPivot());
-    OIIO_CHECK_EQUAL(ec.getLogExposureStep(), ecInv->getLogExposureStep());
-    OIIO_CHECK_EQUAL(ec.getLogMidGray(), ecInv->getLogMidGray());
+    OCIO_CHECK_EQUAL(ec.getExposure(), ecInv->getExposure());
+    OCIO_CHECK_EQUAL(ec.getContrast(), ecInv->getContrast());
+    OCIO_CHECK_EQUAL(ec.getGamma(), ecInv->getGamma());
+    OCIO_CHECK_EQUAL(ec.getPivot(), ecInv->getPivot());
+    OCIO_CHECK_EQUAL(ec.getLogExposureStep(), ecInv->getLogExposureStep());
+    OCIO_CHECK_EQUAL(ec.getLogMidGray(), ecInv->getLogMidGray());
 
-    OIIO_CHECK_EQUAL(ec.getExposureProperty()->isDynamic(),
+    OCIO_CHECK_EQUAL(ec.getExposureProperty()->isDynamic(),
                      ecInv->getExposureProperty()->isDynamic());
-    OIIO_CHECK_EQUAL(ec.getContrastProperty()->isDynamic(),
+    OCIO_CHECK_EQUAL(ec.getContrastProperty()->isDynamic(),
                      ecInv->getContrastProperty()->isDynamic());
-    OIIO_CHECK_EQUAL(ec.getGammaProperty()->isDynamic(),
+    OCIO_CHECK_EQUAL(ec.getGammaProperty()->isDynamic(),
                      ecInv->getGammaProperty()->isDynamic());
 
     // Inverse makes a copy of the dynamic property rather than sharing the original.
     dpExp->setValue(0.21);
-    OIIO_CHECK_NE(ec.getExposure(), ecInv->getExposure());
-    OIIO_CHECK_EQUAL(ec.getExposure(), 0.21);
-    OIIO_CHECK_EQUAL(ecInv->getExposure(), 1.5);
+    OCIO_CHECK_NE(ec.getExposure(), ecInv->getExposure());
+    OCIO_CHECK_EQUAL(ec.getExposure(), 0.21);
+    OCIO_CHECK_EQUAL(ecInv->getExposure(), 1.5);
     
     // Exposure is dynamic in both, so value does not matter.
-    OIIO_CHECK_ASSERT(ec.isInverse(ecInvConst));
+    OCIO_CHECK_ASSERT(ec.isInverse(ecInvConst));
 
     ecInv->getContrastProperty()->makeDynamic();
 
     // Contrast is dynamic in one and not in the other.
-    OIIO_CHECK_ASSERT(!ec.isInverse(ecInvConst));
+    OCIO_CHECK_ASSERT(!ec.isInverse(ecInvConst));
 
     ec.getContrastProperty()->makeDynamic();
-    OIIO_CHECK_ASSERT(ec.isInverse(ecInvConst));
+    OCIO_CHECK_ASSERT(ec.isInverse(ecInvConst));
 
     // Gamma values are now different.
     ec.setGamma(1.2);
-    OIIO_CHECK_ASSERT(!ec.isInverse(ecInvConst));
+    OCIO_CHECK_ASSERT(!ec.isInverse(ecInvConst));
 }
 
-OIIO_ADD_TEST(ExposureContrastOpData, equality)
+OCIO_ADD_TEST(ExposureContrastOpData, equality)
 {
     OCIO::ExposureContrastOpData ec0;
     OCIO::ExposureContrastOpData ec1;
-    OIIO_CHECK_ASSERT(ec0 == ec1);
+    OCIO_CHECK_ASSERT(ec0 == ec1);
 
     // Change style.
     ec0.setStyle(OCIO::ExposureContrastOpData::STYLE_VIDEO);
-    OIIO_CHECK_ASSERT(!(ec0 == ec1));
+    OCIO_CHECK_ASSERT(!(ec0 == ec1));
     ec1.setStyle(OCIO::ExposureContrastOpData::STYLE_VIDEO);
-    OIIO_CHECK_ASSERT(ec0 == ec1);
+    OCIO_CHECK_ASSERT(ec0 == ec1);
 
     // Change dynamic.
     ec0.getExposureProperty()->makeDynamic();
-    OIIO_CHECK_ASSERT(!(ec0 == ec1));
+    OCIO_CHECK_ASSERT(!(ec0 == ec1));
     ec1.getExposureProperty()->makeDynamic();
-    OIIO_CHECK_ASSERT(ec0 == ec1);
+    OCIO_CHECK_ASSERT(ec0 == ec1);
 
     // Change value of enabled dynamic property.
     ec0.setExposure(0.5);
-    OIIO_CHECK_ASSERT(ec0 == ec1);
+    OCIO_CHECK_ASSERT(ec0 == ec1);
     
     // Change value of dynamic property not enabled.
     ec1.setContrast(0.5);
-    OIIO_CHECK_ASSERT(!(ec0 == ec1));
+    OCIO_CHECK_ASSERT(!(ec0 == ec1));
     
     ec0.setContrast(0.5);
-    OIIO_CHECK_ASSERT(ec0 == ec1);
+    OCIO_CHECK_ASSERT(ec0 == ec1);
 }
 
-OIIO_ADD_TEST(ExposureContrastOpData, replace_dynamic_property)
+OCIO_ADD_TEST(ExposureContrastOpData, replace_dynamic_property)
 {
     OCIO::ExposureContrastOpData ec0;
     OCIO::ExposureContrastOpData ec1;
@@ -699,23 +700,23 @@ OIIO_ADD_TEST(ExposureContrastOpData, replace_dynamic_property)
     auto dpe1 = ec1.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE);
     
     // These are 2 different pointers.
-    OIIO_CHECK_NE(dpe0.get(), dpe1.get());
+    OCIO_CHECK_NE(dpe0.get(), dpe1.get());
 
     ec1.replaceDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE, ec0.getExposureProperty());
     dpe1 = ec1.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE);
 
     // Now, this is the same pointer.
-    OIIO_CHECK_EQUAL(dpe0.get(), dpe1.get());
+    OCIO_CHECK_EQUAL(dpe0.get(), dpe1.get());
 
     ec0.getContrastProperty()->makeDynamic();
     // Contrast is not enabled in ec1.
-    OIIO_CHECK_THROW(ec1.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST), OCIO::Exception);
+    OCIO_CHECK_THROW(ec1.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST), OCIO::Exception);
 
     // The property is not replaced if dynamic is not enabled.
-    OIIO_CHECK_THROW(ec1.replaceDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST,
+    OCIO_CHECK_THROW(ec1.replaceDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST,
                                                 ec0.getContrastProperty()),
                      OCIO::Exception);
-    OIIO_CHECK_THROW(ec1.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST), OCIO::Exception);
+    OCIO_CHECK_THROW(ec1.getDynamicProperty(OCIO::DYNAMIC_PROPERTY_CONTRAST), OCIO::Exception);
 }
 
 #endif

--- a/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOps.cpp
+++ b/src/OpenColorIO/ops/exposurecontrast/ExposureContrastOps.cpp
@@ -230,9 +230,9 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(ExposureContrastOp, create)
+OCIO_ADD_TEST(ExposureContrastOp, create)
 {
     OCIO::TransformDirection direction = OCIO::TRANSFORM_DIR_FORWARD;
     OCIO::ExposureContrastOpDataRcPtr data =
@@ -241,21 +241,21 @@ OIIO_ADD_TEST(ExposureContrastOp, create)
 
     // Make it dynamic so that it is not a no op.
     data->getExposureProperty()->makeDynamic();
-    OIIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_REQUIRE_ASSERT(ops[0]);
-    OIIO_CHECK_EQUAL(ops[0]->getInfo(), "<ExposureContrastOp>");
+    OCIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_ASSERT(ops[0]);
+    OCIO_CHECK_EQUAL(ops[0]->getInfo(), "<ExposureContrastOp>");
 
     data = data->clone();
     data->getContrastProperty()->makeDynamic();
-    OIIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_REQUIRE_ASSERT(ops[1]);
+    OCIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_ASSERT(ops[1]);
     OCIO::ConstOpRcPtr op1 = ops[1];
-    OIIO_CHECK_ASSERT(ops[0]->isSameType(op1));
+    OCIO_CHECK_ASSERT(ops[0]->isSameType(op1));
 }
 
-OIIO_ADD_TEST(ExposureContrastOp, inverse)
+OCIO_ADD_TEST(ExposureContrastOp, inverse)
 {
     OCIO::TransformDirection direction = OCIO::TRANSFORM_DIR_FORWARD;
     OCIO::ExposureContrastOpDataRcPtr data =
@@ -265,60 +265,60 @@ OIIO_ADD_TEST(ExposureContrastOp, inverse)
     data->setPivot(0.5);
 
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
-    OIIO_REQUIRE_ASSERT(ops[0]);
+    OCIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_ASSERT(ops[0]);
 
     data = data->clone();
     direction = OCIO::TRANSFORM_DIR_INVERSE;
-    OIIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
-    OIIO_REQUIRE_ASSERT(ops[1]);
+    OCIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_ASSERT(ops[1]);
 
     OCIO::ConstOpRcPtr op0 = ops[0];
     OCIO::ConstOpRcPtr op1 = ops[1];
-    OIIO_CHECK_ASSERT(op0->isInverse(op1));
-    OIIO_CHECK_ASSERT(op1->isInverse(op0));
+    OCIO_CHECK_ASSERT(op0->isInverse(op1));
+    OCIO_CHECK_ASSERT(op1->isInverse(op0));
 
     // Create op2 similar to op1 with different exposure.
     data = data->clone();
     data->setExposure(1.3);
-    OIIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
-    OIIO_REQUIRE_EQUAL(ops.size(), 3);
-    OIIO_REQUIRE_ASSERT(ops[2]);
+    OCIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
+    OCIO_REQUIRE_EQUAL(ops.size(), 3);
+    OCIO_REQUIRE_ASSERT(ops[2]);
 
     OCIO::ConstOpRcPtr op2 = ops[2];
     // As exposure from E/C is not dynamic and exposure is different,
     // op1 and op2 are different.
-    OIIO_CHECK_ASSERT(op1 != op2);
-    OIIO_CHECK_ASSERT(!op0->isInverse(op2));
+    OCIO_CHECK_ASSERT(op1 != op2);
+    OCIO_CHECK_ASSERT(!op0->isInverse(op2));
 
     // With dynamic property.
     data = data->clone();
     data->getExposureProperty()->makeDynamic();
     OCIO::DynamicPropertyRcPtr dp3 = data->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE);
-    OIIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
-    OIIO_REQUIRE_EQUAL(ops.size(), 4);
-    OIIO_REQUIRE_ASSERT(ops[3]);
+    OCIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
+    OCIO_REQUIRE_EQUAL(ops.size(), 4);
+    OCIO_REQUIRE_ASSERT(ops[3]);
     OCIO::ConstOpRcPtr op3 = ops[3];
 
     data = data->clone();
     OCIO::DynamicPropertyRcPtr dp4 = data->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE);
 
     direction = OCIO::TRANSFORM_DIR_FORWARD;
-    OIIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
-    OIIO_REQUIRE_EQUAL(ops.size(), 5);
-    OIIO_REQUIRE_ASSERT(ops[4]);
+    OCIO_CHECK_NO_THROW(OCIO::CreateExposureContrastOp(ops, data, direction));
+    OCIO_REQUIRE_EQUAL(ops.size(), 5);
+    OCIO_REQUIRE_ASSERT(ops[4]);
 
     // Exposure dynamic, same value, opposite direction.
-    OIIO_CHECK_ASSERT(ops[4]->isInverse(op3));
-    OIIO_CHECK_ASSERT(!ops[4]->isInverse(op1));
-    OIIO_CHECK_ASSERT(!ops[4]->isInverse(op0));
+    OCIO_CHECK_ASSERT(ops[4]->isInverse(op3));
+    OCIO_CHECK_ASSERT(!ops[4]->isInverse(op1));
+    OCIO_CHECK_ASSERT(!ops[4]->isInverse(op0));
 
     // Value is not taken into account when dynamic property is enabled.
     dp4->setValue(-1.);
-    OIIO_CHECK_ASSERT(dp3->getDoubleValue() != dp4->getDoubleValue());
-    OIIO_CHECK_ASSERT(ops[4]->isInverse(op3));
+    OCIO_CHECK_ASSERT(dp3->getDoubleValue() != dp4->getDoubleValue());
+    OCIO_CHECK_ASSERT(ops[4]->isInverse(op3));
 }
 
 #endif

--- a/src/OpenColorIO/ops/reference/ReferenceOpData.cpp
+++ b/src/OpenColorIO/ops/reference/ReferenceOpData.cpp
@@ -121,25 +121,25 @@ namespace OCIO = OCIO_NAMESPACE;
 #include "ops/Matrix/MatrixOpData.h"
 #include "ops/NoOp/NoOps.h"
 #include "ops/Range/RangeOpData.h"
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
-OIIO_ADD_TEST(Reference, accessors)
+OCIO_ADD_TEST(Reference, accessors)
 {
     OCIO::ReferenceOpData r;
 
-    OIIO_CHECK_EQUAL(r.getReferenceStyle(), OCIO::REF_PATH);
-    OIIO_CHECK_EQUAL(r.getPath(), "");
+    OCIO_CHECK_EQUAL(r.getReferenceStyle(), OCIO::REF_PATH);
+    OCIO_CHECK_EQUAL(r.getPath(), "");
 
     const std::string alias{ "Alias" };
     r.setAlias(alias);
-    OIIO_CHECK_EQUAL(r.getReferenceStyle(), OCIO::REF_ALIAS);
-    OIIO_CHECK_EQUAL(r.getAlias(), alias);
+    OCIO_CHECK_EQUAL(r.getReferenceStyle(), OCIO::REF_ALIAS);
+    OCIO_CHECK_EQUAL(r.getAlias(), alias);
 
     const std::string file{ "TestPath.txt" };
     r.setPath(file);
-    OIIO_CHECK_EQUAL(r.getReferenceStyle(), OCIO::REF_PATH);
-    OIIO_CHECK_EQUAL(r.getPath(), file);
+    OCIO_CHECK_EQUAL(r.getReferenceStyle(), OCIO::REF_PATH);
+    OCIO_CHECK_EQUAL(r.getPath(), file);
 }
 
 // Use OCIO public interface to load a file transform.
@@ -163,62 +163,62 @@ OCIO::ConstProcessorRcPtr GetTransformFileProcessor(const std::string & fileName
     return pConfig->getProcessor(pFileTransform);
 }
 
-OIIO_ADD_TEST(Reference, load_path_resolve_failing)
+OCIO_ADD_TEST(Reference, load_path_resolve_failing)
 {
     std::string fileName("reference_path_missing_file.ctf");
-    OIIO_CHECK_THROW_WHAT(GetTransformFileProcessor(fileName), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(GetTransformFileProcessor(fileName), OCIO::Exception,
                           "could not be located");
 }
 
-OIIO_ADD_TEST(Reference, load_multiple_resolve)
+OCIO_ADD_TEST(Reference, load_multiple_resolve)
 {
     std::string fileName("references_some_inverted.ctf");
     OCIO::ConstProcessorRcPtr processor;
-    OIIO_CHECK_NO_THROW(processor = GetTransformFileProcessor(fileName));
-    OIIO_REQUIRE_ASSERT(processor);
+    OCIO_CHECK_NO_THROW(processor = GetTransformFileProcessor(fileName));
+    OCIO_REQUIRE_ASSERT(processor);
 }
 
-OIIO_ADD_TEST(Reference, load_same_twice_resolve)
+OCIO_ADD_TEST(Reference, load_same_twice_resolve)
 {
     std::string fileName("references_same_twice.ctf");
     OCIO::ConstProcessorRcPtr processor;
-    OIIO_CHECK_NO_THROW(processor = GetTransformFileProcessor(fileName));
-    OIIO_REQUIRE_ASSERT(processor);
+    OCIO_CHECK_NO_THROW(processor = GetTransformFileProcessor(fileName));
+    OCIO_REQUIRE_ASSERT(processor);
 }
 
-OIIO_ADD_TEST(Reference, load_nested_resolve)
+OCIO_ADD_TEST(Reference, load_nested_resolve)
 {
     std::string fileName("reference_nested.ctf");
     OCIO::ConstProcessorRcPtr processor;
-    OIIO_CHECK_NO_THROW(processor = GetTransformFileProcessor(fileName));
-    OIIO_REQUIRE_ASSERT(processor);
+    OCIO_CHECK_NO_THROW(processor = GetTransformFileProcessor(fileName));
+    OCIO_REQUIRE_ASSERT(processor);
 }
 
-OIIO_ADD_TEST(Reference, load_cycle_itself_resolve_failing)
+OCIO_ADD_TEST(Reference, load_cycle_itself_resolve_failing)
 {
     std::string fileName("reference_cycle_itself.ctf");
-    OIIO_CHECK_THROW_WHAT(GetTransformFileProcessor(fileName), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(GetTransformFileProcessor(fileName), OCIO::Exception,
                           "is creating a recursion");
 }
 
-OIIO_ADD_TEST(Reference, load_cycle_2_resolve_failing)
+OCIO_ADD_TEST(Reference, load_cycle_2_resolve_failing)
 {
     std::string fileName("reference_cycle_2levels.ctf");
-    OIIO_CHECK_THROW_WHAT(GetTransformFileProcessor(fileName), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(GetTransformFileProcessor(fileName), OCIO::Exception,
                           "is creating a recursion");
 }
 
-OIIO_ADD_TEST(Reference, load_cycle_3_resolve_failing)
+OCIO_ADD_TEST(Reference, load_cycle_3_resolve_failing)
 {
     std::string fileName("reference_cycle_3levels.ctf");
-    OIIO_CHECK_THROW_WHAT(GetTransformFileProcessor(fileName), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(GetTransformFileProcessor(fileName), OCIO::Exception,
                           "is creating a recursion");
 }
 
-OIIO_ADD_TEST(Reference, load_cycle_rel_resolve_failing)
+OCIO_ADD_TEST(Reference, load_cycle_rel_resolve_failing)
 {
     std::string fileName("reference_cycle_path_not_equal.ctf");
-    OIIO_CHECK_THROW_WHAT(GetTransformFileProcessor(fileName), OCIO::Exception,
+    OCIO_CHECK_THROW_WHAT(GetTransformFileProcessor(fileName), OCIO::Exception,
                           "is creating a recursion");
 }
 
@@ -242,123 +242,123 @@ bool GetFilePath(std::string & path, OCIO::ConstOpRcPtr & op)
 // the referenced files are loaded correctly.
 //
 
-OIIO_ADD_TEST(Reference, load_one_reference)
+OCIO_ADD_TEST(Reference, load_one_reference)
 {
     OCIO::ContextRcPtr context = OCIO::Context::Create();
     context->addSearchPath(OCIO::getTestFilesDir());
     std::string fileName("reference_one_matrix.ctf");
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(BuildOpsTest(ops, fileName, context, OCIO::TRANSFORM_DIR_FORWARD));
+    OCIO_CHECK_NO_THROW(BuildOpsTest(ops, fileName, context, OCIO::TRANSFORM_DIR_FORWARD));
 
     // Ops contains [FileNoOp, FileNoOp, Matrix].
-    OIIO_REQUIRE_EQUAL(ops.size(), 3);
+    OCIO_REQUIRE_EQUAL(ops.size(), 3);
 
-    OIIO_CHECK_NO_THROW(ops.validate());
+    OCIO_CHECK_NO_THROW(ops.validate());
 
     OCIO::ConstOpRcPtr op = ops[2];
     auto matrixData = OCIO::DynamicPtrCast<const OCIO::MatrixOpData>(op->data());
-    OIIO_REQUIRE_ASSERT(matrixData);
-    OIIO_CHECK_EQUAL(op->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
-    OIIO_CHECK_EQUAL(op->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_REQUIRE_ASSERT(matrixData);
+    OCIO_CHECK_EQUAL(op->getInputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(op->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 }
 
-OIIO_ADD_TEST(Reference, load_multiple_resolve_internal)
+OCIO_ADD_TEST(Reference, load_multiple_resolve_internal)
 {
     OCIO::ContextRcPtr context = OCIO::Context::Create();
     context->addSearchPath(OCIO::getTestFilesDir());
     std::string fileName("references_some_inverted.ctf");
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(BuildOpsTest(ops, fileName, context, OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 9);
-    OIIO_REQUIRE_ASSERT(ops[0]);
+    OCIO_CHECK_NO_THROW(BuildOpsTest(ops, fileName, context, OCIO::TRANSFORM_DIR_FORWARD));
+    OCIO_REQUIRE_EQUAL(ops.size(), 9);
+    OCIO_REQUIRE_ASSERT(ops[0]);
     std::string path;
     OCIO::ConstOpRcPtr op = ops[0];
-    OIIO_REQUIRE_ASSERT(GetFilePath(path, op));
-    OIIO_CHECK_NE(path.find(fileName), std::string::npos);
+    OCIO_REQUIRE_ASSERT(GetFilePath(path, op));
+    OCIO_CHECK_NE(path.find(fileName), std::string::npos);
 
-    OIIO_REQUIRE_ASSERT(ops[1]);
+    OCIO_REQUIRE_ASSERT(ops[1]);
     op = ops[1];
-    OIIO_REQUIRE_ASSERT(GetFilePath(path, op));
-    OIIO_CHECK_NE(path.find("matrix_example.clf"), std::string::npos);
+    OCIO_REQUIRE_ASSERT(GetFilePath(path, op));
+    OCIO_CHECK_NE(path.find("matrix_example.clf"), std::string::npos);
 
-    OIIO_REQUIRE_ASSERT(ops[2]);
+    OCIO_REQUIRE_ASSERT(ops[2]);
     op = ops[2];
     auto matrixData = OCIO::DynamicPtrCast<const OCIO::MatrixOpData>(op->data());
-    OIIO_REQUIRE_ASSERT(matrixData);
-    OIIO_CHECK_EQUAL(op->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_REQUIRE_ASSERT(matrixData);
+    OCIO_CHECK_EQUAL(op->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
     // (OutDepth was 32f in referenced file.)
-    OIIO_CHECK_EQUAL(op->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(op->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT12);
 
-    OIIO_REQUIRE_ASSERT(ops[3]);
+    OCIO_REQUIRE_ASSERT(ops[3]);
     op = ops[3];
-    OIIO_REQUIRE_ASSERT(GetFilePath(path, op));
-    OIIO_CHECK_NE(path.find("xyz_to_rgb.clf"), std::string::npos);
+    OCIO_REQUIRE_ASSERT(GetFilePath(path, op));
+    OCIO_CHECK_NE(path.find("xyz_to_rgb.clf"), std::string::npos);
 
-    OIIO_REQUIRE_ASSERT(ops[4]);
+    OCIO_REQUIRE_ASSERT(ops[4]);
     op = ops[4];
     auto lutData = OCIO::DynamicPtrCast<const OCIO::Lut1DOpData>(op->data());
-    OIIO_REQUIRE_ASSERT(lutData);
-    OIIO_CHECK_EQUAL(lutData->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_REQUIRE_ASSERT(lutData);
+    OCIO_CHECK_EQUAL(lutData->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
     // (InDepth was 32f in original.)
-    OIIO_CHECK_EQUAL(op->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
-    OIIO_CHECK_EQUAL(op->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(op->getInputBitDepth(), OCIO::BIT_DEPTH_UINT12);
+    OCIO_CHECK_EQUAL(op->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 
-    OIIO_REQUIRE_ASSERT(ops[5]);
+    OCIO_REQUIRE_ASSERT(ops[5]);
     op = ops[5];
     auto matrixData2 = OCIO::DynamicPtrCast<const OCIO::MatrixOpData>(op->data());
-    OIIO_REQUIRE_ASSERT(matrixData2);
-    OIIO_CHECK_EQUAL(op->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_REQUIRE_ASSERT(matrixData2);
+    OCIO_CHECK_EQUAL(op->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
     // (OutDepth was 32f in referenced file.)
-    OIIO_CHECK_EQUAL(op->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
+    OCIO_CHECK_EQUAL(op->getOutputBitDepth(), OCIO::BIT_DEPTH_UINT8);
 
-    OIIO_REQUIRE_ASSERT(ops[6]);
+    OCIO_REQUIRE_ASSERT(ops[6]);
     op = ops[6];
     auto rangeData = OCIO::DynamicPtrCast<const OCIO::RangeOpData>(op->data());
-    OIIO_REQUIRE_ASSERT(rangeData);
+    OCIO_REQUIRE_ASSERT(rangeData);
 
-    OIIO_REQUIRE_ASSERT(ops[7]);
+    OCIO_REQUIRE_ASSERT(ops[7]);
     op = ops[7];
-    OIIO_REQUIRE_ASSERT(GetFilePath(path, op));
-    OIIO_CHECK_NE(path.find("cdl_clamp_fwd.clf"), std::string::npos);
+    OCIO_REQUIRE_ASSERT(GetFilePath(path, op));
+    OCIO_CHECK_NE(path.find("cdl_clamp_fwd.clf"), std::string::npos);
 
-    OIIO_REQUIRE_ASSERT(ops[8]);
+    OCIO_REQUIRE_ASSERT(ops[8]);
     op = ops[8];
     auto cdlData = OCIO::DynamicPtrCast<const OCIO::CDLOpData>(op->data());
-    OIIO_REQUIRE_ASSERT(cdlData);
+    OCIO_REQUIRE_ASSERT(cdlData);
     // (OutDepth was 16f in original.)
-    OIIO_CHECK_EQUAL(op->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
-    OIIO_CHECK_EQUAL(op->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(op->getInputBitDepth(), OCIO::BIT_DEPTH_F32);
+    OCIO_CHECK_EQUAL(op->getOutputBitDepth(), OCIO::BIT_DEPTH_F32);
 }
 
-OIIO_ADD_TEST(Reference, load_nested_resolve_internal)
+OCIO_ADD_TEST(Reference, load_nested_resolve_internal)
 {
     OCIO::ContextRcPtr context = OCIO::Context::Create();
     context->addSearchPath(OCIO::getTestFilesDir());
     std::string fileName("reference_nested.ctf");
     OCIO::OpRcPtrVec ops;
-    OIIO_CHECK_NO_THROW(BuildOpsTest(ops, fileName, context, OCIO::TRANSFORM_DIR_FORWARD));
-    OIIO_REQUIRE_EQUAL(ops.size(), 4);
+    OCIO_CHECK_NO_THROW(BuildOpsTest(ops, fileName, context, OCIO::TRANSFORM_DIR_FORWARD));
+    OCIO_REQUIRE_EQUAL(ops.size(), 4);
 
     std::string path;
     OCIO::ConstOpRcPtr op = ops[0];
-    OIIO_REQUIRE_ASSERT(op);
-    OIIO_REQUIRE_ASSERT(GetFilePath(path, op));
-    OIIO_CHECK_NE(path.find("reference_nested.ctf"), std::string::npos);
+    OCIO_REQUIRE_ASSERT(op);
+    OCIO_REQUIRE_ASSERT(GetFilePath(path, op));
+    OCIO_CHECK_NE(path.find("reference_nested.ctf"), std::string::npos);
 
     op = ops[1];
-    OIIO_REQUIRE_ASSERT(op);
-    OIIO_REQUIRE_ASSERT(GetFilePath(path, op));
-    OIIO_CHECK_NE(path.find("reference_nested_2.ctf"), std::string::npos);
+    OCIO_REQUIRE_ASSERT(op);
+    OCIO_REQUIRE_ASSERT(GetFilePath(path, op));
+    OCIO_CHECK_NE(path.find("reference_nested_2.ctf"), std::string::npos);
 
     op = ops[2];
-    OIIO_REQUIRE_ASSERT(op);
-    OIIO_REQUIRE_ASSERT(GetFilePath(path, op));
-    OIIO_CHECK_NE(path.find("matrix_example.clf"), std::string::npos);
+    OCIO_REQUIRE_ASSERT(op);
+    OCIO_REQUIRE_ASSERT(GetFilePath(path, op));
+    OCIO_CHECK_NE(path.find("matrix_example.clf"), std::string::npos);
 
     op = ops[3];
-    OIIO_REQUIRE_ASSERT(op);
+    OCIO_REQUIRE_ASSERT(op);
     auto matrixData = OCIO::DynamicPtrCast<const OCIO::MatrixOpData>(op->data());
-    OIIO_REQUIRE_ASSERT(matrixData);
+    OCIO_REQUIRE_ASSERT(matrixData);
 }
 
 // TODO: Once searchPath for Windows is fixed, add test where files are in different directories

--- a/src/OpenColorIO/transforms/AllocationTransform.cpp
+++ b/src/OpenColorIO/transforms/AllocationTransform.cpp
@@ -230,32 +230,32 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(AllocationTransform, allocation)
+OCIO_ADD_TEST(AllocationTransform, allocation)
 {
     OCIO::AllocationTransformRcPtr al = OCIO::AllocationTransform::Create();
 
     al->setAllocation(OCIO::ALLOCATION_UNIFORM);
-    OIIO_CHECK_NO_THROW(al->validate());
+    OCIO_CHECK_NO_THROW(al->validate());
 
     std::vector<float> envs(2, 0.0f);
     al->setVars(static_cast<int>(envs.size()), &envs[0]);
-    OIIO_CHECK_NO_THROW(al->validate());
+    OCIO_CHECK_NO_THROW(al->validate());
 
     envs.push_back(0.01f);
     al->setVars(static_cast<int>(envs.size()), &envs[0]);
-    OIIO_CHECK_THROW(al->validate(), OCIO::Exception);
+    OCIO_CHECK_THROW(al->validate(), OCIO::Exception);
 
     al->setAllocation(OCIO::ALLOCATION_LG2);
-    OIIO_CHECK_NO_THROW(al->validate());
+    OCIO_CHECK_NO_THROW(al->validate());
 
     envs.push_back(0.1f);
     al->setVars(static_cast<int>(envs.size()), &envs[0]);
-    OIIO_CHECK_THROW(al->validate(), OCIO::Exception);
+    OCIO_CHECK_THROW(al->validate(), OCIO::Exception);
 
     al->setVars(0, 0x0);
-    OIIO_CHECK_NO_THROW(al->validate());
+    OCIO_CHECK_NO_THROW(al->validate());
 }
 
 #endif

--- a/src/OpenColorIO/transforms/CDLTransform.cpp
+++ b/src/OpenColorIO/transforms/CDLTransform.cpp
@@ -670,29 +670,29 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 #include "Platform.h"
 
 
-OIIO_ADD_TEST(CDLTransform, equality)
+OCIO_ADD_TEST(CDLTransform, equality)
 {
     const OCIO::CDLTransformRcPtr cdl1 = OCIO::CDLTransform::Create();
     const OCIO::CDLTransformRcPtr cdl2 = OCIO::CDLTransform::Create();
 
-    OIIO_CHECK_ASSERT(cdl1->equals(cdl1));
-    OIIO_CHECK_ASSERT(cdl1->equals(cdl2));
-    OIIO_CHECK_ASSERT(cdl2->equals(cdl1));
+    OCIO_CHECK_ASSERT(cdl1->equals(cdl1));
+    OCIO_CHECK_ASSERT(cdl1->equals(cdl2));
+    OCIO_CHECK_ASSERT(cdl2->equals(cdl1));
 
     const OCIO::CDLTransformRcPtr cdl3 = OCIO::CDLTransform::Create();
     cdl3->setSat(cdl3->getSat()+0.002f);
 
-    OIIO_CHECK_ASSERT(!cdl1->equals(cdl3));
-    OIIO_CHECK_ASSERT(!cdl2->equals(cdl3));
-    OIIO_CHECK_ASSERT(cdl3->equals(cdl3));
+    OCIO_CHECK_ASSERT(!cdl1->equals(cdl3));
+    OCIO_CHECK_ASSERT(!cdl2->equals(cdl3));
+    OCIO_CHECK_ASSERT(cdl3->equals(cdl3));
 }
 
-OIIO_ADD_TEST(CDLTransform, CreateFromCCFile)
+OCIO_ADD_TEST(CDLTransform, CreateFromCCFile)
 {
     const std::string filePath(std::string(OCIO::getTestFilesDir())
                                + "/cdl_test1.cc");
@@ -701,25 +701,25 @@ OIIO_ADD_TEST(CDLTransform, CreateFromCCFile)
 
     {
         std::string idStr(transform->getID());
-        OIIO_CHECK_EQUAL("foo", idStr);
+        OCIO_CHECK_EQUAL("foo", idStr);
         std::string descStr(transform->getDescription());
-        OIIO_CHECK_EQUAL("this is a description", descStr);
+        OCIO_CHECK_EQUAL("this is a description", descStr);
         float slope[3] = {0.f, 0.f, 0.f};
-        OIIO_CHECK_NO_THROW(transform->getSlope(slope));
-        OIIO_CHECK_EQUAL(1.1f, slope[0]);
-        OIIO_CHECK_EQUAL(1.2f, slope[1]);
-        OIIO_CHECK_EQUAL(1.3f, slope[2]);
+        OCIO_CHECK_NO_THROW(transform->getSlope(slope));
+        OCIO_CHECK_EQUAL(1.1f, slope[0]);
+        OCIO_CHECK_EQUAL(1.2f, slope[1]);
+        OCIO_CHECK_EQUAL(1.3f, slope[2]);
         float offset[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(transform->getOffset(offset));
-        OIIO_CHECK_EQUAL(2.1f, offset[0]);
-        OIIO_CHECK_EQUAL(2.2f, offset[1]);
-        OIIO_CHECK_EQUAL(2.3f, offset[2]);
+        OCIO_CHECK_NO_THROW(transform->getOffset(offset));
+        OCIO_CHECK_EQUAL(2.1f, offset[0]);
+        OCIO_CHECK_EQUAL(2.2f, offset[1]);
+        OCIO_CHECK_EQUAL(2.3f, offset[2]);
         float power[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(transform->getPower(power));
-        OIIO_CHECK_EQUAL(3.1f, power[0]);
-        OIIO_CHECK_EQUAL(3.2f, power[1]);
-        OIIO_CHECK_EQUAL(3.3f, power[2]);
-        OIIO_CHECK_EQUAL(0.7f, transform->getSat());
+        OCIO_CHECK_NO_THROW(transform->getPower(power));
+        OCIO_CHECK_EQUAL(3.1f, power[0]);
+        OCIO_CHECK_EQUAL(3.2f, power[1]);
+        OCIO_CHECK_EQUAL(3.3f, power[2]);
+        OCIO_CHECK_EQUAL(0.7f, transform->getSat());
     }
 
     const std::string expectedOutXML(
@@ -735,36 +735,36 @@ OIIO_ADD_TEST(CDLTransform, CreateFromCCFile)
         "    </SatNode>\n"
         "</ColorCorrection>");
     std::string outXML(transform->getXML());
-    OIIO_CHECK_EQUAL(expectedOutXML, outXML);
+    OCIO_CHECK_EQUAL(expectedOutXML, outXML);
 
     // parse again using setXML
     OCIO::CDLTransformRcPtr transformCDL = OCIO::CDLTransform::Create();
     transformCDL->setXML(expectedOutXML.c_str());
     {
         std::string idStr(transformCDL->getID());
-        OIIO_CHECK_EQUAL("foo", idStr);
+        OCIO_CHECK_EQUAL("foo", idStr);
         std::string descStr(transformCDL->getDescription());
-        OIIO_CHECK_EQUAL("this is a description", descStr);
+        OCIO_CHECK_EQUAL("this is a description", descStr);
         float slope[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(transformCDL->getSlope(slope));
-        OIIO_CHECK_EQUAL(1.1f, slope[0]);
-        OIIO_CHECK_EQUAL(1.2f, slope[1]);
-        OIIO_CHECK_EQUAL(1.3f, slope[2]);
+        OCIO_CHECK_NO_THROW(transformCDL->getSlope(slope));
+        OCIO_CHECK_EQUAL(1.1f, slope[0]);
+        OCIO_CHECK_EQUAL(1.2f, slope[1]);
+        OCIO_CHECK_EQUAL(1.3f, slope[2]);
         float offset[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(transformCDL->getOffset(offset));
-        OIIO_CHECK_EQUAL(2.1f, offset[0]);
-        OIIO_CHECK_EQUAL(2.2f, offset[1]);
-        OIIO_CHECK_EQUAL(2.3f, offset[2]);
+        OCIO_CHECK_NO_THROW(transformCDL->getOffset(offset));
+        OCIO_CHECK_EQUAL(2.1f, offset[0]);
+        OCIO_CHECK_EQUAL(2.2f, offset[1]);
+        OCIO_CHECK_EQUAL(2.3f, offset[2]);
         float power[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(transformCDL->getPower(power));
-        OIIO_CHECK_EQUAL(3.1f, power[0]);
-        OIIO_CHECK_EQUAL(3.2f, power[1]);
-        OIIO_CHECK_EQUAL(3.3f, power[2]);
-        OIIO_CHECK_EQUAL(0.7f, transformCDL->getSat());
+        OCIO_CHECK_NO_THROW(transformCDL->getPower(power));
+        OCIO_CHECK_EQUAL(3.1f, power[0]);
+        OCIO_CHECK_EQUAL(3.2f, power[1]);
+        OCIO_CHECK_EQUAL(3.3f, power[2]);
+        OCIO_CHECK_EQUAL(0.7f, transformCDL->getSat());
     }
 }
 
-OIIO_ADD_TEST(CDLTransform, CreateFromCCCFile)
+OCIO_ADD_TEST(CDLTransform, CreateFromCCCFile)
 {
     const std::string filePath(std::string(OCIO::getTestFilesDir())
                                + "/cdl_test1.ccc");
@@ -773,72 +773,72 @@ OIIO_ADD_TEST(CDLTransform, CreateFromCCCFile)
         OCIO::CDLTransformRcPtr transform =
             OCIO::CDLTransform::CreateFromFile(filePath.c_str(), "cc0003");
         std::string idStr(transform->getID());
-        OIIO_CHECK_EQUAL("cc0003", idStr);
+        OCIO_CHECK_EQUAL("cc0003", idStr);
         std::string descStr(transform->getDescription());
-        OIIO_CHECK_EQUAL("golden", descStr);
+        OCIO_CHECK_EQUAL("golden", descStr);
         float slope[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(transform->getSlope(slope));
-        OIIO_CHECK_EQUAL(1.2f, slope[0]);
-        OIIO_CHECK_EQUAL(1.1f, slope[1]);
-        OIIO_CHECK_EQUAL(1.0f, slope[2]);
+        OCIO_CHECK_NO_THROW(transform->getSlope(slope));
+        OCIO_CHECK_EQUAL(1.2f, slope[0]);
+        OCIO_CHECK_EQUAL(1.1f, slope[1]);
+        OCIO_CHECK_EQUAL(1.0f, slope[2]);
         float offset[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(transform->getOffset(offset));
-        OIIO_CHECK_EQUAL(0.0f, offset[0]);
-        OIIO_CHECK_EQUAL(0.0f, offset[1]);
-        OIIO_CHECK_EQUAL(0.0f, offset[2]);
+        OCIO_CHECK_NO_THROW(transform->getOffset(offset));
+        OCIO_CHECK_EQUAL(0.0f, offset[0]);
+        OCIO_CHECK_EQUAL(0.0f, offset[1]);
+        OCIO_CHECK_EQUAL(0.0f, offset[2]);
         float power[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(transform->getPower(power));
-        OIIO_CHECK_EQUAL(0.9f, power[0]);
-        OIIO_CHECK_EQUAL(1.0f, power[1]);
-        OIIO_CHECK_EQUAL(1.2f, power[2]);
-        OIIO_CHECK_EQUAL(1.0f, transform->getSat());
+        OCIO_CHECK_NO_THROW(transform->getPower(power));
+        OCIO_CHECK_EQUAL(0.9f, power[0]);
+        OCIO_CHECK_EQUAL(1.0f, power[1]);
+        OCIO_CHECK_EQUAL(1.2f, power[2]);
+        OCIO_CHECK_EQUAL(1.0f, transform->getSat());
     }
     {
         // Using 0 based index
         OCIO::CDLTransformRcPtr transform =
             OCIO::CDLTransform::CreateFromFile(filePath.c_str(), "3");
         std::string idStr(transform->getID());
-        OIIO_CHECK_EQUAL("", idStr);
+        OCIO_CHECK_EQUAL("", idStr);
         std::string descStr(transform->getDescription());
-        OIIO_CHECK_EQUAL("", descStr);
+        OCIO_CHECK_EQUAL("", descStr);
         float slope[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(transform->getSlope(slope));
-        OIIO_CHECK_EQUAL(4.0f, slope[0]);
-        OIIO_CHECK_EQUAL(5.0f, slope[1]);
-        OIIO_CHECK_EQUAL(6.0f, slope[2]);
+        OCIO_CHECK_NO_THROW(transform->getSlope(slope));
+        OCIO_CHECK_EQUAL(4.0f, slope[0]);
+        OCIO_CHECK_EQUAL(5.0f, slope[1]);
+        OCIO_CHECK_EQUAL(6.0f, slope[2]);
         float offset[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(transform->getOffset(offset));
-        OIIO_CHECK_EQUAL(0.0f, offset[0]);
-        OIIO_CHECK_EQUAL(0.0f, offset[1]);
-        OIIO_CHECK_EQUAL(0.0f, offset[2]);
+        OCIO_CHECK_NO_THROW(transform->getOffset(offset));
+        OCIO_CHECK_EQUAL(0.0f, offset[0]);
+        OCIO_CHECK_EQUAL(0.0f, offset[1]);
+        OCIO_CHECK_EQUAL(0.0f, offset[2]);
         float power[3] = { 0.f, 0.f, 0.f };
-        OIIO_CHECK_NO_THROW(transform->getPower(power));
-        OIIO_CHECK_EQUAL(0.9f, power[0]);
-        OIIO_CHECK_EQUAL(1.0f, power[1]);
-        OIIO_CHECK_EQUAL(1.2f, power[2]);
-        OIIO_CHECK_EQUAL(1.0f, transform->getSat());
+        OCIO_CHECK_NO_THROW(transform->getPower(power));
+        OCIO_CHECK_EQUAL(0.9f, power[0]);
+        OCIO_CHECK_EQUAL(1.0f, power[1]);
+        OCIO_CHECK_EQUAL(1.2f, power[2]);
+        OCIO_CHECK_EQUAL(1.0f, transform->getSat());
     }
 }
 
-OIIO_ADD_TEST(CDLTransform, CreateFromCCCFileFailure)
+OCIO_ADD_TEST(CDLTransform, CreateFromCCCFileFailure)
 {
     const std::string filePath(std::string(OCIO::getTestFilesDir())
         + "/cdl_test1.ccc");
     {
         // Using ID
-        OIIO_CHECK_THROW_WHAT(
+        OCIO_CHECK_THROW_WHAT(
             OCIO::CDLTransform::CreateFromFile(filePath.c_str(), "NotFound"),
             OCIO::Exception, "could not be loaded from the src file");
     }
     {
         // Using index
-        OIIO_CHECK_THROW_WHAT(
+        OCIO_CHECK_THROW_WHAT(
             OCIO::CDLTransform::CreateFromFile(filePath.c_str(), "42"),
             OCIO::Exception, "could not be loaded from the src file");
     }
 }
 
-OIIO_ADD_TEST(CDLTransform, EscapeXML)
+OCIO_ADD_TEST(CDLTransform, EscapeXML)
 {
     const std::string inputXML(
         "<ColorCorrection id=\"Esc &lt; &amp; &quot; &apos; &gt;\">\n"
@@ -858,9 +858,9 @@ OIIO_ADD_TEST(CDLTransform, EscapeXML)
     transformCDL->setXML(inputXML.c_str());
     {
         std::string idStr(transformCDL->getID());
-        OIIO_CHECK_EQUAL("Esc < & \" ' >", idStr);
+        OCIO_CHECK_EQUAL("Esc < & \" ' >", idStr);
         std::string descStr(transformCDL->getDescription());
-        OIIO_CHECK_EQUAL("These: < & \" ' > are escape chars", descStr);
+        OCIO_CHECK_EQUAL("These: < & \" ' > are escape chars", descStr);
     }
 }
 
@@ -919,50 +919,50 @@ namespace
 
 }
 
-OIIO_ADD_TEST(CDLTransform, clear_caches)
+OCIO_ADD_TEST(CDLTransform, clear_caches)
 {
     std::string filename;
-    OIIO_CHECK_NO_THROW(OCIO::Platform::CreateTempFilename(filename, ""));
+    OCIO_CHECK_NO_THROW(OCIO::Platform::CreateTempFilename(filename, ""));
 
     std::fstream stream(filename, std::ios_base::out|std::ios_base::trunc);
     stream << kContentsA;
     stream.close();
 
     OCIO::CDLTransformRcPtr transform; 
-    OIIO_CHECK_NO_THROW(transform = OCIO::CDLTransform::CreateFromFile(filename.c_str(), "cc03343"));
+    OCIO_CHECK_NO_THROW(transform = OCIO::CDLTransform::CreateFromFile(filename.c_str(), "cc03343"));
 
     float slope[3];
 
-    OIIO_CHECK_NO_THROW(transform->getSlope(slope));
-    OIIO_CHECK_EQUAL(slope[0], 0.1f);
-    OIIO_CHECK_EQUAL(slope[1], 0.2f);
-    OIIO_CHECK_EQUAL(slope[2], 0.3f);
+    OCIO_CHECK_NO_THROW(transform->getSlope(slope));
+    OCIO_CHECK_EQUAL(slope[0], 0.1f);
+    OCIO_CHECK_EQUAL(slope[1], 0.2f);
+    OCIO_CHECK_EQUAL(slope[2], 0.3f);
 
     stream.open(filename, std::ios_base::out|std::ios_base::trunc);
     stream << kContentsB;
     stream.close();
 
-    OIIO_CHECK_NO_THROW(OCIO::ClearAllCaches());
+    OCIO_CHECK_NO_THROW(OCIO::ClearAllCaches());
 
-    OIIO_CHECK_NO_THROW(transform = OCIO::CDLTransform::CreateFromFile(filename.c_str(), "cc03343"));
-    OIIO_CHECK_NO_THROW(transform->getSlope(slope));
+    OCIO_CHECK_NO_THROW(transform = OCIO::CDLTransform::CreateFromFile(filename.c_str(), "cc03343"));
+    OCIO_CHECK_NO_THROW(transform->getSlope(slope));
 
-    OIIO_CHECK_EQUAL(slope[0], 1.1f);
-    OIIO_CHECK_EQUAL(slope[1], 2.2f);
-    OIIO_CHECK_EQUAL(slope[2], 3.3f);
+    OCIO_CHECK_EQUAL(slope[0], 1.1f);
+    OCIO_CHECK_EQUAL(slope[1], 2.2f);
+    OCIO_CHECK_EQUAL(slope[2], 3.3f);
 }
 
-OIIO_ADD_TEST(CDLTransform, faulty_file_content)
+OCIO_ADD_TEST(CDLTransform, faulty_file_content)
 {
     std::string filename;
-    OIIO_CHECK_NO_THROW(OCIO::Platform::CreateTempFilename(filename, ""));
+    OCIO_CHECK_NO_THROW(OCIO::Platform::CreateTempFilename(filename, ""));
 
     {
         std::fstream stream(filename, std::ios_base::out|std::ios_base::trunc);
         stream << kContentsA << "Some Extra faulty information";
         stream.close();
 
-        OIIO_CHECK_THROW_WHAT(OCIO::CDLTransform::CreateFromFile(filename.c_str(), "cc03343"),
+        OCIO_CHECK_THROW_WHAT(OCIO::CDLTransform::CreateFromFile(filename.c_str(), "cc03343"),
                               OCIO::Exception,
                               "Error parsing ColorCorrectionCollection (). Error is: XML parsing error");
     }
@@ -971,7 +971,7 @@ OIIO_ADD_TEST(CDLTransform, faulty_file_content)
 
         std::string faultyContent = kContentsA;
         const std::size_t found = faultyContent.find("cc03344");
-        OIIO_CHECK_ASSERT(found!=std::string::npos);
+        OCIO_CHECK_ASSERT(found!=std::string::npos);
         faultyContent.replace(found, strlen("cc03344"), "cc03343");
 
 
@@ -979,7 +979,7 @@ OIIO_ADD_TEST(CDLTransform, faulty_file_content)
         stream << faultyContent;
         stream.close();
 
-        OIIO_CHECK_THROW_WHAT(OCIO::CDLTransform::CreateFromFile(filename.c_str(), "cc03343"),
+        OCIO_CHECK_THROW_WHAT(OCIO::CDLTransform::CreateFromFile(filename.c_str(), "cc03343"),
                               OCIO::Exception,
                               "Error loading ccc xml. Duplicate elements with 'cc03343'");
     }

--- a/src/OpenColorIO/transforms/ExponentTransform.cpp
+++ b/src/OpenColorIO/transforms/ExponentTransform.cpp
@@ -233,25 +233,25 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 
-OIIO_ADD_TEST(ExponentTransform, basic)
+OCIO_ADD_TEST(ExponentTransform, basic)
 {
     OCIO::ExponentTransformRcPtr exp = OCIO::ExponentTransform::Create();
-    OIIO_CHECK_EQUAL(exp->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(exp->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
 
     exp->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(exp->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(exp->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
 
     std::vector<float> val4(4, 1.), identity_val4(4, 1.);
-    OIIO_CHECK_NO_THROW(exp->getValue(&val4[0]));
-    OIIO_CHECK_ASSERT(val4 == identity_val4);
+    OCIO_CHECK_NO_THROW(exp->getValue(&val4[0]));
+    OCIO_CHECK_ASSERT(val4 == identity_val4);
 
     val4[1] = 2.;
-    OIIO_CHECK_NO_THROW(exp->setValue(&val4[0]));
-    OIIO_CHECK_NO_THROW(exp->getValue(&val4[0]));
-    OIIO_CHECK_ASSERT(val4 != identity_val4);
+    OCIO_CHECK_NO_THROW(exp->setValue(&val4[0]));
+    OCIO_CHECK_NO_THROW(exp->getValue(&val4[0]));
+    OCIO_CHECK_ASSERT(val4 != identity_val4);
 }
 
 namespace
@@ -261,27 +261,27 @@ void CheckValues(const double(&v1)[4], const double(&v2)[4])
 {
     static const float errThreshold = 1e-8f;
 
-    OIIO_CHECK_CLOSE(v1[0], v2[0], errThreshold);
-    OIIO_CHECK_CLOSE(v1[1], v2[1], errThreshold);
-    OIIO_CHECK_CLOSE(v1[2], v2[2], errThreshold);
-    OIIO_CHECK_CLOSE(v1[3], v2[3], errThreshold);
+    OCIO_CHECK_CLOSE(v1[0], v2[0], errThreshold);
+    OCIO_CHECK_CLOSE(v1[1], v2[1], errThreshold);
+    OCIO_CHECK_CLOSE(v1[2], v2[2], errThreshold);
+    OCIO_CHECK_CLOSE(v1[3], v2[3], errThreshold);
 }
 
 };
 
-OIIO_ADD_TEST(ExponentTransform, double)
+OCIO_ADD_TEST(ExponentTransform, double)
 {
     OCIO::ExponentTransformRcPtr exp = OCIO::ExponentTransform::Create();
-    OIIO_CHECK_EQUAL(exp->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(exp->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
 
     double val4[4] = { -1., -2., -3., -4. };
-    OIIO_CHECK_NO_THROW(exp->getValue(val4));
+    OCIO_CHECK_NO_THROW(exp->getValue(val4));
     CheckValues(val4, { 1., 1., 1., 1. });
 
     val4[1] = 2.1234567;
-    OIIO_CHECK_NO_THROW(exp->setValue(val4));
+    OCIO_CHECK_NO_THROW(exp->setValue(val4));
     val4[1] = -2.;
-    OIIO_CHECK_NO_THROW(exp->getValue(val4));
+    OCIO_CHECK_NO_THROW(exp->getValue(val4));
     CheckValues(val4, {1., 2.1234567, 1., 1.});
 }
 

--- a/src/OpenColorIO/transforms/ExponentWithLinearTransform.cpp
+++ b/src/OpenColorIO/transforms/ExponentWithLinearTransform.cpp
@@ -235,7 +235,7 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 
 namespace
@@ -245,40 +245,40 @@ void CheckValues(const double(&v1)[4], const double(&v2)[4])
 {
     static const float errThreshold = 1e-8f;
 
-    OIIO_CHECK_CLOSE(v1[0], v2[0], errThreshold);
-    OIIO_CHECK_CLOSE(v1[1], v2[1], errThreshold);
-    OIIO_CHECK_CLOSE(v1[2], v2[2], errThreshold);
-    OIIO_CHECK_CLOSE(v1[3], v2[3], errThreshold);
+    OCIO_CHECK_CLOSE(v1[0], v2[0], errThreshold);
+    OCIO_CHECK_CLOSE(v1[1], v2[1], errThreshold);
+    OCIO_CHECK_CLOSE(v1[2], v2[2], errThreshold);
+    OCIO_CHECK_CLOSE(v1[3], v2[3], errThreshold);
 }
 
 };
 
-OIIO_ADD_TEST(ExponentWithLinearTransform, basic)
+OCIO_ADD_TEST(ExponentWithLinearTransform, basic)
 {
     OCIO::ExponentWithLinearTransformRcPtr exp = OCIO::ExponentWithLinearTransform::Create();
-    OIIO_CHECK_EQUAL(exp->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(exp->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
 
     exp->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(exp->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(exp->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
 
     double val4[4] = { -1., -1. -1. -1. };
 
-    OIIO_CHECK_NO_THROW(exp->getGamma(val4));
+    OCIO_CHECK_NO_THROW(exp->getGamma(val4));
     CheckValues(val4, { 1., 1., 1., 1. });
 
     val4[1] = 2.1234567;
-    OIIO_CHECK_NO_THROW(exp->setGamma(val4));
+    OCIO_CHECK_NO_THROW(exp->setGamma(val4));
     val4[1] = -1.;
-    OIIO_CHECK_NO_THROW(exp->getGamma(val4));
+    OCIO_CHECK_NO_THROW(exp->getGamma(val4));
     CheckValues(val4, {1., 2.1234567, 1., 1.});
 
-    OIIO_CHECK_NO_THROW(exp->getOffset(val4));
+    OCIO_CHECK_NO_THROW(exp->getOffset(val4));
     CheckValues(val4, { 0., 0., 0., 0. });
 
     val4[1] = 0.1234567;
-    OIIO_CHECK_NO_THROW(exp->setOffset(val4));
+    OCIO_CHECK_NO_THROW(exp->setOffset(val4));
     val4[1] = -1.;
-    OIIO_CHECK_NO_THROW(exp->getOffset(val4));
+    OCIO_CHECK_NO_THROW(exp->getOffset(val4));
     CheckValues(val4, { 0., 0.1234567, 0., 0. });
 }
 

--- a/src/OpenColorIO/transforms/ExposureContrastTransform.cpp
+++ b/src/OpenColorIO/transforms/ExposureContrastTransform.cpp
@@ -355,40 +355,40 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(ExposureContrastTransform, basic)
+OCIO_ADD_TEST(ExposureContrastTransform, basic)
 {
     OCIO::ExposureContrastTransformRcPtr ec = OCIO::ExposureContrastTransform::Create();
-    OIIO_CHECK_EQUAL(ec->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(ec->getStyle(), OCIO::EXPOSURE_CONTRAST_LINEAR);
-    OIIO_CHECK_EQUAL(ec->getExposure(), 0.0);
-    OIIO_CHECK_EQUAL(ec->getContrast(), 1.0);
-    OIIO_CHECK_EQUAL(ec->getGamma(), 1.0);
-    OIIO_CHECK_EQUAL(ec->getPivot(), 0.18);
-    OIIO_CHECK_EQUAL(ec->getLogExposureStep(), 0.088);
-    OIIO_CHECK_EQUAL(ec->getLogMidGray(), 0.435);
-    OIIO_CHECK_NO_THROW(ec->validate());
+    OCIO_CHECK_EQUAL(ec->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(ec->getStyle(), OCIO::EXPOSURE_CONTRAST_LINEAR);
+    OCIO_CHECK_EQUAL(ec->getExposure(), 0.0);
+    OCIO_CHECK_EQUAL(ec->getContrast(), 1.0);
+    OCIO_CHECK_EQUAL(ec->getGamma(), 1.0);
+    OCIO_CHECK_EQUAL(ec->getPivot(), 0.18);
+    OCIO_CHECK_EQUAL(ec->getLogExposureStep(), 0.088);
+    OCIO_CHECK_EQUAL(ec->getLogMidGray(), 0.435);
+    OCIO_CHECK_NO_THROW(ec->validate());
 
-    OIIO_CHECK_NO_THROW(ec->setDirection(OCIO::TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_EQUAL(ec->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_NO_THROW(ec->validate());
+    OCIO_CHECK_NO_THROW(ec->setDirection(OCIO::TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_EQUAL(ec->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_NO_THROW(ec->validate());
 
-    OIIO_CHECK_NO_THROW(ec->setStyle(OCIO::EXPOSURE_CONTRAST_LOGARITHMIC));
-    OIIO_CHECK_EQUAL(ec->getStyle(), OCIO::EXPOSURE_CONTRAST_LOGARITHMIC);
-    OIIO_CHECK_NO_THROW(ec->validate());
+    OCIO_CHECK_NO_THROW(ec->setStyle(OCIO::EXPOSURE_CONTRAST_LOGARITHMIC));
+    OCIO_CHECK_EQUAL(ec->getStyle(), OCIO::EXPOSURE_CONTRAST_LOGARITHMIC);
+    OCIO_CHECK_NO_THROW(ec->validate());
 
-    OIIO_CHECK_NO_THROW(ec->setStyle(OCIO::EXPOSURE_CONTRAST_VIDEO));
-    OIIO_CHECK_EQUAL(ec->getStyle(), OCIO::EXPOSURE_CONTRAST_VIDEO);
-    OIIO_CHECK_NO_THROW(ec->validate());
+    OCIO_CHECK_NO_THROW(ec->setStyle(OCIO::EXPOSURE_CONTRAST_VIDEO));
+    OCIO_CHECK_EQUAL(ec->getStyle(), OCIO::EXPOSURE_CONTRAST_VIDEO);
+    OCIO_CHECK_NO_THROW(ec->validate());
 }
 
-OIIO_ADD_TEST(ExposureContrastTransform, processor)
+OCIO_ADD_TEST(ExposureContrastTransform, processor)
 {
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
 
     OCIO::ExposureContrastTransformRcPtr ec = OCIO::ExposureContrastTransform::Create();
-    OIIO_CHECK_NO_THROW(ec->setStyle(OCIO::EXPOSURE_CONTRAST_VIDEO));
+    OCIO_CHECK_NO_THROW(ec->setStyle(OCIO::EXPOSURE_CONTRAST_VIDEO));
     ec->setExposure(1.1);
     ec->makeExposureDynamic();
     ec->setContrast(0.5);
@@ -400,9 +400,9 @@ OIIO_ADD_TEST(ExposureContrastTransform, processor)
     processor->applyRGB(pixel);
 
     const float error = 1e-5f;
-    OIIO_CHECK_CLOSE(pixel[0], 0.32340f, error);
-    OIIO_CHECK_CLOSE(pixel[1], 0.43834f, error);
-    OIIO_CHECK_CLOSE(pixel[2], 0.54389f, error);
+    OCIO_CHECK_CLOSE(pixel[0], 0.32340f, error);
+    OCIO_CHECK_CLOSE(pixel[1], 0.43834f, error);
+    OCIO_CHECK_CLOSE(pixel[2], 0.54389f, error);
 
     // Changing the original transform does not change the processor.
     ec->setExposure(2.1);
@@ -411,25 +411,25 @@ OIIO_ADD_TEST(ExposureContrastTransform, processor)
     pixel[1] = 0.3f;
     pixel[2] = 0.4f;
     processor->applyRGB(pixel);
-    OIIO_CHECK_CLOSE(pixel[0], 0.32340f, error);
-    OIIO_CHECK_CLOSE(pixel[1], 0.43834f, error);
-    OIIO_CHECK_CLOSE(pixel[2], 0.54389f, error);
+    OCIO_CHECK_CLOSE(pixel[0], 0.32340f, error);
+    OCIO_CHECK_CLOSE(pixel[1], 0.43834f, error);
+    OCIO_CHECK_CLOSE(pixel[2], 0.54389f, error);
 
     OCIO::DynamicPropertyRcPtr dpExposure;
-    OIIO_CHECK_NO_THROW(dpExposure = processor->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
+    OCIO_CHECK_NO_THROW(dpExposure = processor->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
     dpExposure->setValue(2.1);
 
     // Gamma is a property of ExposureContrast but here it is not defined as dynamic.
-    OIIO_CHECK_THROW(processor->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_GAMMA), OCIO::Exception);
+    OCIO_CHECK_THROW(processor->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_GAMMA), OCIO::Exception);
 
     // Processor has been changed by dpExposure.
     pixel[0] = 0.2f;
     pixel[1] = 0.3f;
     pixel[2] = 0.4f;
     processor->applyRGB(pixel);
-    OIIO_CHECK_CLOSE(pixel[0], 0.42965f, error);
-    OIIO_CHECK_CLOSE(pixel[1], 0.58235f, error);
-    OIIO_CHECK_CLOSE(pixel[2], 0.72258f, error);
+    OCIO_CHECK_CLOSE(pixel[0], 0.42965f, error);
+    OCIO_CHECK_CLOSE(pixel[1], 0.58235f, error);
+    OCIO_CHECK_CLOSE(pixel[2], 0.72258f, error);
 
     // dpExposure can be used to change the processor.
     dpExposure->setValue(0.8);
@@ -437,10 +437,10 @@ OIIO_ADD_TEST(ExposureContrastTransform, processor)
     pixel[1] = 0.3f;
     pixel[2] = 0.4f;
     processor->applyRGB(pixel);
-    OIIO_CHECK_CLOSE(pixel[0], 0.29698f, error);
+    OCIO_CHECK_CLOSE(pixel[0], 0.29698f, error);
     // Adjust error for SSE approximation.
-    OIIO_CHECK_CLOSE(pixel[1], 0.40252f, error*2.0f);
-    OIIO_CHECK_CLOSE(pixel[2], 0.49946f, error);
+    OCIO_CHECK_CLOSE(pixel[1], 0.40252f, error*2.0f);
+    OCIO_CHECK_CLOSE(pixel[2], 0.49946f, error);
 }
 
 // This test verifies that if there are several ops in a processor that contain
@@ -449,7 +449,7 @@ OIIO_ADD_TEST(ExposureContrastTransform, processor)
 //    in the property, and
 // 2) Ops where a given dynamic property is not enabled continue to use the
 //    initial value and do not respond to changes to the property.
-OIIO_ADD_TEST(ExposureContrastTransform, processor_several_ec)
+OCIO_ADD_TEST(ExposureContrastTransform, processor_several_ec)
 {
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
 
@@ -461,7 +461,7 @@ OIIO_ADD_TEST(ExposureContrastTransform, processor_several_ec)
     const double a = 1.1;
     const double b = 2.1;
     OCIO::ExposureContrastTransformRcPtr ec1 = OCIO::ExposureContrastTransform::Create();
-    OIIO_CHECK_NO_THROW(ec1->setStyle(OCIO::EXPOSURE_CONTRAST_LOGARITHMIC));
+    OCIO_CHECK_NO_THROW(ec1->setStyle(OCIO::EXPOSURE_CONTRAST_LOGARITHMIC));
 
     ec1->setExposure(a);
     ec1->setContrast(0.5);
@@ -484,7 +484,7 @@ OIIO_ADD_TEST(ExposureContrastTransform, processor_several_ec)
     }
 
     OCIO::ExposureContrastTransformRcPtr ec2 = OCIO::ExposureContrastTransform::Create();
-    OIIO_CHECK_NO_THROW(ec2->setStyle(OCIO::EXPOSURE_CONTRAST_LOGARITHMIC));
+    OCIO_CHECK_NO_THROW(ec2->setStyle(OCIO::EXPOSURE_CONTRAST_LOGARITHMIC));
 
     ec2->setExposure(b);
     ec2->setContrast(0.5);
@@ -525,16 +525,16 @@ OIIO_ADD_TEST(ExposureContrastTransform, processor_several_ec)
 
         // Make second exposure dynamic. Value is still a.
         OCIO::DynamicPropertyRcPtr dpExposure;
-        OIIO_CHECK_NO_THROW(dpExposure = processor->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
+        OCIO_CHECK_NO_THROW(dpExposure = processor->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
 
         float pixel[3] = { srcPixel[0], srcPixel[1], srcPixel[2] };
 
         // Apply a then a.
         processor->applyRGB(pixel);
 
-        OIIO_CHECK_CLOSE(pixel[0], pixel_aa[0], error);
-        OIIO_CHECK_CLOSE(pixel[1], pixel_aa[1], error);
-        OIIO_CHECK_CLOSE(pixel[2], pixel_aa[2], error);
+        OCIO_CHECK_CLOSE(pixel[0], pixel_aa[0], error);
+        OCIO_CHECK_CLOSE(pixel[1], pixel_aa[1], error);
+        OCIO_CHECK_CLOSE(pixel[2], pixel_aa[2], error);
 
         // Change the 2nd exposure.
         dpExposure->setValue(b);
@@ -545,9 +545,9 @@ OIIO_ADD_TEST(ExposureContrastTransform, processor_several_ec)
         // Apply a then b.
         processor->applyRGB(pixel);
 
-        OIIO_CHECK_CLOSE(pixel[0], pixel_ab[0], error);
-        OIIO_CHECK_CLOSE(pixel[1], pixel_ab[1], error);
-        OIIO_CHECK_CLOSE(pixel[2], pixel_ab[2], error);
+        OCIO_CHECK_CLOSE(pixel[0], pixel_ab[0], error);
+        OCIO_CHECK_CLOSE(pixel[1], pixel_ab[1], error);
+        OCIO_CHECK_CLOSE(pixel[2], pixel_ab[2], error);
     }
 
     // Make exposure of first E/C dynamic.
@@ -568,7 +568,7 @@ OIIO_ADD_TEST(ExposureContrastTransform, processor_several_ec)
 
         // The dynamic property is common to both ops.
         OCIO::DynamicPropertyRcPtr dpExposure;
-        OIIO_CHECK_NO_THROW(dpExposure = processor->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
+        OCIO_CHECK_NO_THROW(dpExposure = processor->getDynamicProperty(OCIO::DYNAMIC_PROPERTY_EXPOSURE));
 
         float pixel[3] = { srcPixel[0], srcPixel[1], srcPixel[2] };
 
@@ -578,9 +578,9 @@ OIIO_ADD_TEST(ExposureContrastTransform, processor_several_ec)
         // Apply a twice.
         processor->applyRGB(pixel);
 
-        OIIO_CHECK_CLOSE(pixel[0], pixel_aa[0], error);
-        OIIO_CHECK_CLOSE(pixel[1], pixel_aa[1], error);
-        OIIO_CHECK_CLOSE(pixel[2], pixel_aa[2], error);
+        OCIO_CHECK_CLOSE(pixel[0], pixel_aa[0], error);
+        OCIO_CHECK_CLOSE(pixel[1], pixel_aa[1], error);
+        OCIO_CHECK_CLOSE(pixel[2], pixel_aa[2], error);
 
         // Changing the dynamic property is changing both exposures to b.
         dpExposure->setValue(b);
@@ -591,9 +591,9 @@ OIIO_ADD_TEST(ExposureContrastTransform, processor_several_ec)
         // Apply b twice.
         processor->applyRGB(pixel);
 
-        OIIO_CHECK_CLOSE(pixel[0], pixel_bb[0], error);
-        OIIO_CHECK_CLOSE(pixel[1], pixel_bb[1], error);
-        OIIO_CHECK_CLOSE(pixel[2], pixel_bb[2], error);
+        OCIO_CHECK_CLOSE(pixel[0], pixel_bb[0], error);
+        OCIO_CHECK_CLOSE(pixel[1], pixel_bb[1], error);
+        OCIO_CHECK_CLOSE(pixel[2], pixel_bb[2], error);
     }
 }
 

--- a/src/OpenColorIO/transforms/FileTransform.cpp
+++ b/src/OpenColorIO/transforms/FileTransform.cpp
@@ -801,112 +801,112 @@ OCIO_NAMESPACE_EXIT
 
 namespace OCIO = OCIO_NAMESPACE;
 #include <algorithm>
-#include "unittest.h"
+#include "UnitTest.h"
 #include "UnitTestUtils.h"
 
-OIIO_ADD_TEST(FileTransform, LoadFileOK)
+OCIO_ADD_TEST(FileTransform, LoadFileOK)
 {
     OCIO::ConstProcessorRcPtr proc;
 
     // Discreet 1D LUT.
     const std::string discreetLut("logtolin_8to8.lut");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(discreetLut));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(discreetLut));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 
     // Houdini 1D LUT.
     const std::string houdiniLut("houdini.lut");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(houdiniLut));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(houdiniLut));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 
     // Discreet 3D LUT file.
     const std::string discree3DtLut("discreet-3d-lut.3dl");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(discree3DtLut));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(discree3DtLut));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 
     // 3D LUT file.
     const std::string crosstalk3DtLut("crosstalk.3dl");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(crosstalk3DtLut));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(crosstalk3DtLut));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 
     // Lustre 3D LUT file.
     const std::string lustre3DtLut("lustre_33x33x33.3dl");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(lustre3DtLut));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(lustre3DtLut));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 
     // Autodesk color transform format.
     const std::string ctfTransform("matrix_example4x4.ctf");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(ctfTransform));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(ctfTransform));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 
     // Academy/ASC common LUT format.
     const std::string clfRangeTransform("range.clf");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(clfRangeTransform));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(clfRangeTransform));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 
     // Academy/ASC common LUT format.
     const std::string clfMatTransform("matrix_example.clf");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(clfMatTransform));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(clfMatTransform));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 
     // Test other types of CLF/CTF elements.
     const std::string clfCdlTransform("cdl_clamp_fwd.clf");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(clfCdlTransform));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(clfCdlTransform));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 
     const std::string clfLut1Transform("lut1d_example.clf");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(clfLut1Transform));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(clfLut1Transform));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 
     const std::string clfLut3Transform("lut3d_2x2x2_32f_32f.clf");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(clfLut3Transform));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(clfLut3Transform));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 
     const std::string ctFFfTransform("ff_aces_redmod.ctf");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(ctFFfTransform));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(ctFFfTransform));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 
     const std::string ctfGammaTransform("gamma_test1.ctf");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(ctfGammaTransform));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(ctfGammaTransform));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 
     const std::string ctfLogTransform("log_logtolin.ctf");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(ctfLogTransform));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(ctfLogTransform));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 
     const std::string ctfInvLut1Transform("lut1d_inv.ctf");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(ctfInvLut1Transform));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(ctfInvLut1Transform));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 
     const std::string ctfInvLut3Transform("lut3d_example_Inv.ctf");
-    OIIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(ctfInvLut3Transform));
-    OIIO_CHECK_ASSERT(!proc->isNoOp());
+    OCIO_CHECK_NO_THROW(proc = OCIO::GetFileTransformProcessor(ctfInvLut3Transform));
+    OCIO_CHECK_ASSERT(!proc->isNoOp());
 }
 
-OIIO_ADD_TEST(FileTransform, LoadFileFail)
+OCIO_ADD_TEST(FileTransform, LoadFileFail)
 {
     // Legacy Lustre 1D LUT files. Similar to supported formats but actually
     // are different formats.
     // Test that they are correctly recognized as unreadable.
     {
         const std::string lustreOldLut("legacy_slog_to_log_v3_lustre.lut");
-        OIIO_CHECK_THROW_WHAT(OCIO::GetFileTransformProcessor(lustreOldLut),
+        OCIO_CHECK_THROW_WHAT(OCIO::GetFileTransformProcessor(lustreOldLut),
                               OCIO::Exception, "could not be loaded");
     }
 
     {
         const std::string lustreOldLut("legacy_flmlk_desat.lut");
-        OIIO_CHECK_THROW_WHAT(OCIO::GetFileTransformProcessor(lustreOldLut),
+        OCIO_CHECK_THROW_WHAT(OCIO::GetFileTransformProcessor(lustreOldLut),
                               OCIO::Exception, "could not be loaded");
     }
 
     // Invalid file.
     const std::string unKnown("error_unknown_format.txt");
-    OIIO_CHECK_THROW_WHAT(OCIO::GetFileTransformProcessor(unKnown),
+    OCIO_CHECK_THROW_WHAT(OCIO::GetFileTransformProcessor(unKnown),
                           OCIO::Exception, "could not be loaded");
 
     // Missing file.
     const std::string missing("missing.file");
-    OIIO_CHECK_THROW_WHAT(OCIO::GetFileTransformProcessor(missing),
+    OCIO_CHECK_THROW_WHAT(OCIO::GetFileTransformProcessor(missing),
                           OCIO::Exception, "could not be located");
 }
 
@@ -952,62 +952,62 @@ bool FormatExtensionFoundByName(const std::string & extension, const std::string
     return foundIt;
 }
 
-OIIO_ADD_TEST(FileTransform, AllFormats)
+OCIO_ADD_TEST(FileTransform, AllFormats)
 {
     OCIO::FormatRegistry & formatRegistry = OCIO::FormatRegistry::GetInstance();
-    OIIO_CHECK_EQUAL(19, formatRegistry.getNumRawFormats());
-    OIIO_CHECK_EQUAL(23, formatRegistry.getNumFormats(OCIO::FORMAT_CAPABILITY_READ));
-    OIIO_CHECK_EQUAL(8, formatRegistry.getNumFormats(OCIO::FORMAT_CAPABILITY_WRITE));
+    OCIO_CHECK_EQUAL(19, formatRegistry.getNumRawFormats());
+    OCIO_CHECK_EQUAL(23, formatRegistry.getNumFormats(OCIO::FORMAT_CAPABILITY_READ));
+    OCIO_CHECK_EQUAL(8, formatRegistry.getNumFormats(OCIO::FORMAT_CAPABILITY_WRITE));
 
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("3dl", "flame"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("cc", "ColorCorrection"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("ccc", "ColorCorrectionCollection"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("cdl", "ColorDecisionList"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("clf", "Academy/ASC Common LUT Format"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("csp", "cinespace"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("cub", "truelight"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("cube", "iridas_cube"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("cube", "resolve_cube"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("itx", "iridas_itx"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("icc", "International Color Consortium profile"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("look", "iridas_look"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("lut", "houdini"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("lut", "Discreet 1D LUT"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("mga", "pandora_mga"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("spi1d", "spi1d"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("spi3d", "spi3d"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("spimtx", "spimtx"));
-    OIIO_CHECK_ASSERT(FormatNameFoundByExtension("vf", "nukevf"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("3dl", "flame"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("cc", "ColorCorrection"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("ccc", "ColorCorrectionCollection"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("cdl", "ColorDecisionList"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("clf", "Academy/ASC Common LUT Format"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("csp", "cinespace"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("cub", "truelight"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("cube", "iridas_cube"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("cube", "resolve_cube"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("itx", "iridas_itx"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("icc", "International Color Consortium profile"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("look", "iridas_look"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("lut", "houdini"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("lut", "Discreet 1D LUT"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("mga", "pandora_mga"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("spi1d", "spi1d"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("spi3d", "spi3d"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("spimtx", "spimtx"));
+    OCIO_CHECK_ASSERT(FormatNameFoundByExtension("vf", "nukevf"));
     // When a FileFormat handles 2 "formats" it declares both names
     // but only exposes one name using the getName() function.
-    OIIO_CHECK_ASSERT(!FormatNameFoundByExtension("3dl", "lustre"));
-    OIIO_CHECK_ASSERT(!FormatNameFoundByExtension("m3d", "pandora_m3d"));
-    OIIO_CHECK_ASSERT(!FormatNameFoundByExtension("icm", "Image Color Matching"));
-    OIIO_CHECK_ASSERT(!FormatNameFoundByExtension("ctf", "Color Transform Format"));
+    OCIO_CHECK_ASSERT(!FormatNameFoundByExtension("3dl", "lustre"));
+    OCIO_CHECK_ASSERT(!FormatNameFoundByExtension("m3d", "pandora_m3d"));
+    OCIO_CHECK_ASSERT(!FormatNameFoundByExtension("icm", "Image Color Matching"));
+    OCIO_CHECK_ASSERT(!FormatNameFoundByExtension("ctf", "Color Transform Format"));
 
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("3dl", "flame"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("3dl", "lustre"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("cc", "ColorCorrection"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("ccc", "ColorCorrectionCollection"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("cdl", "ColorDecisionList"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("clf", "Academy/ASC Common LUT Format"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("ctf", "Color Transform Format"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("csp", "cinespace"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("cub", "truelight"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("cube", "iridas_cube"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("cube", "resolve_cube"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("itx", "iridas_itx"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("icc", "International Color Consortium profile"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("icm", "International Color Consortium profile"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("look", "iridas_look"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("lut", "houdini"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("lut", "Discreet 1D LUT"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("m3d", "pandora_m3d"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("mga", "pandora_mga"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("spi1d", "spi1d"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("spi3d", "spi3d"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("spimtx", "spimtx"));
-    OIIO_CHECK_ASSERT(FormatExtensionFoundByName("vf", "nukevf"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("3dl", "flame"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("3dl", "lustre"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("cc", "ColorCorrection"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("ccc", "ColorCorrectionCollection"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("cdl", "ColorDecisionList"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("clf", "Academy/ASC Common LUT Format"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("ctf", "Color Transform Format"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("csp", "cinespace"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("cub", "truelight"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("cube", "iridas_cube"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("cube", "resolve_cube"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("itx", "iridas_itx"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("icc", "International Color Consortium profile"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("icm", "International Color Consortium profile"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("look", "iridas_look"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("lut", "houdini"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("lut", "Discreet 1D LUT"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("m3d", "pandora_m3d"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("mga", "pandora_mga"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("spi1d", "spi1d"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("spi3d", "spi3d"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("spimtx", "spimtx"));
+    OCIO_CHECK_ASSERT(FormatExtensionFoundByName("vf", "nukevf"));
 }
 
 void ValidateFormatByIndex(OCIO::FormatRegistry &reg, int cap)
@@ -1015,34 +1015,34 @@ void ValidateFormatByIndex(OCIO::FormatRegistry &reg, int cap)
     int numFormat = reg.getNumFormats(cap);
 
     // Check out of bounds access
-    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatNameByIndex(cap, -1), ""));
-    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatExtensionByIndex(cap, -1), ""));
-    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatNameByIndex(cap, numFormat), ""));
-    OIIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatExtensionByIndex(cap, numFormat), ""));
+    OCIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatNameByIndex(cap, -1), ""));
+    OCIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatExtensionByIndex(cap, -1), ""));
+    OCIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatNameByIndex(cap, numFormat), ""));
+    OCIO_CHECK_EQUAL(0, OCIO::Platform::Strcasecmp(reg.getFormatExtensionByIndex(cap, numFormat), ""));
 
     // Check valid access
     for (int i = 0; i < numFormat; ++i) {
-        OIIO_CHECK_NE(0, OCIO::Platform::Strcasecmp(reg.getFormatNameByIndex(cap, i), ""));
-        OIIO_CHECK_NE(0, OCIO::Platform::Strcasecmp(reg.getFormatExtensionByIndex(cap, i), ""));
+        OCIO_CHECK_NE(0, OCIO::Platform::Strcasecmp(reg.getFormatNameByIndex(cap, i), ""));
+        OCIO_CHECK_NE(0, OCIO::Platform::Strcasecmp(reg.getFormatExtensionByIndex(cap, i), ""));
     }
 }
 
-OIIO_ADD_TEST(FileTransform, FormatByIndex)
+OCIO_ADD_TEST(FileTransform, FormatByIndex)
 {
     OCIO::FormatRegistry & formatRegistry = OCIO::FormatRegistry::GetInstance();
     ValidateFormatByIndex(formatRegistry, OCIO::FORMAT_CAPABILITY_WRITE);
     ValidateFormatByIndex(formatRegistry, OCIO::FORMAT_CAPABILITY_READ);
 }
 
-OIIO_ADD_TEST(FileTransform, Validate)
+OCIO_ADD_TEST(FileTransform, Validate)
 {
     OCIO::FileTransformRcPtr tr = OCIO::FileTransform::Create();
 
     tr->setSrc("lut3d_17x17x17_32f_12i.clf");
-    OIIO_CHECK_NO_THROW(tr->validate());
+    OCIO_CHECK_NO_THROW(tr->validate());
 
     tr->setSrc("");
-    OIIO_CHECK_THROW(tr->validate(), OCIO::Exception);
+    OCIO_CHECK_THROW(tr->validate(), OCIO::Exception);
 }
 
 

--- a/src/OpenColorIO/transforms/FixedFunctionTransform.cpp
+++ b/src/OpenColorIO/transforms/FixedFunctionTransform.cpp
@@ -312,47 +312,47 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 
 OCIO_NAMESPACE_USING
 
 
-OIIO_ADD_TEST(FixedFunctionTransform, basic)
+OCIO_ADD_TEST(FixedFunctionTransform, basic)
 {
     OCIO::FixedFunctionTransformRcPtr func = OCIO::FixedFunctionTransform::Create();
-    OIIO_CHECK_EQUAL(func->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(func->getStyle(), OCIO::FIXED_FUNCTION_ACES_RED_MOD_03);
-    OIIO_CHECK_EQUAL(func->getNumParams(), 0);
-    OIIO_CHECK_NO_THROW(func->validate());
+    OCIO_CHECK_EQUAL(func->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(func->getStyle(), OCIO::FIXED_FUNCTION_ACES_RED_MOD_03);
+    OCIO_CHECK_EQUAL(func->getNumParams(), 0);
+    OCIO_CHECK_NO_THROW(func->validate());
 
-    OIIO_CHECK_NO_THROW(func->setDirection(OCIO::TRANSFORM_DIR_INVERSE));
-    OIIO_CHECK_EQUAL(func->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(func->getNumParams(), 0);
-    OIIO_CHECK_NO_THROW(func->validate());
+    OCIO_CHECK_NO_THROW(func->setDirection(OCIO::TRANSFORM_DIR_INVERSE));
+    OCIO_CHECK_EQUAL(func->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(func->getNumParams(), 0);
+    OCIO_CHECK_NO_THROW(func->validate());
 
-    OIIO_CHECK_NO_THROW(func->setStyle(OCIO::FIXED_FUNCTION_ACES_RED_MOD_10));
-    OIIO_CHECK_EQUAL(func->getStyle(), OCIO::FIXED_FUNCTION_ACES_RED_MOD_10);
-    OIIO_CHECK_EQUAL(func->getNumParams(), 0);
-    OIIO_CHECK_NO_THROW(func->validate());
+    OCIO_CHECK_NO_THROW(func->setStyle(OCIO::FIXED_FUNCTION_ACES_RED_MOD_10));
+    OCIO_CHECK_EQUAL(func->getStyle(), OCIO::FIXED_FUNCTION_ACES_RED_MOD_10);
+    OCIO_CHECK_EQUAL(func->getNumParams(), 0);
+    OCIO_CHECK_NO_THROW(func->validate());
 
-    OIIO_CHECK_NO_THROW(func->setStyle(OCIO::FIXED_FUNCTION_REC2100_SURROUND));
-    OIIO_CHECK_THROW_WHAT(func->validate(), OCIO::Exception, 
+    OCIO_CHECK_NO_THROW(func->setStyle(OCIO::FIXED_FUNCTION_REC2100_SURROUND));
+    OCIO_CHECK_THROW_WHAT(func->validate(), OCIO::Exception, 
                           "The style 'REC2100_Surround' must have "
                           "one parameter but 0 found.");
 
-    OIIO_CHECK_EQUAL(func->getNumParams(), 0);
+    OCIO_CHECK_EQUAL(func->getNumParams(), 0);
     const double values[1] = { 1. };
-    OIIO_CHECK_NO_THROW(func->setParams(&values[0], 1));
-    OIIO_CHECK_EQUAL(func->getNumParams(), 1);
+    OCIO_CHECK_NO_THROW(func->setParams(&values[0], 1));
+    OCIO_CHECK_EQUAL(func->getNumParams(), 1);
     double results[1] = { 0. };
-    OIIO_CHECK_NO_THROW(func->getParams(&results[0]));
-    OIIO_CHECK_EQUAL(results[0], values[0]);
+    OCIO_CHECK_NO_THROW(func->getParams(&results[0]));
+    OCIO_CHECK_EQUAL(results[0], values[0]);
 
-    OIIO_CHECK_NO_THROW(func->validate());
+    OCIO_CHECK_NO_THROW(func->validate());
 
-    OIIO_CHECK_NO_THROW(func->setStyle(OCIO::FIXED_FUNCTION_ACES_DARK_TO_DIM_10));
-    OIIO_CHECK_THROW_WHAT(func->validate(), OCIO::Exception, 
+    OCIO_CHECK_NO_THROW(func->setStyle(OCIO::FIXED_FUNCTION_ACES_DARK_TO_DIM_10));
+    OCIO_CHECK_THROW_WHAT(func->validate(), OCIO::Exception, 
                           "The style 'ACES_DarkToDim10 (Forward)' must have "
                           "zero parameters but 1 found.");
 }

--- a/src/OpenColorIO/transforms/LogAffineTransform.cpp
+++ b/src/OpenColorIO/transforms/LogAffineTransform.cpp
@@ -224,64 +224,64 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 bool AllEqual(double (&values)[3])
 {
     return values[0] == values[1] && values[0] == values[2];
 }
 
-OIIO_ADD_TEST(LogAffineTransform, basic)
+OCIO_ADD_TEST(LogAffineTransform, basic)
 {
     const OCIO::LogAffineTransformRcPtr log = OCIO::LogAffineTransform::Create();
 
     const double base = log->getBase();
-    OIIO_CHECK_EQUAL(base, 2.0);
+    OCIO_CHECK_EQUAL(base, 2.0);
     double values[3];
     log->getLinSideOffsetValue(values);
-    OIIO_CHECK_ASSERT(AllEqual(values));
-    OIIO_CHECK_EQUAL(values[0], 0.0);
+    OCIO_CHECK_ASSERT(AllEqual(values));
+    OCIO_CHECK_EQUAL(values[0], 0.0);
     log->getLinSideSlopeValue(values);
-    OIIO_CHECK_ASSERT(AllEqual(values));
-    OIIO_CHECK_EQUAL(values[0], 1.0);
+    OCIO_CHECK_ASSERT(AllEqual(values));
+    OCIO_CHECK_EQUAL(values[0], 1.0);
     log->getLogSideOffsetValue(values);
-    OIIO_CHECK_ASSERT(AllEqual(values));
-    OIIO_CHECK_EQUAL(values[0], 0.0);
+    OCIO_CHECK_ASSERT(AllEqual(values));
+    OCIO_CHECK_EQUAL(values[0], 0.0);
     log->getLogSideSlopeValue(values);
-    OIIO_CHECK_ASSERT(AllEqual(values));
-    OIIO_CHECK_EQUAL(values[0], 1.0);
-    OIIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_ASSERT(AllEqual(values));
+    OCIO_CHECK_EQUAL(values[0], 1.0);
+    OCIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
 
     log->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
 
     log->setBase(3.0);
     log->getBase();
-    OIIO_CHECK_EQUAL(log->getBase(), 3.0);
+    OCIO_CHECK_EQUAL(log->getBase(), 3.0);
 
     log->setLinSideOffsetValue({ 0.1, 0.2, 0.3 });
     log->getLinSideOffsetValue(values);
-    OIIO_CHECK_EQUAL(values[0], 0.1);
-    OIIO_CHECK_EQUAL(values[1], 0.2);
-    OIIO_CHECK_EQUAL(values[2], 0.3);
+    OCIO_CHECK_EQUAL(values[0], 0.1);
+    OCIO_CHECK_EQUAL(values[1], 0.2);
+    OCIO_CHECK_EQUAL(values[2], 0.3);
 
     log->setLinSideSlopeValue({ 1.1, 1.2, 1.3 });
     log->getLinSideSlopeValue(values);
-    OIIO_CHECK_EQUAL(values[0], 1.1);
-    OIIO_CHECK_EQUAL(values[1], 1.2);
-    OIIO_CHECK_EQUAL(values[2], 1.3);
+    OCIO_CHECK_EQUAL(values[0], 1.1);
+    OCIO_CHECK_EQUAL(values[1], 1.2);
+    OCIO_CHECK_EQUAL(values[2], 1.3);
 
     log->setLogSideOffsetValue({ 0.1, 0.2, 0.3 });
     log->getLogSideOffsetValue(values);
-    OIIO_CHECK_EQUAL(values[0], 0.1);
-    OIIO_CHECK_EQUAL(values[1], 0.2);
-    OIIO_CHECK_EQUAL(values[2], 0.3);
+    OCIO_CHECK_EQUAL(values[0], 0.1);
+    OCIO_CHECK_EQUAL(values[1], 0.2);
+    OCIO_CHECK_EQUAL(values[2], 0.3);
 
     log->setLogSideSlopeValue({ 1.1, 1.2, 1.3 });
     log->getLogSideSlopeValue(values);
-    OIIO_CHECK_EQUAL(values[0], 1.1);
-    OIIO_CHECK_EQUAL(values[1], 1.2);
-    OIIO_CHECK_EQUAL(values[2], 1.3);
+    OCIO_CHECK_EQUAL(values[0], 1.1);
+    OCIO_CHECK_EQUAL(values[1], 1.2);
+    OCIO_CHECK_EQUAL(values[2], 1.3);
 }
 
 #endif

--- a/src/OpenColorIO/transforms/LogTransform.cpp
+++ b/src/OpenColorIO/transforms/LogTransform.cpp
@@ -168,20 +168,20 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(LogTransform, basic)
+OCIO_ADD_TEST(LogTransform, basic)
 {
     const OCIO::LogTransformRcPtr log = OCIO::LogTransform::Create();
 
-    OIIO_CHECK_EQUAL(log->getBase(), 2.0f);
-    OIIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(log->getBase(), 2.0f);
+    OCIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
 
     log->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(log->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
 
     log->setBase(10.0f);
-    OIIO_CHECK_EQUAL(log->getBase(), 10.0f);
+    OCIO_CHECK_EQUAL(log->getBase(), 10.0f);
 }
 
 #endif

--- a/src/OpenColorIO/transforms/MatrixTransform.cpp
+++ b/src/OpenColorIO/transforms/MatrixTransform.cpp
@@ -478,44 +478,44 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(MatrixTransform, basic)
+OCIO_ADD_TEST(MatrixTransform, basic)
 {
     OCIO::MatrixTransformRcPtr matrix = OCIO::MatrixTransform::Create();
-    OIIO_CHECK_EQUAL(matrix->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(matrix->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
     
     float m44[16];
     float offset4[4];
     matrix->getValue(m44, offset4);
 
-    OIIO_CHECK_EQUAL(m44[0], 1.0f);
-    OIIO_CHECK_EQUAL(m44[1], 0.0f);
-    OIIO_CHECK_EQUAL(m44[2], 0.0f);
-    OIIO_CHECK_EQUAL(m44[3], 0.0f);
+    OCIO_CHECK_EQUAL(m44[0], 1.0f);
+    OCIO_CHECK_EQUAL(m44[1], 0.0f);
+    OCIO_CHECK_EQUAL(m44[2], 0.0f);
+    OCIO_CHECK_EQUAL(m44[3], 0.0f);
     
-    OIIO_CHECK_EQUAL(m44[4], 0.0f);
-    OIIO_CHECK_EQUAL(m44[5], 1.0f);
-    OIIO_CHECK_EQUAL(m44[6], 0.0f);
-    OIIO_CHECK_EQUAL(m44[7], 0.0f);
+    OCIO_CHECK_EQUAL(m44[4], 0.0f);
+    OCIO_CHECK_EQUAL(m44[5], 1.0f);
+    OCIO_CHECK_EQUAL(m44[6], 0.0f);
+    OCIO_CHECK_EQUAL(m44[7], 0.0f);
     
-    OIIO_CHECK_EQUAL(m44[8], 0.0f);
-    OIIO_CHECK_EQUAL(m44[9], 0.0f);
-    OIIO_CHECK_EQUAL(m44[10], 1.0f);
-    OIIO_CHECK_EQUAL(m44[11], 0.0f);
+    OCIO_CHECK_EQUAL(m44[8], 0.0f);
+    OCIO_CHECK_EQUAL(m44[9], 0.0f);
+    OCIO_CHECK_EQUAL(m44[10], 1.0f);
+    OCIO_CHECK_EQUAL(m44[11], 0.0f);
     
-    OIIO_CHECK_EQUAL(m44[12], 0.0f);
-    OIIO_CHECK_EQUAL(m44[13], 0.0f);
-    OIIO_CHECK_EQUAL(m44[14], 0.0f);
-    OIIO_CHECK_EQUAL(m44[15], 1.0f);
+    OCIO_CHECK_EQUAL(m44[12], 0.0f);
+    OCIO_CHECK_EQUAL(m44[13], 0.0f);
+    OCIO_CHECK_EQUAL(m44[14], 0.0f);
+    OCIO_CHECK_EQUAL(m44[15], 1.0f);
 
-    OIIO_CHECK_EQUAL(offset4[0], 0.0f);
-    OIIO_CHECK_EQUAL(offset4[1], 0.0f);
-    OIIO_CHECK_EQUAL(offset4[2], 0.0f);
-    OIIO_CHECK_EQUAL(offset4[3], 0.0f);
+    OCIO_CHECK_EQUAL(offset4[0], 0.0f);
+    OCIO_CHECK_EQUAL(offset4[1], 0.0f);
+    OCIO_CHECK_EQUAL(offset4[2], 0.0f);
+    OCIO_CHECK_EQUAL(offset4[3], 0.0f);
 
     matrix->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(matrix->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(matrix->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
 
     m44[0]  = 1.0f;
     m44[1]  = 1.01f;
@@ -551,24 +551,24 @@ OIIO_ADD_TEST(MatrixTransform, basic)
 
     for (int i = 0; i < 16; ++i)
     {
-        OIIO_CHECK_EQUAL(m44r[i], m44[i]);
+        OCIO_CHECK_EQUAL(m44r[i], m44[i]);
     }
 
-    OIIO_CHECK_EQUAL(offset4r[0], 1.0f);
-    OIIO_CHECK_EQUAL(offset4r[1], 1.1f);
-    OIIO_CHECK_EQUAL(offset4r[2], 1.2f);
-    OIIO_CHECK_EQUAL(offset4r[3], 1.3f);
+    OCIO_CHECK_EQUAL(offset4r[0], 1.0f);
+    OCIO_CHECK_EQUAL(offset4r[1], 1.1f);
+    OCIO_CHECK_EQUAL(offset4r[2], 1.2f);
+    OCIO_CHECK_EQUAL(offset4r[3], 1.3f);
 }
 
-OIIO_ADD_TEST(MatrixTransform, equals)
+OCIO_ADD_TEST(MatrixTransform, equals)
 {
     OCIO::MatrixTransformRcPtr matrix1 = OCIO::MatrixTransform::Create();
     OCIO::MatrixTransformRcPtr matrix2 = OCIO::MatrixTransform::Create();
 
-    OIIO_CHECK_ASSERT(matrix1->equals(*matrix2));
+    OCIO_CHECK_ASSERT(matrix1->equals(*matrix2));
 
     matrix1->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_ASSERT(!matrix1->equals(*matrix2));
+    OCIO_CHECK_ASSERT(!matrix1->equals(*matrix2));
     matrix1->setDirection(OCIO::TRANSFORM_DIR_FORWARD);
 
     float m44[16];
@@ -576,13 +576,13 @@ OIIO_ADD_TEST(MatrixTransform, equals)
     matrix1->getValue(m44, offset4);
     m44[0] = 1.0f + 1e-6f;
     matrix1->setValue(m44, offset4);
-    OIIO_CHECK_ASSERT(!matrix1->equals(*matrix2));
+    OCIO_CHECK_ASSERT(!matrix1->equals(*matrix2));
     m44[0] = 1.0f;
     matrix1->setValue(m44, offset4);
 
     offset4[0] = 1e-6f;
     matrix1->setValue(m44, offset4);
-    OIIO_CHECK_ASSERT(!matrix1->equals(*matrix2));
+    OCIO_CHECK_ASSERT(!matrix1->equals(*matrix2));
 }
 
 #endif

--- a/src/OpenColorIO/transforms/RangeTransform.cpp
+++ b/src/OpenColorIO/transforms/RangeTransform.cpp
@@ -296,37 +296,37 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
 
 OCIO_NAMESPACE_USING
 
 
-OIIO_ADD_TEST(RangeTransform, basic)
+OCIO_ADD_TEST(RangeTransform, basic)
 {
     OCIO::RangeTransformRcPtr range = OCIO::RangeTransform::Create();
-    OIIO_CHECK_EQUAL(range->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(range->getStyle(), OCIO::RANGE_CLAMP);
-    OIIO_CHECK_ASSERT(!range->hasMinInValue());
-    OIIO_CHECK_ASSERT(!range->hasMaxInValue());
-    OIIO_CHECK_ASSERT(!range->hasMinOutValue());
-    OIIO_CHECK_ASSERT(!range->hasMaxOutValue());
+    OCIO_CHECK_EQUAL(range->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(range->getStyle(), OCIO::RANGE_CLAMP);
+    OCIO_CHECK_ASSERT(!range->hasMinInValue());
+    OCIO_CHECK_ASSERT(!range->hasMaxInValue());
+    OCIO_CHECK_ASSERT(!range->hasMinOutValue());
+    OCIO_CHECK_ASSERT(!range->hasMaxOutValue());
 
     range->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
-    OIIO_CHECK_EQUAL(range->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
+    OCIO_CHECK_EQUAL(range->getDirection(), OCIO::TRANSFORM_DIR_INVERSE);
 
     range->setStyle(OCIO::RANGE_NO_CLAMP);
-    OIIO_CHECK_EQUAL(range->getStyle(), OCIO::RANGE_NO_CLAMP);
+    OCIO_CHECK_EQUAL(range->getStyle(), OCIO::RANGE_NO_CLAMP);
 
     range->setMinInValue(-0.5f);
-    OIIO_CHECK_EQUAL(range->getMinInValue(), -0.5f);
-    OIIO_CHECK_ASSERT(range->hasMinInValue());
+    OCIO_CHECK_EQUAL(range->getMinInValue(), -0.5f);
+    OCIO_CHECK_ASSERT(range->hasMinInValue());
 
     OCIO::RangeTransformRcPtr range2 = OCIO::RangeTransform::Create();
     range2->setDirection(OCIO::TRANSFORM_DIR_INVERSE);
     range2->setMinInValue(-0.5f);
     range2->setStyle(OCIO::RANGE_NO_CLAMP);
-    OIIO_CHECK_ASSERT(range2->equals(*range));
+    OCIO_CHECK_ASSERT(range2->equals(*range));
 
     range2->setDirection(OCIO::TRANSFORM_DIR_FORWARD);
     range2->unsetMinInValue();
@@ -336,60 +336,60 @@ OIIO_ADD_TEST(RangeTransform, basic)
 
     // (Note that the transform would not validate at this point.)
 
-    OIIO_CHECK_ASSERT(!range2->hasMinInValue());
-    OIIO_CHECK_EQUAL(range2->getMaxInValue(), -0.5f);
-    OIIO_CHECK_EQUAL(range2->getMinOutValue(), 1.5f);
-    OIIO_CHECK_EQUAL(range2->getMaxOutValue(), 4.5f);
+    OCIO_CHECK_ASSERT(!range2->hasMinInValue());
+    OCIO_CHECK_EQUAL(range2->getMaxInValue(), -0.5f);
+    OCIO_CHECK_EQUAL(range2->getMinOutValue(), 1.5f);
+    OCIO_CHECK_EQUAL(range2->getMaxOutValue(), 4.5f);
 
     range2->setMinInValue(-1.5f);
-    OIIO_CHECK_EQUAL(range2->getMinInValue(), -1.5f);
-    OIIO_CHECK_EQUAL(range2->getMaxInValue(), -0.5f);
-    OIIO_CHECK_EQUAL(range2->getMinOutValue(), 1.5f);
-    OIIO_CHECK_EQUAL(range2->getMaxOutValue(), 4.5f);
+    OCIO_CHECK_EQUAL(range2->getMinInValue(), -1.5f);
+    OCIO_CHECK_EQUAL(range2->getMaxInValue(), -0.5f);
+    OCIO_CHECK_EQUAL(range2->getMinOutValue(), 1.5f);
+    OCIO_CHECK_EQUAL(range2->getMaxOutValue(), 4.5f);
 
-    OIIO_CHECK_ASSERT(range2->hasMinInValue());
-    OIIO_CHECK_ASSERT(range2->hasMaxInValue());
-    OIIO_CHECK_ASSERT(range2->hasMinOutValue());
-    OIIO_CHECK_ASSERT(range2->hasMaxOutValue());
+    OCIO_CHECK_ASSERT(range2->hasMinInValue());
+    OCIO_CHECK_ASSERT(range2->hasMaxInValue());
+    OCIO_CHECK_ASSERT(range2->hasMinOutValue());
+    OCIO_CHECK_ASSERT(range2->hasMaxOutValue());
 
     range2->unsetMinInValue();
-    OIIO_CHECK_ASSERT(!range2->hasMinInValue());
-    OIIO_CHECK_ASSERT(range2->hasMaxInValue());
-    OIIO_CHECK_ASSERT(range2->hasMinOutValue());
-    OIIO_CHECK_ASSERT(range2->hasMaxOutValue());
+    OCIO_CHECK_ASSERT(!range2->hasMinInValue());
+    OCIO_CHECK_ASSERT(range2->hasMaxInValue());
+    OCIO_CHECK_ASSERT(range2->hasMinOutValue());
+    OCIO_CHECK_ASSERT(range2->hasMaxOutValue());
 
     range2->unsetMaxInValue();
-    OIIO_CHECK_ASSERT(!range2->hasMinInValue());
-    OIIO_CHECK_ASSERT(!range2->hasMaxInValue());
-    OIIO_CHECK_ASSERT(range2->hasMinOutValue());
-    OIIO_CHECK_ASSERT(range2->hasMaxOutValue());
+    OCIO_CHECK_ASSERT(!range2->hasMinInValue());
+    OCIO_CHECK_ASSERT(!range2->hasMaxInValue());
+    OCIO_CHECK_ASSERT(range2->hasMinOutValue());
+    OCIO_CHECK_ASSERT(range2->hasMaxOutValue());
 
     range2->unsetMinOutValue();
-    OIIO_CHECK_ASSERT(!range2->hasMinInValue());
-    OIIO_CHECK_ASSERT(!range2->hasMaxInValue());
-    OIIO_CHECK_ASSERT(!range2->hasMinOutValue());
-    OIIO_CHECK_ASSERT(range2->hasMaxOutValue());
+    OCIO_CHECK_ASSERT(!range2->hasMinInValue());
+    OCIO_CHECK_ASSERT(!range2->hasMaxInValue());
+    OCIO_CHECK_ASSERT(!range2->hasMinOutValue());
+    OCIO_CHECK_ASSERT(range2->hasMaxOutValue());
 
     range2->unsetMaxOutValue();
-    OIIO_CHECK_ASSERT(!range2->hasMinInValue());
-    OIIO_CHECK_ASSERT(!range2->hasMaxInValue());
-    OIIO_CHECK_ASSERT(!range2->hasMinOutValue());
-    OIIO_CHECK_ASSERT(!range2->hasMaxOutValue());
+    OCIO_CHECK_ASSERT(!range2->hasMinInValue());
+    OCIO_CHECK_ASSERT(!range2->hasMaxInValue());
+    OCIO_CHECK_ASSERT(!range2->hasMinOutValue());
+    OCIO_CHECK_ASSERT(!range2->hasMaxOutValue());
 }
 
 
-OIIO_ADD_TEST(RangeTransform, no_clamp_converts_to_matrix)
+OCIO_ADD_TEST(RangeTransform, no_clamp_converts_to_matrix)
 {
     ConfigRcPtr config = Config::Create();
     OCIO::OpRcPtrVec ops;
 
     OCIO::RangeTransformRcPtr range = OCIO::RangeTransform::Create();
-    OIIO_CHECK_EQUAL(range->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
-    OIIO_CHECK_EQUAL(range->getStyle(), OCIO::RANGE_CLAMP);
-    OIIO_CHECK_ASSERT(!range->hasMinInValue());
-    OIIO_CHECK_ASSERT(!range->hasMaxInValue());
-    OIIO_CHECK_ASSERT(!range->hasMinOutValue());
-    OIIO_CHECK_ASSERT(!range->hasMaxOutValue());
+    OCIO_CHECK_EQUAL(range->getDirection(), OCIO::TRANSFORM_DIR_FORWARD);
+    OCIO_CHECK_EQUAL(range->getStyle(), OCIO::RANGE_CLAMP);
+    OCIO_CHECK_ASSERT(!range->hasMinInValue());
+    OCIO_CHECK_ASSERT(!range->hasMaxInValue());
+    OCIO_CHECK_ASSERT(!range->hasMinOutValue());
+    OCIO_CHECK_ASSERT(!range->hasMaxOutValue());
 
     range->setMinInValue(0.0f);
     range->setMaxInValue(0.5f);
@@ -398,50 +398,50 @@ OIIO_ADD_TEST(RangeTransform, no_clamp_converts_to_matrix)
 
     // Test the resulting Range Op
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         BuildRangeOps(ops, *config, *range, OCIO::TRANSFORM_DIR_FORWARD) );
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 1);
+    OCIO_REQUIRE_EQUAL(ops.size(), 1);
     OCIO::ConstOpRcPtr op0 = ops[0];
-    OIIO_REQUIRE_EQUAL(op0->data()->getType(), OCIO::OpData::RangeType);
+    OCIO_REQUIRE_EQUAL(op0->data()->getType(), OCIO::OpData::RangeType);
 
     OCIO::ConstRangeOpDataRcPtr rangeData
         = DynamicPtrCast<const OCIO::RangeOpData>(op0->data());
 
-    OIIO_CHECK_EQUAL(rangeData->getMinInValue(), range->getMinInValue());
-    OIIO_CHECK_EQUAL(rangeData->getMaxInValue(), range->getMaxInValue());
-    OIIO_CHECK_EQUAL(rangeData->getMinOutValue(), range->getMinOutValue());
-    OIIO_CHECK_EQUAL(rangeData->getMaxOutValue(), range->getMaxOutValue());
+    OCIO_CHECK_EQUAL(rangeData->getMinInValue(), range->getMinInValue());
+    OCIO_CHECK_EQUAL(rangeData->getMaxInValue(), range->getMaxInValue());
+    OCIO_CHECK_EQUAL(rangeData->getMinOutValue(), range->getMinOutValue());
+    OCIO_CHECK_EQUAL(rangeData->getMaxOutValue(), range->getMaxOutValue());
 
     // Test the resulting Matrix Op
 
     range->setStyle(OCIO::RANGE_NO_CLAMP);
 
-    OIIO_CHECK_NO_THROW(
+    OCIO_CHECK_NO_THROW(
         BuildRangeOps(ops, *config, *range, OCIO::TRANSFORM_DIR_FORWARD) );
 
-    OIIO_REQUIRE_EQUAL(ops.size(), 2);
+    OCIO_REQUIRE_EQUAL(ops.size(), 2);
     OCIO::ConstOpRcPtr op1 = ops[1];
-    OIIO_REQUIRE_EQUAL(op1->data()->getType(), OCIO::OpData::MatrixType);
+    OCIO_REQUIRE_EQUAL(op1->data()->getType(), OCIO::OpData::MatrixType);
 
     OCIO::ConstMatrixOpDataRcPtr matrixData
         = DynamicPtrCast<const OCIO::MatrixOpData>(op1->data());
 
-    OIIO_CHECK_EQUAL(matrixData->getOffsetValue(0), rangeData->getOffset());
+    OCIO_CHECK_EQUAL(matrixData->getOffsetValue(0), rangeData->getOffset());
 
-    OIIO_CHECK_EQUAL(matrixData->getOffsetValue(0), 0.5);
-    OIIO_CHECK_EQUAL(matrixData->getOffsetValue(1), 0.5);
-    OIIO_CHECK_EQUAL(matrixData->getOffsetValue(2), 0.5);
-    OIIO_CHECK_EQUAL(matrixData->getOffsetValue(3), 0.0);
+    OCIO_CHECK_EQUAL(matrixData->getOffsetValue(0), 0.5);
+    OCIO_CHECK_EQUAL(matrixData->getOffsetValue(1), 0.5);
+    OCIO_CHECK_EQUAL(matrixData->getOffsetValue(2), 0.5);
+    OCIO_CHECK_EQUAL(matrixData->getOffsetValue(3), 0.0);
 
-    OIIO_CHECK_ASSERT(matrixData->isDiagonal());
+    OCIO_CHECK_ASSERT(matrixData->isDiagonal());
 
-    OIIO_CHECK_EQUAL(matrixData->getArray()[0], rangeData->getScale());
+    OCIO_CHECK_EQUAL(matrixData->getArray()[0], rangeData->getScale());
 
-    OIIO_CHECK_EQUAL(matrixData->getArray()[ 0], 2.0);
-    OIIO_CHECK_EQUAL(matrixData->getArray()[ 5], 2.0);
-    OIIO_CHECK_EQUAL(matrixData->getArray()[10], 2.0);
-    OIIO_CHECK_EQUAL(matrixData->getArray()[15], 1.0);
+    OCIO_CHECK_EQUAL(matrixData->getArray()[ 0], 2.0);
+    OCIO_CHECK_EQUAL(matrixData->getArray()[ 5], 2.0);
+    OCIO_CHECK_EQUAL(matrixData->getArray()[10], 2.0);
+    OCIO_CHECK_EQUAL(matrixData->getArray()[15], 1.0);
 }
 
 #endif

--- a/src/OpenColorIO/transforms/TruelightTransform.cpp
+++ b/src/OpenColorIO/transforms/TruelightTransform.cpp
@@ -372,9 +372,9 @@ OCIO_ADD_TEST(TruelightTransform, simpletest)
     
     
     std::vector<std::string> osvec;
-    pystring::splitlines(os.str(), osvec);
+    OCIO::pystring::splitlines(os.str(), osvec);
     std::vector<std::string> referenceconfigvec;
-    pystring::splitlines(referenceconfig, referenceconfigvec);
+    OCIO::pystring::splitlines(referenceconfig, referenceconfigvec);
     
     OCIO_CHECK_EQUAL(osvec.size(), referenceconfigvec.size());
     for(unsigned int i = 0; i < referenceconfigvec.size(); ++i)

--- a/src/OpenColorIO/transforms/TruelightTransform.cpp
+++ b/src/OpenColorIO/transforms/TruelightTransform.cpp
@@ -284,9 +284,9 @@ OCIO_NAMESPACE_EXIT
 #ifdef OCIO_UNIT_TEST
 
 namespace OCIO = OCIO_NAMESPACE;
-#include "unittest.h"
+#include "UnitTest.h"
 
-OIIO_ADD_TEST(TruelightTransform, simpletest)
+OCIO_ADD_TEST(TruelightTransform, simpletest)
 {
     
     OCIO::ConfigRcPtr config = OCIO::Config::Create();
@@ -316,25 +316,25 @@ OIIO_ADD_TEST(TruelightTransform, simpletest)
     OCIO::ConstProcessorRcPtr tolog;
     
 #ifdef OCIO_TRUELIGHT_SUPPORT
-    OIIO_CHECK_NO_THROW(tosrgb = config->getProcessor("log", "sRGB"));
-    OIIO_CHECK_NO_THROW(tolog = config->getProcessor("sRGB", "log"));
+    OCIO_CHECK_NO_THROW(tosrgb = config->getProcessor("log", "sRGB"));
+    OCIO_CHECK_NO_THROW(tolog = config->getProcessor("sRGB", "log"));
 #else
-    OIIO_CHECK_THROW(tosrgb = config->getProcessor("log", "sRGB"), OCIO::Exception);
-    OIIO_CHECK_THROW(tolog = config->getProcessor("sRGB", "log"), OCIO::Exception);
+    OCIO_CHECK_THROW(tosrgb = config->getProcessor("log", "sRGB"), OCIO::Exception);
+    OCIO_CHECK_THROW(tolog = config->getProcessor("sRGB", "log"), OCIO::Exception);
 #endif
     
 #ifdef OCIO_TRUELIGHT_SUPPORT
     float input[3] = {0.5f, 0.5f, 0.5f};
     float output[3] = {0.500098f, 0.500317f, 0.501134f};
-    OIIO_CHECK_NO_THROW(tosrgb->applyRGB(input));
-    OIIO_CHECK_NO_THROW(tolog->applyRGB(input));
-    OIIO_CHECK_CLOSE(input[0], output[0], 1e-4);
-    OIIO_CHECK_CLOSE(input[1], output[1], 1e-4);
-    OIIO_CHECK_CLOSE(input[2], output[2], 1e-4);
+    OCIO_CHECK_NO_THROW(tosrgb->applyRGB(input));
+    OCIO_CHECK_NO_THROW(tolog->applyRGB(input));
+    OCIO_CHECK_CLOSE(input[0], output[0], 1e-4);
+    OCIO_CHECK_CLOSE(input[1], output[1], 1e-4);
+    OCIO_CHECK_CLOSE(input[2], output[2], 1e-4);
 #endif
     
     std::ostringstream os;
-    OIIO_CHECK_NO_THROW(config->serialize(os));
+    OCIO_CHECK_NO_THROW(config->serialize(os));
     
     std::string referenceconfig =
     "ocio_profile_version: 1\n"
@@ -372,18 +372,18 @@ OIIO_ADD_TEST(TruelightTransform, simpletest)
     
     
     std::vector<std::string> osvec;
-    OCIO::pystring::splitlines(os.str(), osvec);
+    pystring::splitlines(os.str(), osvec);
     std::vector<std::string> referenceconfigvec;
-    OCIO::pystring::splitlines(referenceconfig, referenceconfigvec);
+    pystring::splitlines(referenceconfig, referenceconfigvec);
     
-    OIIO_CHECK_EQUAL(osvec.size(), referenceconfigvec.size());
+    OCIO_CHECK_EQUAL(osvec.size(), referenceconfigvec.size());
     for(unsigned int i = 0; i < referenceconfigvec.size(); ++i)
-        OIIO_CHECK_EQUAL(osvec[i], referenceconfigvec[i]);
+        OCIO_CHECK_EQUAL(osvec[i], referenceconfigvec[i]);
     
     std::istringstream is;
     is.str(referenceconfig);
     OCIO::ConstConfigRcPtr rtconfig;
-    OIIO_CHECK_NO_THROW(rtconfig = OCIO::Config::CreateFromStream(is));
+    OCIO_CHECK_NO_THROW(rtconfig = OCIO::Config::CreateFromStream(is));
     
 }
 

--- a/src/apps/apputils/argparse.cpp
+++ b/src/apps/apputils/argparse.cpp
@@ -42,11 +42,6 @@
 #include "strutil.h"
 #include "argparse.h"
 
-/*
-OIIO_NAMESPACE_ENTER
-{
-*/
-
 class ArgOption {
 public:
     typedef int (*callback_t) (int, const char**);
@@ -527,10 +522,3 @@ ArgParse::command_line () const
     }
     return s;
 }
-
-
-/*
-}
-OIIO_NAMESPACE_EXIT
-*/
-

--- a/src/apps/apputils/argparse.h
+++ b/src/apps/apputils/argparse.h
@@ -47,11 +47,6 @@
         __attribute__ ((format (printf, fmtarg_pos, vararg_pos) ))
 #endif
 
-/*
-OIIO_NAMESPACE_ENTER
-{
-*/
-
 class ArgOption;   // Forward declaration
 
 
@@ -173,10 +168,5 @@ private:
     void error (const char *format, ...) OPENCOLORIO_PRINTF_ARGS(2,3);
     int found (const char *option);      // number of times option was parsed
 };
-
-/*
-}
-OIIO_NAMESPACE_EXIT
-*/
 
 #endif // OPENCOLORIO_ARGPARSE_H

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -20,7 +20,6 @@ function(add_ocio_test NAME SOURCES PRIVATE_INCLUDES)
 			yamlcpp
 			pystring
 			sampleicc
-			oiio_unittest
 			unittest_data
 			libexpat
 			ilmbase

--- a/tests/gpu/ECOps_test.cpp
+++ b/tests/gpu/ECOps_test.cpp
@@ -212,7 +212,7 @@ OCIO_ADD_GPU_TEST(ExposureContrast, style_linear_dynamic_parameter)
 
 void Prepare2ECDynamic(OCIOGPUTest & test, bool firstDyn, bool secondDyn)
 {
-    // See also OIIO_ADD_TEST(ExposureContrastTransform, processor_several_ec).
+    // See also OCIO_ADD_TEST(ExposureContrastTransform, processor_several_ec).
     OCIO::ExposureContrastTransformRcPtr ec1 = OCIO::ExposureContrastTransform::Create();
     ec1->setStyle(OCIO::EXPOSURE_CONTRAST_LOGARITHMIC);
 


### PR DESCRIPTION
As part of the larger effort of cleaning out ext/, this PR moves ext/oiio/src/include/unittest.h to src/OpenColorIO/UnitTest.h and renames all macros and functions from OIIO_ to OCIO_. A few other stray OIIO references are also resolved.

Amidst the mass rename, there is a related fix preventing a -Wmaybe-uninitialized compiler warning that appeared. That change is to the `ExposureContrastOpData.cpp` `style` test.

This PR will have merge conflicts with #771 which I will resolve between their merges.