### PR TITLE
CI branch cleanup RB-1.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,7 @@
+branches:
+  only:
+    - /^RB-.*$/
+
 version: '{branch}-{build}'
 image: Visual Studio 2013
 clone_folder: C:\source\ocio

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 # travis-ci.org build file
 # https://docs.travis-ci.com/user/languages/cpp
 
+branches:
+  only:
+    - /^RB-.*$/
+
 matrix:
   include:
     - os: linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,18 @@ if(NOT DEFINED CMAKE_FIRST_RUN)
 endif()
 
 ###############################################################################
+### C++ configuration ###
+
+if(CMAKE_CXX_STANDARD AND NOT CMAKE_CXX_STANDARD EQUAL 98)
+    message(WARNING " CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD} is not officially supported. Use 98 for full support.")
+elseif(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 98)
+endif()
+
+# Disable fallback to other C++ version if standard is not supported.
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+###############################################################################
 ### GLOBAL ###
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -330,7 +330,7 @@ OCIO_NAMESPACE_ENTER
                 sanitytext_ = rhs.sanitytext_;
                 
                 cacheids_ = rhs.cacheids_;
-                cacheidnocontext_ = cacheidnocontext_;
+                cacheidnocontext_ = rhs.cacheidnocontext_;
             }
             return *this;
         }

--- a/src/pyglue/PyAllocationTransform.cpp
+++ b/src/pyglue/PyAllocationTransform.cpp
@@ -53,7 +53,6 @@ OCIO_NAMESPACE_ENTER
         ///
         
         int PyOCIO_AllocationTransform_init(PyOCIO_Transform * self, PyObject * args, PyObject * kwds);
-        PyObject * PyOCIO_AllocationTransform_equals(PyObject * self,  PyObject * args);
         PyObject * PyOCIO_AllocationTransform_getAllocation(PyObject * self);
         PyObject * PyOCIO_AllocationTransform_setAllocation(PyObject * self,  PyObject * args);
         PyObject * PyOCIO_AllocationTransform_getNumVars(PyObject * self);


### PR DESCRIPTION
RB-1.1 counterpart to #797 . Note: The branch filter is here more to communicate intent than out of technical necessity.

Update:
Fixed a self-assign-field warning breaking the Linux build in Travis, which has already been done in master.