### PR TITLE
Address two warnings in GCC 8/9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,10 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     # Enable a bunch of compiler warnings...
     # http://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wshadow -Wconversion -Wcast-qual -Wformat=2")
+    # GCC 8 and above has a new heuristic to detect invalid pointer
+    # casts. However, this results in false positives on the Python
+    # C API which we compile against to generate Python bindings.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-cast-function-type")
     # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
 endif(CMAKE_COMPILER_IS_GNUCXX)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,10 +148,6 @@ if(CMAKE_COMPILER_IS_GNUCXX)
     # Enable a bunch of compiler warnings...
     # http://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wshadow -Wconversion -Wcast-qual -Wformat=2")
-    # GCC 8 and above has a new heuristic to detect invalid pointer
-    # casts. However, this results in false positives on the Python
-    # C API which we compile against to generate Python bindings.
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-cast-function-type")
     # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic")
 endif(CMAKE_COMPILER_IS_GNUCXX)
 

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -1915,9 +1915,13 @@ OIIO_ADD_TEST(Config, EnvCheck)
     "  - !<View> {name: Raw, colorspace: raw}\n"
     "\n";
     
-    
+#ifdef WINDOWS
+    _putenv_s("SHOW", "bar");
+    _putenv_s("TASK", "lighting");
+#else
     setenv("SHOW", "bar", 1);
     setenv("TASK", "lighting", 1);
+#endif
     
     std::istringstream is;
     is.str(SIMPLE_PROFILE);
@@ -2038,7 +2042,11 @@ OIIO_ADD_TEST(Config, Env_colorspace_name)
     }
 
     {
+#ifdef WINDOWS
+        _putenv_s("CAMERARAW", "lnh");
+#else
         setenv("CAMERARAW", "lnh", 1);
+#endif
 
         std::istringstream is;
         is.str(MY_OCIO_CONFIG);
@@ -2051,8 +2059,11 @@ OIIO_ADD_TEST(Config, Env_colorspace_name)
 
     {
         // Test when the env. variable content is wrong
-
+#ifdef WINDOWS
+        _putenv_s("CAMERARAW", "FaultyColorSpaceName");
+#else
         setenv("CAMERARAW", "FaultyColorSpaceName", 1);
+#endif
 
         std::istringstream is;
         is.str(MY_OCIO_CONFIG);

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -1915,13 +1915,8 @@ OIIO_ADD_TEST(Config, EnvCheck)
     "  - !<View> {name: Raw, colorspace: raw}\n"
     "\n";
     
-#ifdef WINDOWS
-    _putenv_s("SHOW", "bar");
-    _putenv_s("TASK", "lighting");
-#else
-    setenv("SHOW", "bar", 1);
-    setenv("TASK", "lighting", 1);
-#endif
+    OCIO::Platform::setenv("SHOW", "bar");
+    OCIO::Platform::setenv("TASK", "lighting");
     
     std::istringstream is;
     is.str(SIMPLE_PROFILE);
@@ -2042,11 +2037,7 @@ OIIO_ADD_TEST(Config, Env_colorspace_name)
     }
 
     {
-#ifdef WINDOWS
-        _putenv_s("CAMERARAW", "lnh");
-#else
-        setenv("CAMERARAW", "lnh", 1);
-#endif
+        OCIO::Platform::setenv("CAMERARAW", "lnh");
 
         std::istringstream is;
         is.str(MY_OCIO_CONFIG);
@@ -2059,11 +2050,7 @@ OIIO_ADD_TEST(Config, Env_colorspace_name)
 
     {
         // Test when the env. variable content is wrong
-#ifdef WINDOWS
-        _putenv_s("CAMERARAW", "FaultyColorSpaceName");
-#else
-        setenv("CAMERARAW", "FaultyColorSpaceName", 1);
-#endif
+        OCIO::Platform::setenv("CAMERARAW", "FaultyColorSpaceName");
 
         std::istringstream is;
         is.str(MY_OCIO_CONFIG);

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -1916,10 +1916,8 @@ OIIO_ADD_TEST(Config, EnvCheck)
     "\n";
     
     
-    std::string test("SHOW=bar");
-    putenv((char *)test.c_str());
-    std::string test2("TASK=lighting");
-    putenv((char *)test2.c_str());
+    setenv("SHOW", "bar", 1);
+    setenv("TASK", "lighting", 1);
     
     std::istringstream is;
     is.str(SIMPLE_PROFILE);
@@ -2040,8 +2038,7 @@ OIIO_ADD_TEST(Config, Env_colorspace_name)
     }
 
     {
-        char * env = (char *)"CAMERARAW=lnh";
-        putenv(env);
+        setenv("CAMERARAW", "lnh", 1);
 
         std::istringstream is;
         is.str(MY_OCIO_CONFIG);
@@ -2055,8 +2052,7 @@ OIIO_ADD_TEST(Config, Env_colorspace_name)
     {
         // Test when the env. variable content is wrong
 
-        char * env = (char *)"CAMERARAW=FaultyColorSpaceName";
-        putenv(env);
+        setenv("CAMERARAW", "FaultyColorSpaceName", 1);
 
         std::istringstream is;
         is.str(MY_OCIO_CONFIG);

--- a/src/core/Platform.cpp
+++ b/src/core/Platform.cpp
@@ -45,6 +45,14 @@ OCIO_NAMESPACE_ENTER
             value = (val && *val) ? val : "";
 #endif 
         }
+        void setenv (const char* name, const std::string& value)
+        {
+#ifdef WINDOWS
+            ::_putenv_s(name, value.c_str());
+#else
+            ::setenv(name, value.c_str(), 1);
+#endif
+        }
 
     }//namespace platform
 
@@ -87,11 +95,10 @@ OIIO_ADD_TEST(Platform, getenv)
     }
 }
 
