### PR TITLE
Backport support for GLSL 4.0 to the v1.1 branch

### DIFF
--- a/export/OpenColorIO/OpenColorTypes.h
+++ b/export/OpenColorIO/OpenColorTypes.h
@@ -263,7 +263,8 @@ OCIO_NAMESPACE_ENTER
         GPU_LANGUAGE_UNKNOWN = 0,
         GPU_LANGUAGE_CG,           ///< Nvidia Cg shader
         GPU_LANGUAGE_GLSL_1_0,     ///< OpenGL Shading Language
-        GPU_LANGUAGE_GLSL_1_3      ///< OpenGL Shading Language
+        GPU_LANGUAGE_GLSL_1_3,     ///< OpenGL Shading Language
+        GPU_LANGUAGE_GLSL_4_0      ///< OpenGL Shading Language
     };
     
     //!cpp:type::

--- a/src/core/GpuShaderUtils.cpp
+++ b/src/core/GpuShaderUtils.cpp
@@ -48,7 +48,7 @@ OCIO_NAMESPACE_ENTER
             }
             os << ")";
         }
-        else if(lang == GPU_LANGUAGE_GLSL_1_0 || lang == GPU_LANGUAGE_GLSL_1_3)
+        else if(lang == GPU_LANGUAGE_GLSL_1_0 || lang == GPU_LANGUAGE_GLSL_1_3 || lang == GPU_LANGUAGE_GLSL_4_0)
         {
             os << "mat4(";
             for(int i=0; i<16; i++)
@@ -76,7 +76,7 @@ OCIO_NAMESPACE_ENTER
             }
             os << ")";
         }
-        else if(lang == GPU_LANGUAGE_GLSL_1_0 || lang == GPU_LANGUAGE_GLSL_1_3)
+        else if(lang == GPU_LANGUAGE_GLSL_1_0 || lang == GPU_LANGUAGE_GLSL_1_3 || lang == GPU_LANGUAGE_GLSL_4_0)
         {
             os << "vec4(";
             for(int i=0; i<4; i++)
@@ -104,7 +104,7 @@ OCIO_NAMESPACE_ENTER
             }
             os << ")";
         }
-        else if(lang == GPU_LANGUAGE_GLSL_1_0 || lang == GPU_LANGUAGE_GLSL_1_3)
+        else if(lang == GPU_LANGUAGE_GLSL_1_0 || lang == GPU_LANGUAGE_GLSL_1_3 || lang == GPU_LANGUAGE_GLSL_4_0)
         {
             os << "vec3(";
             for(int i=0; i<3; i++)
@@ -153,7 +153,7 @@ OCIO_NAMESPACE_ENTER
         {
             os << "mul( " << mtx << ", " << vec << ")";
         }
-        else if(lang == GPU_LANGUAGE_GLSL_1_0 || lang == GPU_LANGUAGE_GLSL_1_3)
+        else if(lang == GPU_LANGUAGE_GLSL_1_0 || lang == GPU_LANGUAGE_GLSL_1_3 || lang == GPU_LANGUAGE_GLSL_4_0)
         {
             os << vec << " * " << mtx;
         }
@@ -180,6 +180,12 @@ OCIO_NAMESPACE_ENTER
         else if(lang == GPU_LANGUAGE_GLSL_1_0 || lang == GPU_LANGUAGE_GLSL_1_3)
         {
             os << "texture3D(";
+            os << lutName << ", ";
+            os << m << " * " << variableName << ".rgb + " << b << ").rgb;" << std::endl;
+        }
+        else if(lang == GPU_LANGUAGE_GLSL_4_0)
+        {
+            os << "texture(";
             os << lutName << ", ";
             os << m << " * " << variableName << ".rgb + " << b << ").rgb;" << std::endl;
         }

--- a/src/core/ParseUtils.cpp
+++ b/src/core/ParseUtils.cpp
@@ -207,6 +207,7 @@ OCIO_NAMESPACE_ENTER
         if(language == GPU_LANGUAGE_CG) return "cg";
         else if(language == GPU_LANGUAGE_GLSL_1_0) return "glsl_1.0";
         else if(language == GPU_LANGUAGE_GLSL_1_3) return "glsl_1.3";
+        else if(language == GPU_LANGUAGE_GLSL_4_0) return "glsl_4.0";
         return "unknown";
     }
     
@@ -216,6 +217,7 @@ OCIO_NAMESPACE_ENTER
         if(str == "cg") return GPU_LANGUAGE_CG;
         else if(str == "glsl_1.0") return GPU_LANGUAGE_GLSL_1_0;
         else if(str == "glsl_1.3") return GPU_LANGUAGE_GLSL_1_3;
