### PR TITLE
Fix Azure Windows CI Python failure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,23 +146,38 @@ jobs:
         agentImage: 'vs2017-win2016'
         buildSharedLibs: ON
         buildDocs: ON
+        installPython: false
       2016 MSVC 14.16 (Static):
         agentImage: 'vs2017-win2016'
         buildSharedLibs: OFF
         buildDocs: OFF
+        installPython: false
       2012 MSVC 14.0:
         agentImage: 'vs2015-win2012r2'
         buildSharedLibs: ON
         buildDocs: ON
+        installPython: true
   pool:
     vmImage: $(agentImage)
 
   steps:
   - template: share/ci/templates/checkout.yml
   - powershell: |
+      share/ci/scripts/windows/install_cmake.ps1 3.11.0
+    displayName: Install CMake
+
+  - powershell: |
       share/ci/scripts/windows/install_python.ps1 2.7.16
-      share/ci/scripts/windows/install_cmake.ps1 3.14.4
-    displayName: Install dependencies
+    displayName: Install Python
+    condition: and(succeeded(), eq(variables['installPython'], 'true'))
+
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '2.7'
+      addToPath: true
+      architecture: 'x64'
+    displayName: Configure Python
+    condition: and(succeeded(), eq(variables['installPython'], 'false'))
 
   - template: share/ci/templates/configure.yml
     parameters:


### PR DESCRIPTION
This fix is pulled from #771 and should correct the Windows CI failures occurring since the agent bumped it's Python version last week.