-OIIO_ADD_TEST(Platform, putenv)
+OIIO_ADD_TEST(Platform, setenv)
 {
     {
-        const std::string value("MY_DUMMY_ENV=SomeValue");
-        ::putenv(const_cast<char*>(value.c_str()));
+        OCIO::Platform::setenv("MY_DUMMY_ENV", "SomeValue");
         std::string env;
         OCIO::Platform::getenv("MY_DUMMY_ENV", env);
         OIIO_CHECK_ASSERT(!env.empty());
@@ -100,8 +107,7 @@ OIIO_ADD_TEST(Platform, putenv)
         OIIO_CHECK_EQUAL(strlen("SomeValue"), env.size());
     }
     {
-        const std::string value("MY_DUMMY_ENV= ");
-        ::putenv(const_cast<char*>(value.c_str()));
+        OCIO::Platform::setenv("MY_DUMMY_ENV", " ");
         std::string env;
         OCIO::Platform::getenv("MY_DUMMY_ENV", env);
         OIIO_CHECK_ASSERT(!env.empty());
@@ -110,8 +116,7 @@ OIIO_ADD_TEST(Platform, putenv)
         OIIO_CHECK_EQUAL(strlen(" "), env.size());
     }
     {
-        const std::string value("MY_DUMMY_ENV=");
-        ::putenv(const_cast<char*>(value.c_str()));
+        OCIO::Platform::setenv("MY_DUMMY_ENV", "");
         std::string env;
         OCIO::Platform::getenv("MY_DUMMY_ENV", env);
         OIIO_CHECK_ASSERT(env.empty());

--- a/src/core/Platform.h
+++ b/src/core/Platform.h
@@ -103,7 +103,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 #define snprintf sprintf_s
 #define strtok_r strtok_s
 #define sscanf sscanf_s
-#define putenv _putenv
 typedef __int64 FilePos;
 #define fseeko _fseeki64
 #define ftello _ftelli64
@@ -158,6 +157,7 @@ OCIO_NAMESPACE_ENTER
   namespace Platform
   {
     void getenv (const char* name, std::string& value);
+    void setenv (const char* name, const std::string& value);
   }
 
 }

--- a/src/pyglue/CMakeLists.txt
+++ b/src/pyglue/CMakeLists.txt
@@ -11,6 +11,10 @@ endif()
 if(CMAKE_COMPILER_IS_GNUCXX)
     # Python breaks strict-aliasing rules. Disable the warning here.
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-strict-aliasing -Wno-missing-field-initializers")
+    # GCC 8 and above has a new heuristic to detect invalid pointer
+    # casts. However, this results in false positives on the Python
+    # C API which we compile against to generate Python bindings.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-cast-function-type")
 endif()
 
 if(WIN32)


### PR DESCRIPTION
GCC 9.20 warns about a `const char* -> char*` cast which casts away constness. This was required for the `putenv` function but can be resolved by using the more modern `setenv` function instead.

The GCC 8+ function pointer cast warnings mentioned in #747 appear to be a red-herring. Please refer to https://bugs.python.org/issue33012. Thus, I've updated the CXXFLAGS in the CMakeLists.txt to suppress the warning along with a comment explaining the issue.