+        else if(str == "glsl_4.0") return GPU_LANGUAGE_GLSL_4_0;
         return GPU_LANGUAGE_UNKNOWN;
     }
     

--- a/src/core/Processor.cpp
+++ b/src/core/Processor.cpp
@@ -241,7 +241,7 @@ OCIO_NAMESPACE_ENTER
                 shader << "vec4 " << fcnName << "(vec4 inPixel, \n";
                 shader << "    sampler3D " << lut3dName << ") \n";
             }
-            else if(lang == GPU_LANGUAGE_GLSL_1_3)
+            else if(lang == GPU_LANGUAGE_GLSL_1_3 || lang == GPU_LANGUAGE_GLSL_4_0)
             {
                 shader << "vec4 " << fcnName << "(in vec4 inPixel, \n";
                 shader << "    const sampler3D " << lut3dName << ") \n";
@@ -254,7 +254,7 @@ OCIO_NAMESPACE_ENTER
             {
                 shader << "half4 " << pixelName << " = inPixel; \n";
             }
-            else if(lang == GPU_LANGUAGE_GLSL_1_0 || lang == GPU_LANGUAGE_GLSL_1_3)
+            else if(lang == GPU_LANGUAGE_GLSL_1_0 || lang == GPU_LANGUAGE_GLSL_1_3 || lang == GPU_LANGUAGE_GLSL_4_0)
             {
                 shader << "vec4 " << pixelName << " = inPixel; \n";
             }

--- a/src/jniglue/org/OpenColorIO/GpuLanguage.java
+++ b/src/jniglue/org/OpenColorIO/GpuLanguage.java
@@ -43,4 +43,6 @@ public class GpuLanguage extends LoadLibrary
       GPU_LANGUAGE_GLSL_1_0 = new GpuLanguage(2);
     public static final GpuLanguage
       GPU_LANGUAGE_GLSL_1_3 = new GpuLanguage(3);
+    public static final GpuLanguage
+      GPU_LANGUAGE_GLSL_4_0 = new GpuLanguage(4);
 }

--- a/src/jniglue/tests/org/OpenColorIO/GlobalsTest.java
+++ b/src/jniglue/tests/org/OpenColorIO/GlobalsTest.java
@@ -133,6 +133,8 @@ public class GlobalsTest extends TestCase {
         assertEquals(globals.GpuLanguageFromString("glsl_1.0"), GpuLanguage.GPU_LANGUAGE_GLSL_1_0);
         assertEquals(globals.GpuLanguageToString(GpuLanguage.GPU_LANGUAGE_GLSL_1_3), "glsl_1.3");
         assertEquals(globals.GpuLanguageFromString("glsl_1.3"), GpuLanguage.GPU_LANGUAGE_GLSL_1_3);
+        assertEquals(globals.GpuLanguageToString(GpuLanguage.GPU_LANGUAGE_GLSL_4_0), "glsl_4.0");
+        assertEquals(globals.GpuLanguageFromString("glsl_4.0"), GpuLanguage.GPU_LANGUAGE_GLSL_4_0);
         
         // EnvironmentMode
         assertEquals(globals.EnvironmentModeToString(EnvironmentMode.ENV_ENVIRONMENT_UNKNOWN), "unknown");

--- a/src/jniglue/tests/org/OpenColorIO/GpuShaderDescTest.java
+++ b/src/jniglue/tests/org/OpenColorIO/GpuShaderDescTest.java
@@ -12,13 +12,23 @@ public class GpuShaderDescTest extends TestCase {
     
     public void test_interface() {
         GpuShaderDesc desc = new GpuShaderDesc();
-        desc.setLanguage(GpuLanguage.GPU_LANGUAGE_GLSL_1_3);
-        assertEquals(GpuLanguage.GPU_LANGUAGE_GLSL_1_3, desc.getLanguage());
+
         desc.setFunctionName("foo123");
         assertEquals("foo123", desc.getFunctionName());
         desc.setLut3DEdgeLen(32);
         assertEquals(32, desc.getLut3DEdgeLen());
+
+        desc.setLanguage(GpuLanguage.GPU_LANGUAGE_GLSL_1_0);
+        assertEquals(GpuLanguage.GPU_LANGUAGE_GLSL_1_0, desc.getLanguage());
+        assertEquals("glsl_1.0 foo123 32", desc.getCacheID());
+
+        desc.setLanguage(GpuLanguage.GPU_LANGUAGE_GLSL_1_3);
+        assertEquals(GpuLanguage.GPU_LANGUAGE_GLSL_1_3, desc.getLanguage());
         assertEquals("glsl_1.3 foo123 32", desc.getCacheID());
+
+        desc.setLanguage(GpuLanguage.GPU_LANGUAGE_GLSL_4_0);
+        assertEquals(GpuLanguage.GPU_LANGUAGE_GLSL_4_0, desc.getLanguage());
+        assertEquals("glsl_4.0 foo123 32", desc.getCacheID());
     }
     
 }

--- a/src/pyglue/PyConstants.cpp
+++ b/src/pyglue/PyConstants.cpp
@@ -148,6 +148,8 @@ OCIO_NAMESPACE_ENTER
             const_cast<char*>(GpuLanguageToString(GPU_LANGUAGE_GLSL_1_0)));
         PyModule_AddStringConstant(m, "GPU_LANGUAGE_GLSL_1_3",
             const_cast<char*>(GpuLanguageToString(GPU_LANGUAGE_GLSL_1_3)));
