### PR TITLE
update to Cmake 3.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.11)
 
 project(OpenColorIO 
 	VERSION 2.0.0


### PR DESCRIPTION
As suggested in https://github.com/imageworks/OpenColorIO/pull/776#issuecomment-514502914: 
> Noting that PR #771 bumps the minimum CMake version to 3.11, which is the current minimum of OpenEXR 2.3.0 (that OCIO uses Half from).