+        PyModule_AddStringConstant(m, "GPU_LANGUAGE_GLSL_4_0",
+            const_cast<char*>(GpuLanguageToString(GPU_LANGUAGE_GLSL_4_0)));
         
         PyModule_AddStringConstant(m, "ENV_ENVIRONMENT_UNKNOWN",
             const_cast<char*>(EnvironmentModeToString(ENV_ENVIRONMENT_UNKNOWN)));

--- a/src/pyglue/tests/ConstantsTest.py
+++ b/src/pyglue/tests/ConstantsTest.py
@@ -58,6 +58,7 @@ class ConstantsTest(unittest.TestCase):
         self.assertEqual(OCIO.Constants.GPU_LANGUAGE_CG, "cg")
         self.assertEqual(OCIO.Constants.GPU_LANGUAGE_GLSL_1_0, "glsl_1.0")
         self.assertEqual(OCIO.Constants.GPU_LANGUAGE_GLSL_1_3, "glsl_1.3")
+        self.assertEqual(OCIO.Constants.GPU_LANGUAGE_GLSL_4_0, "glsl_4.0")
         
         # EnvironmentMode
         self.assertEqual(OCIO.Constants.ENV_ENVIRONMENT_UNKNOWN, "unknown")

--- a/src/pyglue/tests/GpuShaderDescTest.py
+++ b/src/pyglue/tests/GpuShaderDescTest.py
@@ -7,11 +7,21 @@ class GpuShaderDescTest(unittest.TestCase):
     
     def test_interface(self):
         desc = OCIO.GpuShaderDesc()
-        desc.setLanguage(OCIO.Constants.GPU_LANGUAGE_GLSL_1_3)
-        self.assertEqual(OCIO.Constants.GPU_LANGUAGE_GLSL_1_3, desc.getLanguage())
+
         desc.setFunctionName("foo123")
         self.assertEqual("foo123", desc.getFunctionName())
         desc.setLut3DEdgeLen(32)
         self.assertEqual(32, desc.getLut3DEdgeLen())
+
+        desc.setLanguage(OCIO.Constants.GPU_LANGUAGE_GLSL_1_0)
+        self.assertEqual(OCIO.Constants.GPU_LANGUAGE_GLSL_1_0, desc.getLanguage())
+        self.assertEqual("glsl_1.0 foo123 32", desc.getCacheID())
+
+        desc.setLanguage(OCIO.Constants.GPU_LANGUAGE_GLSL_1_3)
+        self.assertEqual(OCIO.Constants.GPU_LANGUAGE_GLSL_1_3, desc.getLanguage())
         self.assertEqual("glsl_1.3 foo123 32", desc.getCacheID())
+
+        desc.setLanguage(OCIO.Constants.GPU_LANGUAGE_GLSL_4_0)
+        self.assertEqual(OCIO.Constants.GPU_LANGUAGE_GLSL_4_0, desc.getLanguage())
+        self.assertEqual("glsl_4.0 foo123 32", desc.getCacheID())
 


### PR DESCRIPTION
The VFX Reference Platform recommends the use of OpenColorIO 1.1.x through CY2020. However, OpenColorIO 1.1.x doesn't support versions of GLSL above 1.3 where support for the `texture3d` function (replaced by `texture`) has been removed. In order to address this, I've backported GPU_LANGUAGE_GLSL_4_0 to the v1.1 branch. This effectively changes `texture3d` -> `texture` for that particular case allowing OCIO v1.1.x to generate a fragment shader that is compatible with GLSL 4.